### PR TITLE
feat(rankings): consume provider-scoped rankings API

### DIFF
--- a/src/pages/rankings/renderRankingsLanding.ts
+++ b/src/pages/rankings/renderRankingsLanding.ts
@@ -1,37 +1,32 @@
 // Rankings landing page — provider-agnostic entry point at /#/rankings.
 //
-// Lists the ranking bundles currently available so visitors can pick a
-// provider before drilling into the per-provider table at
-// /#/rankings/:providerAbbr (renderRankingsPage). Today the rankings
-// service returns a single bundle (BOBOCA only — see
-// courthive-rankings/src/modules/bundle/bundle.controller.ts); this view
-// surfaces that one bundle as a single link and is ready to grow when
-// the service exposes a list endpoint.
+// Lists the providers that currently have rankings so visitors can pick one
+// before drilling into the per-provider table at /#/rankings/:providerAbbr
+// (renderRankingsPage). Reads the providers directory from
+// /api/rankings/providers (courthive-rankings' list endpoint) through the
+// CFS RankingsProxy.
 //
-// Sibling to renderRankingsPage.ts. Same data source (/api/rankings/bundle
-// through the CFS RankingsProxy), same --sp-* / --chc-* theme tokens, no
+// Sibling to renderRankingsPage.ts. Same --sp-* / --chc-* theme tokens, no
 // framework.
 
 import 'src/styles/rankings.css';
 
-const BUNDLE_URL = '/api/rankings/bundle';
+const PROVIDERS_URL = '/api/rankings/providers';
 
-interface BundleSummary {
-  provider: { name: string; abbreviation: string };
-  asOfDate: string;
-  tournaments: { id: string; name: string; endDate: string }[];
-  rankings: { men: { entries: unknown[] }; women: { entries: unknown[] } };
+interface ProviderSummary {
+  name: string;
+  abbreviation: string;
 }
 
-async function fetchAvailableBundles(): Promise<BundleSummary[]> {
+async function fetchProviders(): Promise<ProviderSummary[]> {
   try {
-    const res = await fetch(BUNDLE_URL, { headers: { accept: 'application/json' } });
+    const res = await fetch(PROVIDERS_URL, { headers: { accept: 'application/json' } });
     if (!res.ok) return [];
-    const bundle = (await res.json()) as BundleSummary;
-    if (!bundle?.provider?.abbreviation) return [];
-    return [bundle];
+    const providers = (await res.json()) as ProviderSummary[];
+    if (!Array.isArray(providers)) return [];
+    return providers.filter((p) => p?.abbreviation);
   } catch (e) {
-    console.warn('[rankings-landing] bundle fetch failed:', e);
+    console.warn('[rankings-landing] providers fetch failed:', e);
     return [];
   }
 }
@@ -44,13 +39,13 @@ export function renderRankingsLanding(container: HTMLElement) {
   loading.textContent = 'Loading available rank lists…';
   container.appendChild(loading);
 
-  fetchAvailableBundles().then((bundles) => {
+  fetchProviders().then((providers) => {
     container.innerHTML = '';
-    container.appendChild(buildLandingRoot(bundles));
+    container.appendChild(buildLandingRoot(providers));
   });
 }
 
-function buildLandingRoot(bundles: BundleSummary[]): HTMLElement {
+function buildLandingRoot(providers: ProviderSummary[]): HTMLElement {
   const root = document.createElement('div');
   root.className = 'rk-root';
 
@@ -69,7 +64,7 @@ function buildLandingRoot(bundles: BundleSummary[]): HTMLElement {
 
   root.appendChild(header);
 
-  if (bundles.length === 0) {
+  if (providers.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'rk-not-found';
     empty.textContent =
@@ -77,7 +72,7 @@ function buildLandingRoot(bundles: BundleSummary[]): HTMLElement {
       'or no provider has ingested results yet. Try again in a moment, or contact the operator.';
     root.appendChild(empty);
   } else {
-    root.appendChild(buildAvailableSection(bundles));
+    root.appendChild(buildAvailableSection(providers));
   }
 
   // Intentionally NO methodology footer here. Each provider chooses its
@@ -91,36 +86,26 @@ function buildLandingRoot(bundles: BundleSummary[]): HTMLElement {
   return root;
 }
 
-function buildAvailableSection(bundles: BundleSummary[]): HTMLElement {
+function buildAvailableSection(providers: ProviderSummary[]): HTMLElement {
   const section = document.createElement('section');
   section.className = 'rk-panel';
 
   const heading = document.createElement('h2');
   heading.className = 'rk-panel-title';
-  heading.textContent = `Available rank lists (${bundles.length})`;
+  heading.textContent = `Available rank lists (${providers.length})`;
   section.appendChild(heading);
 
   const list = document.createElement('ul');
   list.className = 'rk-landing-list';
-  for (const b of bundles) {
+  for (const p of providers) {
     const li = document.createElement('li');
     li.className = 'rk-landing-item';
 
     const link = document.createElement('a');
     link.className = 'rk-landing-link';
-    link.href = `#/rankings/${b.provider.abbreviation}`;
-    link.textContent = `${b.provider.name} (${b.provider.abbreviation})`;
+    link.href = `#/rankings/${p.abbreviation}`;
+    link.textContent = `${p.name} (${p.abbreviation})`;
     li.appendChild(link);
-
-    const meta = document.createElement('div');
-    meta.className = 'rk-landing-meta';
-    const men = b.rankings?.men?.entries?.length ?? 0;
-    const women = b.rankings?.women?.entries?.length ?? 0;
-    const tournaments = b.tournaments?.length ?? 0;
-    meta.textContent =
-      `As of ${b.asOfDate} · ${tournaments} tournament${tournaments === 1 ? '' : 's'}` +
-      ` · ${men} men ranked · ${women} women ranked`;
-    li.appendChild(meta);
 
     list.appendChild(li);
   }

--- a/src/pages/rankings/renderRankingsPage.ts
+++ b/src/pages/rankings/renderRankingsPage.ts
@@ -58,12 +58,15 @@ interface RankingsBundle {
 }
 
 // Last-resort fallback when the proxy can't reach rankings. Bundled at
-// build time; refreshed manually via the export script when needed.
+// build time; refreshed manually via the export script when needed. It is
+// BOBOCA-only, so it's used solely when the requested provider IS BOBOCA —
+// serving it under any other provider would be wrong.
 const FALLBACK: RankingsBundle = bobocaRankings as unknown as RankingsBundle;
 
-async function fetchBundle(): Promise<{ bundle: RankingsBundle; isLive: boolean }> {
+async function fetchBundle(providerAbbr: string): Promise<{ bundle: RankingsBundle; isLive: boolean }> {
+  const url = `${BUNDLE_URL}?provider=${encodeURIComponent(providerAbbr.toUpperCase())}`;
   try {
-    const res = await fetch(BUNDLE_URL, { headers: { accept: 'application/json' } });
+    const res = await fetch(url, { headers: { accept: 'application/json' } });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const live = (await res.json()) as RankingsBundle;
     if (live?.rankings?.men && live?.rankings?.women) {
@@ -71,8 +74,13 @@ async function fetchBundle(): Promise<{ bundle: RankingsBundle; isLive: boolean 
     }
     throw new Error('bundle shape unrecognized');
   } catch (e) {
-    console.warn('[rankings] live fetch failed — using static fallback:', e);
-    return { bundle: FALLBACK, isLive: false };
+    console.warn('[rankings] live fetch failed:', e);
+    // The baked-in fallback only speaks for BOBOCA — never surface it under
+    // another provider's abbreviation.
+    if (providerAbbr.toUpperCase() === FALLBACK.provider.abbreviation.toUpperCase()) {
+      return { bundle: FALLBACK, isLive: false };
+    }
+    throw e;
   }
 }
 
@@ -85,19 +93,26 @@ export function renderRankingsPage(container: HTMLElement, providerAbbr: string)
   loading.textContent = 'Loading rankings…';
   container.appendChild(loading);
 
-  fetchBundle().then(({ bundle, isLive }) => {
+  const notFound = () => {
     container.innerHTML = '';
+    const msg = document.createElement('div');
+    msg.className = 'rk-not-found';
+    msg.textContent = `No rankings available for "${providerAbbr}".`;
+    container.appendChild(msg);
+  };
 
-    if (bundle.provider.abbreviation.toUpperCase() !== providerAbbr.toUpperCase()) {
-      const msg = document.createElement('div');
-      msg.className = 'rk-not-found';
-      msg.textContent = `No rankings available for "${providerAbbr}".`;
-      container.appendChild(msg);
-      return;
-    }
-
-    renderBundle(container, bundle, isLive);
-  });
+  fetchBundle(providerAbbr)
+    .then(({ bundle, isLive }) => {
+      container.innerHTML = '';
+      // Scoped fetch should already return the requested provider; keep the
+      // guard as a safety net against a mismatched bundle.
+      if (bundle.provider.abbreviation.toUpperCase() !== providerAbbr.toUpperCase()) {
+        notFound();
+        return;
+      }
+      renderBundle(container, bundle, isLive);
+    })
+    .catch(notFound);
 }
 
 function renderBundle(container: HTMLElement, bundle: RankingsBundle, isLive: boolean) {


### PR DESCRIPTION
## What

Updates the public rankings viewer to use the provider-scoped rankings API (courthive-rankings PR #34).

- **Landing (`/#/rankings`)** — lists providers from the new `GET /api/rankings/providers` endpoint instead of surfacing a single hard-coded bundle. Each provider links to its per-provider table. (Drops the per-provider count meta, which the directory endpoint doesn't carry; counts remain on the detail page.)
- **Per-provider page (`/#/rankings/:abbr`)** — fetches `GET /api/rankings/bundle?provider=<abbr>` so each provider gets its own scoped data.
- **Static fallback** — the baked-in `boboca-rankings.json` is now only used when the requested provider **is** BOBOCA; it's never surfaced under another provider's abbreviation (previously any unreachable-proxy load fell back to BOBOCA data, which the abbreviation guard then rejected).

## Depends on
- courthive-rankings #34 (`?provider=` + `/providers`). Backward compatible: until #34 deploys, `/providers` 404s → landing shows the empty state; the per-provider page's `?provider=` param is ignored by the current single-bundle endpoint (still returns BOBOCA).

## Notes
- No unit tests added — these are DOM renderers; per ecosystem convention the DOM test layer here is Playwright, not happy-dom.
- `check-types` + `lint` clean.