### PR TITLE
Unicode dropdown symbol rather than font awesome

### DIFF
--- a/src/components/buttons/dropDownButton.ts
+++ b/src/components/buttons/dropDownButton.ts
@@ -59,9 +59,10 @@ export function dropDownButton(params: DropDownButton) {
   if (isFunction(button.onClick)) icon.onclick = button.onClick;
   icon.innerHTML = `
       <span class="icon is-small font-medium">
-        <i class="fas fa-angle-down font-medium" aria-hidden="true"></i>
+        ⌄
       </span>
   `;
+  icon.style.height = '2em';
   ddButton.appendChild(icon);
   trigger.appendChild(ddButton);
   elem.appendChild(trigger);


### PR DESCRIPTION
I don't believe the Public site is setup well for Font Awesome icons. They do not show up on mine and others browsers. So rather than bothering with that and packaging it into the public website, use a Unicode symbol styled to work.

From this, currently:
![Screenshot from 2024-09-17 16-26-06](https://github.com/user-attachments/assets/7febea84-dc1f-4617-8ad3-fc638defc3b5)
To this:
![Screenshot from 2024-09-17 16-24-20](https://github.com/user-attachments/assets/fbdd7f6d-d9f9-49c4-9240-2956364b0901)
