### PR TITLE
fix(api): use VITE_SERVER before hardcoded courthive.net fallback

### DIFF
--- a/src/services/api/baseApi.ts
+++ b/src/services/api/baseApi.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 const JWT_TOKEN_STORAGE_NAME = getJwtTokenStorageKey();
 const local = globalThis.location.host.includes('localhost') || globalThis.location.hostname === '127.0.0.1';
 const baseURL =
-  window['dev']?.baseURL || (local ? 'http://localhost:8383' : 'https://courthive.net') || import.meta.env.VITE_SERVER;
+  window['dev']?.baseURL || import.meta.env.VITE_SERVER || (local ? 'http://localhost:8383' : 'https://courthive.net');
 const axiosInstance = axios.create({ baseURL });
 
 axiosInstance.interceptors.request.use(


### PR DESCRIPTION
## The bug

In `src/services/api/baseApi.ts`, the `baseURL` resolution chain places `VITE_SERVER` last:

```ts
const baseURL =
  window['dev']?.baseURL || (local ? 'http://localhost:8383' : 'https://courthive.net') || import.meta.env.VITE_SERVER;
```

The middle ternary always resolves to a truthy non-empty string (either the localhost URL or `https://courthive.net`), so the chained `|| VITE_SERVER` is unreachable. Self-hosted deployments that set `VITE_SERVER` in their `.env.production` still hit `courthive.net`.

## The fix

Move `VITE_SERVER` ahead of the local/courthive.net ternary:

```ts
const baseURL =
  window['dev']?.baseURL || import.meta.env.VITE_SERVER || (local ? 'http://localhost:8383' : 'https://courthive.net');
```

Order of precedence after the fix:
1. `window['dev'].baseURL` — runtime dev override (unchanged)
2. `VITE_SERVER` — build-time env, used by self-hosted deployments
3. `localhost:8383` (when running locally) or `courthive.net` (default production)

No effect on existing production builds that don't set `VITE_SERVER`. They continue to fall through to the `courthive.net` default.

## Context

Caught while standing up a self-hosted CourtHive instance behind a reverse proxy (`https://jim.tennis/api/courthive`). `VITE_SERVER` was set in `.env.production` per project convention but was being silently ignored.