### PR TITLE
chore(deps): bump tods-competition-factory to 5.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "svelte": "^5.55.1",
     "tabulator-tables": "6.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "5.2.3"
+    "tods-competition-factory": "5.2.5"
   }
 }


### PR DESCRIPTION
## Summary
Bumps `tods-competition-factory` `5.2.3` → `5.2.5` (lapped renovate's stale `5.2.4` PR #408 — that one will auto-close once this lands).

5.2.5 ships [factory PR #4423](https://github.com/CourtHive/competition-factory/pull/4423) — the `addMatchUpContext` fix that preserves the hydrated `matchUp.schedule` (`venueName` / `courtName` / `venueAbbreviation` / `isoDateString` / `milliseconds` / `time` + applied embargo/publish-state filtering) under NATIVE schema-write mode.

courthive-public reads `matchUp.schedule.venueName` / `.courtName` off the CFS `/factory/scheduledmatchups` response. The user-facing fix actually lands once CFS #745 deploys to prod; this bump keeps the local factory pin in lockstep so anywhere courthive-public runs factory in-process (offline / SSR) sees the same fix.

## Test plan
- [ ] CI green
- [ ] After CFS 5.2.5 deploys, schedule tab on courthive-public renders venueName/courtName for the IONSport tournament (`ccb37afb-…`)