### PR TITLE
chore(deps): bump tods-competition-factory to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
     "svelte": "^5.55.1",
     "tabulator-tables": "6.5.2",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.0.0"
+    "tods-competition-factory": "6.0.2"
   }
 }


### PR DESCRIPTION
Bump tods-competition-factory to 6.0.2 (latest — bug fixes).