### PR TITLE
chore(deps): bump courthive-components to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@courthive/provider-config": "^0.8.0",
     "axios": "1.18.1",
-    "courthive-components": "3.4.6",
+    "courthive-components": "3.5.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "hotkeys-js": "4.0.4",


### PR DESCRIPTION
Bumps `courthive-components` 3.4.6 → 3.5.1 (already published; this repo was two minors behind). Real version in package.json + `link:` retained in the pnpm-workspace override for local dev. `check-types` passes against 3.5.1's API locally.