### PR TITLE
chore(renovate): block TypeScript major bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,16 @@
         "tods-competition-factory"
       ],
       "enabled": false
+    },
+    {
+      "description": "Block TypeScript major bumps. TS7 ships the native (Go) compiler, whose JS API shim lacks getParsedCommandLineOfConfigFile — nest/tsc-based build toolchains crash on it. Re-enable deliberately once the toolchain supports TS7.",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
TS7 ships the native (Go) compiler; its JS API shim lacks `getParsedCommandLineOfConfigFile`, which the vite/tsc build + typecheck call — they crash on it (CFS broke on this class). Block major `typescript` bumps until the toolchain supports TS7.