### PR TITLE
chore(deps): bump tods-competition-factory to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "svelte": "^5.55.1",
     "tabulator-tables": "6.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "4.2.0"
+    "tods-competition-factory": "5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `tods-competition-factory` from `4.2.0` → `5.0.0` (published 2026-05-31)
- See factory's [4.x → 5.0.0 migration guide](https://github.com/CourtHive/competition-factory/blob/master/documentation/docs/migration/4.x-to-5.0.0.md)

## Local verification

- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm test --run` — 130 tests pass across 17 files

## Test plan

- [ ] CI strip-link path resolves `5.0.0` from npm
- [ ] Tournament view: draws + schedule + results render correctly against a published tournament
- [ ] Live score updates still flow through Socket.IO
- [ ] `/track` interactive scoring practice still works