### PR TITLE
fix(tournament): render splash dates as calendar days (timezone-independent)

### DIFF
--- a/src/pages/tournament/helpers/dateString.test.ts
+++ b/src/pages/tournament/helpers/dateString.test.ts
@@ -31,4 +31,33 @@ describe('dateString', () => {
     let result: any = dateString({ startDate: '2025-12-25', endDate: '2025-12-31' });
     expect(result).toBe('December 25-31, 2025');
   });
+
+  it('renders the exact calendar days (prod repro: Jul 13-14, not 12-13)', () => {
+    let result: any = dateString({ startDate: '2026-07-13', endDate: '2026-07-14' });
+    expect(result).toBe('July 13-14, 2026');
+  });
+
+  it('is timezone-independent — never constructs a Date (guards the UTC-midnight regression)', () => {
+    // The bug was `new Date("YYYY-MM-DD")` (UTC midnight) read back in the
+    // viewer's local zone, shifting the day west of UTC. Stub Date to throw so a
+    // regression to any Date-based parse fails here regardless of the test TZ.
+    const OriginalDate = globalThis.Date;
+    // @ts-expect-error — intentionally replacing Date for the duration of the test
+    globalThis.Date = class {
+      constructor() {
+        throw new Error('dateString must not construct a Date (calendar days are timezone-independent)');
+      }
+    };
+    try {
+      let result: any = dateString({ startDate: '2026-07-13', endDate: '2026-07-14' });
+      expect(result).toBe('July 13-14, 2026');
+    } finally {
+      globalThis.Date = OriginalDate;
+    }
+  });
+
+  it('returns empty string for missing/malformed input', () => {
+    expect(dateString({ startDate: undefined, endDate: undefined } as any)).toBe('');
+    expect(dateString({ startDate: 'not-a-date', endDate: 'x' } as any)).toBe('');
+  });
 });

--- a/src/pages/tournament/helpers/dateString.ts
+++ b/src/pages/tournament/helpers/dateString.ts
@@ -1,31 +1,56 @@
-export function dateString({ startDate, endDate }) {
-  const start = new Date(startDate);
-  const end = new Date(endDate);
-  const monthNames = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-  const sameDay = start.getDate() === end.getDate();
-  const sameYear = start.getFullYear() === end.getFullYear();
-  const sameMonth = sameYear && start.getMonth() === end.getMonth();
-  const formattedDate = (date) => [date.getFullYear(), date.getMonth() + 1, date.getDate()].join('/');
-  if (sameDay && sameYear && sameMonth) {
-    return `${monthNames[start.getMonth()]} ${start.getDate()}, ${start.getFullYear()}`;
-  } else if (sameYear && sameMonth) {
-    return `${monthNames[start.getMonth()]} ${start.getDate()}-${end.getDate()}, ${start.getFullYear()}`;
+type CalendarDate = { year: number; month: number; day: number };
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/**
+ * Parse a calendar-day string ("YYYY-MM-DD") into plain year/month/day
+ * components WITHOUT constructing a `Date`.
+ *
+ * `new Date("2026-07-13")` parses the string as UTC midnight and is then read
+ * back through the viewer's local zone, so any viewer west of UTC sees the
+ * PREVIOUS calendar day (e.g. "July 13" renders as "July 12" in the Americas) —
+ * the production off-by-one on the public tournament splash. Tournament
+ * start/end dates are calendar days, not instants, so the timezone must never
+ * enter the calculation: parse the components directly and format them as-is.
+ */
+function parseCalendarDate(input?: string): CalendarDate | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(input ?? ''));
+  if (!match) return null;
+  return { year: Number(match[1]), month: Number(match[2]), day: Number(match[3]) };
+}
+
+export function dateString({ startDate, endDate }: { startDate?: string; endDate?: string }): string {
+  const start = parseCalendarDate(startDate);
+  const end = parseCalendarDate(endDate) ?? start;
+  if (!start || !end) return '';
+
+  const sameYear = start.year === end.year;
+  const sameMonth = sameYear && start.month === end.month;
+  const sameDay = sameMonth && start.day === end.day;
+
+  const monthName = (date: CalendarDate) => monthNames[date.month - 1];
+  const numeric = (date: CalendarDate) => `${date.year}/${date.month}/${date.day}`;
+
+  if (sameDay) {
+    return `${monthName(start)} ${start.day}, ${start.year}`;
+  } else if (sameMonth) {
+    return `${monthName(start)} ${start.day}-${end.day}, ${start.year}`;
   } else if (sameYear) {
-    return `${monthNames[start.getMonth()]} ${start.getDate()} - ${monthNames[end.getMonth()]} ${end.getDate()}, ${start.getFullYear()}`;
+    return `${monthName(start)} ${start.day} - ${monthName(end)} ${end.day}, ${start.year}`;
   } else {
-    return `${formattedDate(start)} - ${formattedDate(end)}`;
+    return `${numeric(start)} - ${numeric(end)}`;
   }
 }


### PR DESCRIPTION
Public tournament splash showed dates one day early west of UTC (prod `f94e738f`: 'Trials July 13th-14th' rendered 'July 12-13'). `dateString` used `new Date("YYYY-MM-DD")` (UTC midnight → viewer-local shift). Start/end are calendar days, not instants — parse components directly, no Date, no zone. Adds a Date-stub regression test. Tests: 172 green.