### PR TITLE
fix(conferences): regenerate ITA data with the corrected competitive model

### DIFF
--- a/public/data/conferences/alabama-ccc.json
+++ b/public/data/conferences/alabama-ccc.json
@@ -31,7 +31,7 @@
    "stretchRate": 31.5,
    "anchorRate": 4.4,
    "breadth": 0.867,
-   "competitiveRatio": 21.8,
+   "competitiveRatio": 21.1,
    "winRate": 35.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 10.7,
    "anchorRate": 10.7,
    "breadth": 0.883,
-   "competitiveRatio": 28,
+   "competitiveRatio": 27.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 38.5,
    "anchorRate": 2.2,
    "breadth": 0.821,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 19,
    "winRate": 30.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 13.4,
    "anchorRate": 21.6,
    "breadth": 0.819,
-   "competitiveRatio": 27.6,
+   "competitiveRatio": 27.2,
    "winRate": 41.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 53.4,
    "anchorRate": 0,
    "breadth": 0.6,
-   "competitiveRatio": 24.3,
+   "competitiveRatio": 23.1,
    "winRate": 29.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 40.7,
    "anchorRate": 0,
    "breadth": 0.671,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 23.8,
    "winRate": 39.8
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 29.4,
    "anchorRate": 0,
    "breadth": 0.827,
-   "competitiveRatio": 17.6,
+   "competitiveRatio": 16.5,
    "winRate": 31.8
   },
   {

--- a/public/data/conferences/allegheny-mountain-collegiate-conference.json
+++ b/public/data/conferences/allegheny-mountain-collegiate-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 1.3,
    "anchorRate": 0.6,
    "breadth": 0.728,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 25.2,
    "winRate": 47.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.682,
-   "competitiveRatio": 23.6,
+   "competitiveRatio": 23.1,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 2.1,
    "anchorRate": 1,
    "breadth": 0.738,
-   "competitiveRatio": 27.3,
+   "competitiveRatio": 26.6,
    "winRate": 45.1
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 4.1,
    "anchorRate": 0,
    "breadth": 0.758,
-   "competitiveRatio": 31.4,
+   "competitiveRatio": 30.1,
    "winRate": 57.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.581,
-   "competitiveRatio": 35.6,
+   "competitiveRatio": 35.2,
    "winRate": 70.8
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 4.5,
    "breadth": 0.385,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 26.3,
    "winRate": 56.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 2.1,
    "anchorRate": 0,
    "breadth": 0.583,
-   "competitiveRatio": 21.2,
+   "competitiveRatio": 20.3,
    "winRate": 25.4
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.3,
    "anchorRate": 0,
    "breadth": 0.682,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 28.8,
    "winRate": 61.1
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2.8,
    "anchorRate": 0,
    "breadth": 0.179,
-   "competitiveRatio": 19.7,
+   "competitiveRatio": 19.2,
    "winRate": 17.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.632,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 25.8,
    "winRate": 40.7
   },
   {

--- a/public/data/conferences/american-athletic-conference.json
+++ b/public/data/conferences/american-athletic-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 283,
     "UP": 2766,
-    "EVEN": 1458,
-    "DOWN": 2955,
-    "ANCHOR": 571
+    "EVEN": 1438,
+    "DOWN": 2969,
+    "ANCHOR": 577
    },
    "bandPct": {
     "STRETCH": 3.5,
     "UP": 34.4,
-    "EVEN": 18.2,
-    "DOWN": 36.8,
-    "ANCHOR": 7.1
+    "EVEN": 17.9,
+    "DOWN": 37,
+    "ANCHOR": 7.2
    },
    "stretchRate": 3.5,
-   "anchorRate": 7.1,
+   "anchorRate": 7.2,
    "breadth": 0.839,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 47.5,
    "winRate": 53.5
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 1.5,
    "anchorRate": 1.5,
    "breadth": 0.73,
-   "competitiveRatio": 51.6,
+   "competitiveRatio": 50,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 249,
     "UP": 1884,
-    "EVEN": 1036,
-    "DOWN": 2073,
-    "ANCHOR": 537
+    "EVEN": 1016,
+    "DOWN": 2087,
+    "ANCHOR": 543
    },
    "bandPct": {
     "STRETCH": 4.3,
     "UP": 32.6,
-    "EVEN": 17.9,
-    "DOWN": 35.9,
-    "ANCHOR": 9.3
+    "EVEN": 17.6,
+    "DOWN": 36.1,
+    "ANCHOR": 9.4
    },
    "stretchRate": 4.3,
-   "anchorRate": 9.3,
+   "anchorRate": 9.4,
    "breadth": 0.868,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46.5,
    "winRate": 54.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -117,21 +117,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 65,
-    "EVEN": 45,
-    "DOWN": 270,
+    "EVEN": 33,
+    "DOWN": 282,
     "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 16.1,
-    "EVEN": 11.1,
-    "DOWN": 66.8,
+    "EVEN": 8.2,
+    "DOWN": 69.8,
     "ANCHOR": 5.9
    },
    "stretchRate": 0,
    "anchorRate": 5.9,
-   "breadth": 0.606,
-   "competitiveRatio": 56.2,
+   "breadth": 0.57,
+   "competitiveRatio": 55.2,
    "winRate": 59.7
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 14.2,
    "breadth": 0.805,
-   "competitiveRatio": 57.1,
+   "competitiveRatio": 53.4,
    "winRate": 60.3
   },
   {
@@ -172,20 +172,20 @@
     "STRETCH": 6,
     "UP": 122,
     "EVEN": 93,
-    "DOWN": 86,
-    "ANCHOR": 91
+    "DOWN": 80,
+    "ANCHOR": 97
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 30.7,
     "EVEN": 23.4,
-    "DOWN": 21.6,
-    "ANCHOR": 22.9
+    "DOWN": 20.1,
+    "ANCHOR": 24.4
    },
    "stretchRate": 1.5,
-   "anchorRate": 22.9,
-   "breadth": 0.891,
-   "competitiveRatio": 47,
+   "anchorRate": 24.4,
+   "breadth": 0.89,
+   "competitiveRatio": 45.2,
    "winRate": 52.5
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 3.1,
    "anchorRate": 6.4,
    "breadth": 0.823,
-   "competitiveRatio": 58.1,
+   "competitiveRatio": 56.3,
    "winRate": 56.6
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 4,
    "anchorRate": 0,
    "breadth": 0.722,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 42.8,
    "winRate": 57.3
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 18.1,
    "breadth": 0.77,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 43,
    "winRate": 71.9
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 11.2,
    "anchorRate": 7.6,
    "breadth": 0.817,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 50,
    "winRate": 40.3
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 7.7,
    "breadth": 0.787,
-   "competitiveRatio": 42.5,
+   "competitiveRatio": 40.5,
    "winRate": 53.8
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 3.6,
    "anchorRate": 5.3,
    "breadth": 0.797,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 40.4,
    "winRate": 57
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 5.9,
    "anchorRate": 11.6,
    "breadth": 0.918,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49.6,
    "winRate": 53.7
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 7.2,
    "anchorRate": 2.7,
    "breadth": 0.844,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 50.6,
    "winRate": 43.8
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 14.1,
    "breadth": 0.746,
-   "competitiveRatio": 46.5,
+   "competitiveRatio": 45.9,
    "winRate": 61.2
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 3.7,
    "breadth": 0.728,
-   "competitiveRatio": 57.4,
+   "competitiveRatio": 56.1,
    "winRate": 53.1
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 15.9,
    "breadth": 0.683,
-   "competitiveRatio": 39.4,
+   "competitiveRatio": 39,
    "winRate": 64.1
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 15.6,
    "breadth": 0.778,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 42.2,
    "winRate": 49.5
   },
   {
@@ -549,21 +549,21 @@
    "bands": {
     "STRETCH": 3,
     "UP": 189,
-    "EVEN": 48,
-    "DOWN": 73,
+    "EVEN": 40,
+    "DOWN": 81,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1,
     "UP": 60.4,
-    "EVEN": 15.3,
-    "DOWN": 23.3,
+    "EVEN": 12.8,
+    "DOWN": 25.9,
     "ANCHOR": 0
    },
    "stretchRate": 1,
    "anchorRate": 0,
-   "breadth": 0.607,
-   "competitiveRatio": 48.6,
+   "breadth": 0.598,
+   "competitiveRatio": 46.6,
    "winRate": 46.6
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 2.9,
    "anchorRate": 1.6,
    "breadth": 0.767,
-   "competitiveRatio": 48.5,
+   "competitiveRatio": 47.2,
    "winRate": 45.3
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 10.6,
    "anchorRate": 0,
    "breadth": 0.579,
-   "competitiveRatio": 51.2,
+   "competitiveRatio": 49.5,
    "winRate": 46.9
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 14.2,
    "anchorRate": 0,
    "breadth": 0.774,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 46.1,
    "winRate": 45.1
   },
   {
@@ -671,7 +671,7 @@
    "stretchRate": 6.1,
    "anchorRate": 4.4,
    "breadth": 0.823,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 38.8,
    "winRate": 58.5
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 13.7,
    "anchorRate": 2.1,
    "breadth": 0.777,
-   "competitiveRatio": 47.9,
+   "competitiveRatio": 47.2,
    "winRate": 44.4
   },
   {
@@ -725,7 +725,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.618,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46.3,
    "winRate": 47
   },
   {
@@ -752,7 +752,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.541,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 47.7,
    "winRate": 61.3
   }
  ]

--- a/public/data/conferences/american-rivers-conference.json
+++ b/public/data/conferences/american-rivers-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 11.1,
    "anchorRate": 8.7,
    "breadth": 0.908,
-   "competitiveRatio": 31.4,
+   "competitiveRatio": 31,
    "winRate": 46.9
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 13.8,
    "anchorRate": 13.8,
    "breadth": 0.961,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 24.3,
    "winRate": 49.9
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 9.1,
    "anchorRate": 5,
    "breadth": 0.848,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 36,
    "winRate": 44.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.8,
    "anchorRate": 38.5,
    "breadth": 0.853,
-   "competitiveRatio": 40.7,
+   "competitiveRatio": 40.1,
    "winRate": 74
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 42.6,
    "breadth": 0.797,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 41.1,
    "winRate": 65.7
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 3.9,
    "anchorRate": 0,
    "breadth": 0.747,
-   "competitiveRatio": 32.2,
+   "competitiveRatio": 31.3,
    "winRate": 53.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 3.6,
    "breadth": 0.722,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 29.4,
    "winRate": 49.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1.5,
    "anchorRate": 13.3,
    "breadth": 0.814,
-   "competitiveRatio": 31,
+   "competitiveRatio": 28.8,
    "winRate": 65.3
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 30.1,
    "anchorRate": 0,
    "breadth": 0.757,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 35.9,
    "winRate": 39.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 5,
    "anchorRate": 1.7,
    "breadth": 0.801,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.7,
    "winRate": 44.9
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 17.5,
    "anchorRate": 0,
    "breadth": 0.694,
-   "competitiveRatio": 13.7,
+   "competitiveRatio": 14.6,
    "winRate": 14.6
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 25.2,
    "anchorRate": 0,
    "breadth": 0.762,
-   "competitiveRatio": 23.9,
+   "competitiveRatio": 23.6,
    "winRate": 33.1
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 2.1,
    "anchorRate": 0,
    "breadth": 0.701,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 29.9,
    "winRate": 43.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 13.4,
    "anchorRate": 0,
    "breadth": 0.788,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.6,
    "winRate": 38.8
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 30.3,
    "anchorRate": 0,
    "breadth": 0.799,
-   "competitiveRatio": 29.2,
+   "competitiveRatio": 28,
    "winRate": 37.3
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 26.2,
    "anchorRate": 0,
    "breadth": 0.615,
-   "competitiveRatio": 16.5,
+   "competitiveRatio": 16.9,
    "winRate": 20.7
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 2.6,
    "anchorRate": 0,
    "breadth": 0.616,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 29.1,
    "winRate": 37
   }
  ]

--- a/public/data/conferences/american-southwest-conference.json
+++ b/public/data/conferences/american-southwest-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 892,
     "UP": 1997,
-    "EVEN": 581,
-    "DOWN": 1296,
+    "EVEN": 575,
+    "DOWN": 1302,
     "ANCHOR": 477
    },
    "bandPct": {
     "STRETCH": 17,
     "UP": 38.1,
-    "EVEN": 11.1,
-    "DOWN": 24.7,
+    "EVEN": 11,
+    "DOWN": 24.8,
     "ANCHOR": 9.1
    },
    "stretchRate": 17,
    "anchorRate": 9.1,
    "breadth": 0.917,
-   "competitiveRatio": 31.2,
+   "competitiveRatio": 30.9,
    "winRate": 43.7
   },
   "inConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 689,
     "UP": 1365,
-    "EVEN": 415,
-    "DOWN": 664,
+    "EVEN": 409,
+    "DOWN": 670,
     "ANCHOR": 274
    },
    "bandPct": {
     "STRETCH": 20.2,
     "UP": 40.1,
-    "EVEN": 12.2,
-    "DOWN": 19.5,
+    "EVEN": 12,
+    "DOWN": 19.7,
     "ANCHOR": 8
    },
    "stretchRate": 20.2,
    "anchorRate": 8,
-   "breadth": 0.912,
-   "competitiveRatio": 30,
+   "breadth": 0.911,
+   "competitiveRatio": 29.6,
    "winRate": 40.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 13.6,
    "anchorRate": 14.2,
    "breadth": 0.862,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 39.4,
    "winRate": 44.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 24.6,
    "anchorRate": 13.8,
    "breadth": 0.931,
-   "competitiveRatio": 32.7,
+   "competitiveRatio": 31.5,
    "winRate": 57.1
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 12.8,
    "anchorRate": 6.1,
    "breadth": 0.846,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 34.5,
    "winRate": 41.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 5.8,
    "anchorRate": 18.4,
    "breadth": 0.925,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 36.5,
    "winRate": 46.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2,
    "anchorRate": 0,
    "breadth": 0.607,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28.1,
    "winRate": 48.2
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 9,
    "breadth": 0.75,
-   "competitiveRatio": 40.7,
+   "competitiveRatio": 39.3,
    "winRate": 43.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 4.1,
    "anchorRate": 22,
    "breadth": 0.698,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 43.7,
    "winRate": 53.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 6.9,
    "anchorRate": 11,
    "breadth": 0.917,
-   "competitiveRatio": 31.6,
+   "competitiveRatio": 30.9,
    "winRate": 61.5
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 4.2,
    "anchorRate": 7.3,
    "breadth": 0.767,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 34,
    "winRate": 63.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 43.4,
    "anchorRate": 0,
    "breadth": 0.667,
-   "competitiveRatio": 16.5,
+   "competitiveRatio": 16.1,
    "winRate": 24
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 11.1,
    "anchorRate": 10.4,
    "breadth": 0.92,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.4,
    "winRate": 55.9
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 59,
    "anchorRate": 0,
    "breadth": 0.645,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 27.3,
    "winRate": 17.6
   },
   {
@@ -496,20 +496,20 @@
    "bands": {
     "STRETCH": 42,
     "UP": 118,
-    "EVEN": 30,
-    "DOWN": 52,
+    "EVEN": 24,
+    "DOWN": 58,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 15.6,
     "UP": 43.7,
-    "EVEN": 11.1,
-    "DOWN": 19.3,
+    "EVEN": 8.9,
+    "DOWN": 21.5,
     "ANCHOR": 10.4
    },
    "stretchRate": 15.6,
    "anchorRate": 10.4,
-   "breadth": 0.899,
+   "breadth": 0.89,
    "competitiveRatio": 32.6,
    "winRate": 35.6
   },
@@ -537,7 +537,7 @@
    "stretchRate": 0,
    "anchorRate": 10.1,
    "breadth": 0.769,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 35,
    "winRate": 46.4
   },
   {

--- a/public/data/conferences/appalachian-athletic-conference.json
+++ b/public/data/conferences/appalachian-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 21.6,
    "anchorRate": 16.5,
    "breadth": 0.971,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.6,
    "winRate": 46.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 24.9,
    "anchorRate": 24.9,
    "breadth": 0.967,
-   "competitiveRatio": 22.1,
+   "competitiveRatio": 21.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 18.2,
    "anchorRate": 7.8,
    "breadth": 0.928,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 34,
    "winRate": 42.9
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -159,7 +159,7 @@
    "stretchRate": 7.8,
    "anchorRate": 16.9,
    "breadth": 0.885,
-   "competitiveRatio": 39.6,
+   "competitiveRatio": 38.3,
    "winRate": 50.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 17.9,
    "anchorRate": 0,
    "breadth": 0.797,
-   "competitiveRatio": 32,
+   "competitiveRatio": 30.3,
    "winRate": 42.4
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 69.2,
    "breadth": 0.384,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 30.8,
    "winRate": 83.6
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 19.5,
    "anchorRate": 4,
    "breadth": 0.902,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25,
    "winRate": 40.1
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 45.3,
    "breadth": 0.785,
-   "competitiveRatio": 26,
+   "competitiveRatio": 26.4,
    "winRate": 58
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 32.4,
    "anchorRate": 0,
    "breadth": 0.779,
-   "competitiveRatio": 18.4,
+   "competitiveRatio": 17.6,
    "winRate": 24.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 20,
    "anchorRate": 0,
    "breadth": 0.771,
-   "competitiveRatio": 32.5,
+   "competitiveRatio": 29.2,
    "winRate": 50.4
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 56.3,
    "anchorRate": 0,
    "breadth": 0.573,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 19.1,
    "winRate": 19.5
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 18.8,
    "anchorRate": 26.9,
    "breadth": 0.888,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 38.6,
    "winRate": 50.2
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 20.1,
    "anchorRate": 9.8,
    "breadth": 0.891,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 32.2,
    "winRate": 50
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 49.1,
    "anchorRate": 0,
    "breadth": 0.565,
-   "competitiveRatio": 24.3,
+   "competitiveRatio": 23.7,
    "winRate": 44.4
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 31.7,
    "anchorRate": 14,
    "breadth": 0.938,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 30.5,
    "winRate": 34.1
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 38.5,
    "anchorRate": 0,
    "breadth": 0.778,
-   "competitiveRatio": 23.3,
+   "competitiveRatio": 20.5,
    "winRate": 29.1
   }
  ]

--- a/public/data/conferences/atlantic-10-conference.json
+++ b/public/data/conferences/atlantic-10-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 418,
     "UP": 2750,
-    "EVEN": 1174,
-    "DOWN": 2493,
-    "ANCHOR": 388
+    "EVEN": 1162,
+    "DOWN": 2497,
+    "ANCHOR": 396
    },
    "bandPct": {
     "STRETCH": 5.8,
     "UP": 38.1,
-    "EVEN": 16.3,
-    "DOWN": 34.5,
-    "ANCHOR": 5.4
+    "EVEN": 16.1,
+    "DOWN": 34.6,
+    "ANCHOR": 5.5
    },
    "stretchRate": 5.8,
-   "anchorRate": 5.4,
-   "breadth": 0.84,
-   "competitiveRatio": 44.3,
+   "anchorRate": 5.5,
+   "breadth": 0.841,
+   "competitiveRatio": 43.4,
    "winRate": 47.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 1.2,
    "anchorRate": 1.2,
    "breadth": 0.694,
-   "competitiveRatio": 42,
+   "competitiveRatio": 41,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 395,
     "UP": 1925,
-    "EVEN": 876,
-    "DOWN": 1668,
-    "ANCHOR": 365
+    "EVEN": 864,
+    "DOWN": 1672,
+    "ANCHOR": 373
    },
    "bandPct": {
     "STRETCH": 7.6,
     "UP": 36.8,
-    "EVEN": 16.8,
-    "DOWN": 31.9,
-    "ANCHOR": 7
+    "EVEN": 16.5,
+    "DOWN": 32,
+    "ANCHOR": 7.1
    },
    "stretchRate": 7.6,
-   "anchorRate": 7,
+   "anchorRate": 7.1,
    "breadth": 0.878,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.3,
    "winRate": 46.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 8.6,
    "anchorRate": 7.6,
    "breadth": 0.819,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 43.9,
    "winRate": 41.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 10.9,
    "anchorRate": 0,
    "breadth": 0.771,
-   "competitiveRatio": 55.6,
+   "competitiveRatio": 53.4,
    "winRate": 52
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.7,
    "anchorRate": 0,
    "breadth": 0.696,
-   "competitiveRatio": 48.5,
+   "competitiveRatio": 47.1,
    "winRate": 55.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 3.5,
    "anchorRate": 0,
    "breadth": 0.732,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 41.9,
    "winRate": 44.2
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 2.7,
    "anchorRate": 0,
    "breadth": 0.734,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 47.2,
    "winRate": 52.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 7.3,
    "anchorRate": 0,
    "breadth": 0.76,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 40.7,
    "winRate": 32.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0.9,
    "anchorRate": 16.6,
    "breadth": 0.74,
-   "competitiveRatio": 47.8,
+   "competitiveRatio": 46.9,
    "winRate": 62.5
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 2.2,
    "anchorRate": 7.6,
    "breadth": 0.777,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 47.6,
    "winRate": 41.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 9.5,
    "anchorRate": 1.9,
    "breadth": 0.784,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 48.3,
    "winRate": 43.2
   },
   {
@@ -442,21 +442,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 60,
-    "EVEN": 31,
-    "DOWN": 189,
+    "EVEN": 28,
+    "DOWN": 192,
     "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19.1,
-    "EVEN": 9.9,
-    "DOWN": 60.2,
+    "EVEN": 8.9,
+    "DOWN": 61.1,
     "ANCHOR": 10.8
    },
    "stretchRate": 0,
    "anchorRate": 10.8,
-   "breadth": 0.678,
-   "competitiveRatio": 46.2,
+   "breadth": 0.667,
+   "competitiveRatio": 45.9,
    "winRate": 63.7
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 3.9,
    "breadth": 0.651,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 42.9,
    "winRate": 58.1
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 21.2,
    "anchorRate": 2,
    "breadth": 0.796,
-   "competitiveRatio": 39.7,
+   "competitiveRatio": 37.7,
    "winRate": 29.3
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 0,
    "anchorRate": 7.5,
    "breadth": 0.736,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 37.8,
    "winRate": 61.3
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 6.1,
    "anchorRate": 5.7,
    "breadth": 0.868,
-   "competitiveRatio": 46.8,
+   "competitiveRatio": 46.4,
    "winRate": 44.1
   },
   {
@@ -577,21 +577,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 152,
-    "EVEN": 58,
-    "DOWN": 72,
+    "EVEN": 49,
+    "DOWN": 81,
     "ANCHOR": 5
    },
    "bandPct": {
     "STRETCH": 2,
     "UP": 51.9,
-    "EVEN": 19.8,
-    "DOWN": 24.6,
+    "EVEN": 16.7,
+    "DOWN": 27.6,
     "ANCHOR": 1.7
    },
    "stretchRate": 2,
    "anchorRate": 1.7,
-   "breadth": 0.718,
-   "competitiveRatio": 41.4,
+   "breadth": 0.711,
+   "competitiveRatio": 41.1,
    "winRate": 43
   },
   {
@@ -632,20 +632,20 @@
     "STRETCH": 28,
     "UP": 109,
     "EVEN": 61,
-    "DOWN": 62,
-    "ANCHOR": 11
+    "DOWN": 54,
+    "ANCHOR": 19
    },
    "bandPct": {
     "STRETCH": 10.3,
     "UP": 40.2,
     "EVEN": 22.5,
-    "DOWN": 22.9,
-    "ANCHOR": 4.1
+    "DOWN": 19.9,
+    "ANCHOR": 7
    },
    "stretchRate": 10.3,
-   "anchorRate": 4.1,
-   "breadth": 0.872,
-   "competitiveRatio": 33.7,
+   "anchorRate": 7,
+   "breadth": 0.897,
+   "competitiveRatio": 33.3,
    "winRate": 32.5
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 7.4,
    "anchorRate": 8.7,
    "breadth": 0.84,
-   "competitiveRatio": 51.5,
+   "competitiveRatio": 50.6,
    "winRate": 50
   },
   {
@@ -699,7 +699,7 @@
    "stretchRate": 11.6,
    "anchorRate": 4.7,
    "breadth": 0.815,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 41.2,
    "winRate": 35.2
   },
   {
@@ -726,7 +726,7 @@
    "stretchRate": 5.6,
    "anchorRate": 2.6,
    "breadth": 0.744,
-   "competitiveRatio": 34.9,
+   "competitiveRatio": 34.1,
    "winRate": 48.3
   }
  ]

--- a/public/data/conferences/atlantic-coast-conference.json
+++ b/public/data/conferences/atlantic-coast-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 238,
     "UP": 3270,
-    "EVEN": 2346,
-    "DOWN": 4619,
+    "EVEN": 2328,
+    "DOWN": 4637,
     "ANCHOR": 1854
    },
    "bandPct": {
     "STRETCH": 1.9,
     "UP": 26.5,
-    "EVEN": 19,
-    "DOWN": 37.5,
+    "EVEN": 18.9,
+    "DOWN": 37.6,
     "ANCHOR": 15
    },
    "stretchRate": 1.9,
    "anchorRate": 15,
-   "breadth": 0.868,
-   "competitiveRatio": 46.8,
+   "breadth": 0.867,
+   "competitiveRatio": 44.1,
    "winRate": 59.1
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 193,
     "UP": 2317,
-    "EVEN": 1422,
-    "DOWN": 2317,
+    "EVEN": 1404,
+    "DOWN": 2335,
     "ANCHOR": 193
    },
    "bandPct": {
     "STRETCH": 3,
     "UP": 36,
-    "EVEN": 22.1,
-    "DOWN": 36,
+    "EVEN": 21.8,
+    "DOWN": 36.2,
     "ANCHOR": 3
    },
    "stretchRate": 3,
    "anchorRate": 3,
-   "breadth": 0.795,
-   "competitiveRatio": 49.7,
+   "breadth": 0.794,
+   "competitiveRatio": 46.2,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 0.8,
    "anchorRate": 28.2,
    "breadth": 0.837,
-   "competitiveRatio": 43.7,
+   "competitiveRatio": 41.8,
    "winRate": 69.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 24.5,
    "breadth": 0.737,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 43.8,
    "winRate": 73.2
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 8.4,
    "breadth": 0.655,
-   "competitiveRatio": 55.4,
+   "competitiveRatio": 51.4,
    "winRate": 70.7
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 22.9,
    "breadth": 0.654,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 44.2,
    "winRate": 68.7
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 4.7,
    "anchorRate": 14.3,
    "breadth": 0.857,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 42.3,
    "winRate": 57.5
   },
   {
@@ -225,21 +225,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 91,
-    "EVEN": 102,
-    "DOWN": 116,
+    "EVEN": 88,
+    "DOWN": 130,
     "ANCHOR": 105
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 22,
-    "EVEN": 24.6,
-    "DOWN": 28,
+    "EVEN": 21.3,
+    "DOWN": 31.4,
     "ANCHOR": 25.4
    },
    "stretchRate": 0,
    "anchorRate": 25.4,
-   "breadth": 0.859,
-   "competitiveRatio": 50,
+   "breadth": 0.854,
+   "competitiveRatio": 46.4,
    "winRate": 63
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 25.7,
    "breadth": 0.806,
-   "competitiveRatio": 54.4,
+   "competitiveRatio": 47.3,
    "winRate": 60
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 16.3,
    "breadth": 0.806,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 41.1,
    "winRate": 64.4
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 18.1,
    "breadth": 0.817,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 45.2,
    "winRate": 59.3
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 19.4,
    "breadth": 0.796,
-   "competitiveRatio": 45,
+   "competitiveRatio": 44.3,
    "winRate": 54.5
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 7.5,
    "breadth": 0.77,
-   "competitiveRatio": 46.9,
+   "competitiveRatio": 44.1,
    "winRate": 54.4
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 24.1,
    "breadth": 0.732,
-   "competitiveRatio": 33.7,
+   "competitiveRatio": 31.9,
    "winRate": 78.1
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 0,
    "anchorRate": 28.9,
    "breadth": 0.849,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 45.7,
    "winRate": 59.1
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 17.1,
    "breadth": 0.802,
-   "competitiveRatio": 39,
+   "competitiveRatio": 36.6,
    "winRate": 69.9
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0.8,
    "anchorRate": 15,
    "breadth": 0.836,
-   "competitiveRatio": 50.4,
+   "competitiveRatio": 45.6,
    "winRate": 60.2
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 20.5,
    "breadth": 0.84,
-   "competitiveRatio": 52.6,
+   "competitiveRatio": 50.9,
    "winRate": 65.8
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 17,
    "breadth": 0.703,
-   "competitiveRatio": 55.8,
+   "competitiveRatio": 53.8,
    "winRate": 68.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 0,
    "anchorRate": 21.2,
    "breadth": 0.584,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 36.8,
    "winRate": 67.6
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 8.5,
    "breadth": 0.719,
-   "competitiveRatio": 46.2,
+   "competitiveRatio": 45.9,
    "winRate": 67
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 0,
    "anchorRate": 10.1,
    "breadth": 0.815,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 48.3,
    "winRate": 52.1
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 0,
    "anchorRate": 16.6,
    "breadth": 0.838,
-   "competitiveRatio": 54.6,
+   "competitiveRatio": 53.8,
    "winRate": 62.5
   },
   {
@@ -671,7 +671,7 @@
    "stretchRate": 0,
    "anchorRate": 17.5,
    "breadth": 0.771,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 35.3,
    "winRate": 57.9
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 4.5,
    "anchorRate": 0,
    "breadth": 0.74,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 43.5,
    "winRate": 53.1
   },
   {
@@ -725,7 +725,7 @@
    "stretchRate": 0,
    "anchorRate": 13.6,
    "breadth": 0.795,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 45.2,
    "winRate": 47.7
   },
   {
@@ -752,7 +752,7 @@
    "stretchRate": 0,
    "anchorRate": 23.2,
    "breadth": 0.858,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 43.5,
    "winRate": 57.7
   },
   {
@@ -765,21 +765,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 113,
-    "EVEN": 70,
-    "DOWN": 154,
+    "EVEN": 66,
+    "DOWN": 158,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.9,
-    "EVEN": 20.4,
-    "DOWN": 44.9,
+    "EVEN": 19.2,
+    "DOWN": 46.1,
     "ANCHOR": 1.7
    },
    "stretchRate": 0,
    "anchorRate": 1.7,
-   "breadth": 0.696,
-   "competitiveRatio": 49.9,
+   "breadth": 0.69,
+   "competitiveRatio": 47.5,
    "winRate": 60.6
   },
   {
@@ -806,7 +806,7 @@
    "stretchRate": 10.8,
    "anchorRate": 2.7,
    "breadth": 0.713,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39,
    "winRate": 39.6
   },
   {
@@ -833,7 +833,7 @@
    "stretchRate": 0,
    "anchorRate": 9.3,
    "breadth": 0.716,
-   "competitiveRatio": 52,
+   "competitiveRatio": 49.8,
    "winRate": 54.7
   },
   {
@@ -860,7 +860,7 @@
    "stretchRate": 0,
    "anchorRate": 1.8,
    "breadth": 0.699,
-   "competitiveRatio": 46.4,
+   "competitiveRatio": 42.2,
    "winRate": 50.6
   },
   {
@@ -887,7 +887,7 @@
    "stretchRate": 0,
    "anchorRate": 13.3,
    "breadth": 0.808,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 38.7,
    "winRate": 53.8
   },
   {
@@ -914,7 +914,7 @@
    "stretchRate": 0,
    "anchorRate": 2.7,
    "breadth": 0.704,
-   "competitiveRatio": 52,
+   "competitiveRatio": 47.7,
    "winRate": 43.2
   },
   {
@@ -941,7 +941,7 @@
    "stretchRate": 6.1,
    "anchorRate": 10.1,
    "breadth": 0.836,
-   "competitiveRatio": 44.5,
+   "competitiveRatio": 41.9,
    "winRate": 44
   },
   {
@@ -968,7 +968,7 @@
    "stretchRate": 0,
    "anchorRate": 1.9,
    "breadth": 0.657,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 45.7,
    "winRate": 58.7
   },
   {
@@ -995,7 +995,7 @@
    "stretchRate": 47.4,
    "anchorRate": 21.9,
    "breadth": 0.746,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 32.8,
    "winRate": 27.2
   }
  ]

--- a/public/data/conferences/atlantic-east-conference.json
+++ b/public/data/conferences/atlantic-east-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.4,
    "anchorRate": 1.2,
    "breadth": 0.756,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25.1,
    "winRate": 41.8
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 9.2,
    "anchorRate": 1.8,
    "breadth": 0.765,
-   "competitiveRatio": 24.6,
+   "competitiveRatio": 24,
    "winRate": 38.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2,
    "anchorRate": 0,
    "breadth": 0.627,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 24.8,
    "winRate": 49.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 9.8,
    "anchorRate": 0,
    "breadth": 0.737,
-   "competitiveRatio": 23.8,
+   "competitiveRatio": 23,
    "winRate": 40.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.593,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 28.8,
    "winRate": 46.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 2.9,
    "anchorRate": 10,
    "breadth": 0.642,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 27.1,
    "winRate": 55.2
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 10,
    "anchorRate": 0,
    "breadth": 0.8,
-   "competitiveRatio": 22.3,
+   "competitiveRatio": 20.7,
    "winRate": 42.5
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 5.1,
    "anchorRate": 0,
    "breadth": 0.535,
-   "competitiveRatio": 19.3,
+   "competitiveRatio": 19.8,
    "winRate": 24.9
   },
   {

--- a/public/data/conferences/atlantic-sun-conference.json
+++ b/public/data/conferences/atlantic-sun-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 10.6,
    "anchorRate": 8.2,
    "breadth": 0.911,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 46.6,
    "winRate": 48.9
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 8,
    "anchorRate": 8,
    "breadth": 0.9,
-   "competitiveRatio": 52.2,
+   "competitiveRatio": 50.8,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 11.3,
    "anchorRate": 8.2,
    "breadth": 0.912,
-   "competitiveRatio": 46,
+   "competitiveRatio": 45.3,
    "winRate": 48.5
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 19.8,
    "anchorRate": 3.1,
    "breadth": 0.829,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 32.3,
    "winRate": 35.4
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 3.1,
    "anchorRate": 10.2,
    "breadth": 0.786,
-   "competitiveRatio": 56.4,
+   "competitiveRatio": 55.9,
    "winRate": 50
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 2.8,
    "anchorRate": 15.1,
    "breadth": 0.808,
-   "competitiveRatio": 52.5,
+   "competitiveRatio": 51.7,
    "winRate": 62
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 9.2,
    "breadth": 0.478,
-   "competitiveRatio": 50.1,
+   "competitiveRatio": 49.3,
    "winRate": 59.4
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0.9,
    "anchorRate": 18.8,
    "breadth": 0.781,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 43.7,
    "winRate": 67.2
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 5.7,
    "anchorRate": 10.4,
    "breadth": 0.842,
-   "competitiveRatio": 52.2,
+   "competitiveRatio": 51.3,
    "winRate": 40.6
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 21,
    "anchorRate": 6.6,
    "breadth": 0.885,
-   "competitiveRatio": 51.2,
+   "competitiveRatio": 49.4,
    "winRate": 39.5
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 1.9,
    "anchorRate": 9,
    "breadth": 0.737,
-   "competitiveRatio": 51.6,
+   "competitiveRatio": 50.9,
    "winRate": 62.8
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 24,
    "anchorRate": 3.8,
    "breadth": 0.708,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 47.3,
    "winRate": 39.1
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 44.4,
    "anchorRate": 4,
    "breadth": 0.557,
-   "competitiveRatio": 19,
+   "competitiveRatio": 17.9,
    "winRate": 15.3
   }
  ]

--- a/public/data/conferences/big-12-conference.json
+++ b/public/data/conferences/big-12-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 2,
    "anchorRate": 12.8,
    "breadth": 0.842,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 44.8,
    "winRate": 57.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 3,
    "anchorRate": 3,
    "breadth": 0.774,
-   "competitiveRatio": 47.6,
+   "competitiveRatio": 46,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 1.2,
    "anchorRate": 20.3,
    "breadth": 0.835,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 43.9,
    "winRate": 63.5
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 28.6,
    "breadth": 0.838,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 48.2,
    "winRate": 63.3
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 1.4,
    "breadth": 0.716,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 45.4,
    "winRate": 59.6
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 25.3,
    "breadth": 0.556,
-   "competitiveRatio": 54.6,
+   "competitiveRatio": 49.1,
    "winRate": 72.9
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 11.3,
    "breadth": 0.776,
-   "competitiveRatio": 49.9,
+   "competitiveRatio": 47.4,
    "winRate": 60.5
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 32,
    "breadth": 0.81,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 42.9,
    "winRate": 66.5
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 27.9,
    "breadth": 0.843,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 38.1,
    "winRate": 79.3
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 6.8,
    "anchorRate": 19.6,
    "breadth": 0.9,
-   "competitiveRatio": 47.9,
+   "competitiveRatio": 44.8,
    "winRate": 58.1
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 0.8,
    "breadth": 0.667,
-   "competitiveRatio": 47.5,
+   "competitiveRatio": 47,
    "winRate": 58.2
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 6.9,
    "breadth": 0.7,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 42.8,
    "winRate": 59.8
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 9.5,
    "breadth": 0.714,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 50.4,
    "winRate": 55.6
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 4.1,
    "anchorRate": 7.5,
    "breadth": 0.769,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 41,
    "winRate": 45.5
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 0,
    "anchorRate": 8.5,
    "breadth": 0.76,
-   "competitiveRatio": 50,
+   "competitiveRatio": 48.8,
    "winRate": 52.1
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 13.6,
    "breadth": 0.812,
-   "competitiveRatio": 42.1,
+   "competitiveRatio": 40.7,
    "winRate": 56.1
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 16.6,
    "anchorRate": 13.6,
    "breadth": 0.95,
-   "competitiveRatio": 55.7,
+   "competitiveRatio": 54.2,
    "winRate": 56.6
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 3.1,
    "breadth": 0.548,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.1,
    "winRate": 65.2
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 9.3,
    "breadth": 0.639,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 38.7,
    "winRate": 64.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 0,
    "anchorRate": 9.3,
    "breadth": 0.764,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 46.1,
    "winRate": 51.1
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 6.6,
    "anchorRate": 10.3,
    "breadth": 0.741,
-   "competitiveRatio": 36.6,
+   "competitiveRatio": 36.3,
    "winRate": 43.1
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 7.1,
    "anchorRate": 5.5,
    "breadth": 0.659,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 45,
    "winRate": 49.5
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 4.6,
    "anchorRate": 15,
    "breadth": 0.87,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 52.9,
    "winRate": 48.4
   },
   {
@@ -671,7 +671,7 @@
    "stretchRate": 0,
    "anchorRate": 19.3,
    "breadth": 0.528,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 38.3,
    "winRate": 72.1
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 4.6,
    "anchorRate": 3.3,
    "breadth": 0.778,
-   "competitiveRatio": 49.5,
+   "competitiveRatio": 47.2,
    "winRate": 37.7
   },
   {
@@ -725,7 +725,7 @@
    "stretchRate": 0,
    "anchorRate": 9.4,
    "breadth": 0.735,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 45.8,
    "winRate": 65
   },
   {
@@ -752,7 +752,7 @@
    "stretchRate": 2.8,
    "anchorRate": 5.9,
    "breadth": 0.73,
-   "competitiveRatio": 52.8,
+   "competitiveRatio": 51.4,
    "winRate": 39.9
   },
   {
@@ -779,7 +779,7 @@
    "stretchRate": 0,
    "anchorRate": 10.3,
    "breadth": 0.768,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 37.4,
    "winRate": 42
   }
  ]

--- a/public/data/conferences/big-8-conference-north.json
+++ b/public/data/conferences/big-8-conference-north.json
@@ -30,7 +30,7 @@
    "stretchRate": 12,
    "anchorRate": 6.4,
    "breadth": 0.82,
-   "competitiveRatio": 17.8,
+   "competitiveRatio": 17.9,
    "winRate": 50.1
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 14.7,
    "anchorRate": 14.7,
    "breadth": 0.927,
-   "competitiveRatio": 9.4,
+   "competitiveRatio": 10.1,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 11,
    "anchorRate": 3.5,
    "breadth": 0.763,
-   "competitiveRatio": 20.7,
+   "competitiveRatio": 20.6,
    "winRate": 50.2
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 19,
    "anchorRate": 1.9,
    "breadth": 0.815,
-   "competitiveRatio": 18.7,
+   "competitiveRatio": 19,
    "winRate": 63.5
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 12.1,
    "anchorRate": 0,
    "breadth": 0.498,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25.7,
    "winRate": 31.4
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 27,
    "breadth": 0.363,
-   "competitiveRatio": 27.3,
+   "competitiveRatio": 28.2,
    "winRate": 77.5
   },
   {

--- a/public/data/conferences/big-8-conference-south.json
+++ b/public/data/conferences/big-8-conference-south.json
@@ -30,7 +30,7 @@
    "stretchRate": 14.2,
    "anchorRate": 8.2,
    "breadth": 0.883,
-   "competitiveRatio": 21.1,
+   "competitiveRatio": 20.7,
    "winRate": 46.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 14,
    "anchorRate": 14,
    "breadth": 0.902,
-   "competitiveRatio": 21.4,
+   "competitiveRatio": 20.9,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 14.4,
    "anchorRate": 0,
    "breadth": 0.782,
-   "competitiveRatio": 20.8,
+   "competitiveRatio": 20.4,
    "winRate": 41.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 3.9,
    "anchorRate": 24.8,
    "breadth": 0.871,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 19.3,
    "winRate": 61.1
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 7.6,
    "breadth": 0.733,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 21.1,
    "winRate": 55.8
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 19.5,
    "breadth": 0.608,
-   "competitiveRatio": 16.2,
+   "competitiveRatio": 15.7,
    "winRate": 82.4
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 2.9,
    "anchorRate": 20.3,
    "breadth": 0.836,
-   "competitiveRatio": 25.2,
+   "competitiveRatio": 24.8,
    "winRate": 63.3
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 32.2,
    "anchorRate": 0,
    "breadth": 0.702,
-   "competitiveRatio": 30.7,
+   "competitiveRatio": 30.2,
    "winRate": 34.2
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 48.1,
    "anchorRate": 0,
    "breadth": 0.43,
-   "competitiveRatio": 18.8,
+   "competitiveRatio": 18.2,
    "winRate": 7.7
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 67.5,
    "anchorRate": 0,
    "breadth": 0.392,
-   "competitiveRatio": 5.8,
+   "competitiveRatio": 5.2,
    "winRate": 3.2
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.41,
-   "competitiveRatio": 15.6,
+   "competitiveRatio": 14.3,
    "winRate": 53.8
   }
  ]

--- a/public/data/conferences/big-east-conference.json
+++ b/public/data/conferences/big-east-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 525,
     "UP": 2469,
-    "EVEN": 1180,
-    "DOWN": 1875,
+    "EVEN": 1174,
+    "DOWN": 1881,
     "ANCHOR": 300
    },
    "bandPct": {
     "STRETCH": 8.3,
     "UP": 38.9,
-    "EVEN": 18.6,
-    "DOWN": 29.5,
+    "EVEN": 18.5,
+    "DOWN": 29.6,
     "ANCHOR": 4.7
    },
    "stretchRate": 8.3,
    "anchorRate": 4.7,
    "breadth": 0.864,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46.6,
    "winRate": 46.6
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 75,
     "UP": 746,
-    "EVEN": 492,
-    "DOWN": 746,
+    "EVEN": 486,
+    "DOWN": 752,
     "ANCHOR": 75
    },
    "bandPct": {
     "STRETCH": 3.5,
     "UP": 35,
-    "EVEN": 23.1,
-    "DOWN": 35,
+    "EVEN": 22.8,
+    "DOWN": 35.2,
     "ANCHOR": 3.5
    },
    "stretchRate": 3.5,
    "anchorRate": 3.5,
-   "breadth": 0.813,
-   "competitiveRatio": 51.9,
+   "breadth": 0.812,
+   "competitiveRatio": 50.5,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 10.7,
    "anchorRate": 5.3,
    "breadth": 0.876,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 44.7,
    "winRate": 44.9
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 11,
    "anchorRate": 11.8,
    "breadth": 0.957,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 47.5,
    "winRate": 53.2
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 12.4,
    "anchorRate": 0.8,
    "breadth": 0.844,
-   "competitiveRatio": 56.7,
+   "competitiveRatio": 56,
    "winRate": 42.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 4.7,
    "anchorRate": 10.2,
    "breadth": 0.851,
-   "competitiveRatio": 60.5,
+   "competitiveRatio": 58.9,
    "winRate": 50.5
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 3.2,
    "anchorRate": 0,
    "breadth": 0.486,
-   "competitiveRatio": 52,
+   "competitiveRatio": 51.7,
    "winRate": 31.6
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 12.5,
    "anchorRate": 6.1,
    "breadth": 0.871,
-   "competitiveRatio": 49.9,
+   "competitiveRatio": 46.9,
    "winRate": 42.4
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 4.8,
    "breadth": 0.684,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 39.9,
    "winRate": 65.8
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 15.3,
    "anchorRate": 0,
    "breadth": 0.736,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 43.5,
    "winRate": 38.7
   },
   {
@@ -306,21 +306,21 @@
    "bands": {
     "STRETCH": 12,
     "UP": 171,
-    "EVEN": 49,
-    "DOWN": 120,
+    "EVEN": 43,
+    "DOWN": 126,
     "ANCHOR": 15
    },
    "bandPct": {
     "STRETCH": 3.3,
     "UP": 46.6,
-    "EVEN": 13.4,
-    "DOWN": 32.7,
+    "EVEN": 11.7,
+    "DOWN": 34.3,
     "ANCHOR": 4.1
    },
    "stretchRate": 3.3,
    "anchorRate": 4.1,
-   "breadth": 0.766,
-   "competitiveRatio": 44.1,
+   "breadth": 0.756,
+   "competitiveRatio": 43.8,
    "winRate": 49.9
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 4.1,
    "anchorRate": 6.6,
    "breadth": 0.846,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 52.2,
    "winRate": 49.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.705,
-   "competitiveRatio": 50,
+   "competitiveRatio": 48,
    "winRate": 52
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 25.8,
    "anchorRate": 0,
    "breadth": 0.593,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 51.9,
    "winRate": 30.7
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0.9,
    "anchorRate": 0.9,
    "breadth": 0.714,
-   "competitiveRatio": 48,
+   "competitiveRatio": 47.4,
    "winRate": 47.1
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 7.1,
    "breadth": 0.709,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 44.7,
    "winRate": 58.1
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 5.8,
    "anchorRate": 8.9,
    "breadth": 0.844,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 40.3,
    "winRate": 57.4
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 28.9,
    "anchorRate": 0,
    "breadth": 0.664,
-   "competitiveRatio": 35.5,
+   "competitiveRatio": 33.9,
    "winRate": 28.6
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 16.3,
    "breadth": 0.768,
-   "competitiveRatio": 36.2,
+   "competitiveRatio": 35.4,
    "winRate": 64.9
   }
  ]

--- a/public/data/conferences/big-sky-conference.json
+++ b/public/data/conferences/big-sky-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 5.2,
    "anchorRate": 9.1,
    "breadth": 0.865,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 50.1,
    "winRate": 49
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 1.7,
    "anchorRate": 1.7,
    "breadth": 0.749,
-   "competitiveRatio": 58.3,
+   "competitiveRatio": 57.5,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 8.3,
    "anchorRate": 15.4,
    "breadth": 0.88,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 43.9,
    "winRate": 48.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 1.5,
    "anchorRate": 16.7,
    "breadth": 0.595,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 48.4,
    "winRate": 68
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 4.3,
    "anchorRate": 17.4,
    "breadth": 0.861,
-   "competitiveRatio": 55.2,
+   "competitiveRatio": 53,
    "winRate": 67.7
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 16.4,
    "breadth": 0.825,
-   "competitiveRatio": 57.1,
+   "competitiveRatio": 56,
    "winRate": 56
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 10.1,
    "breadth": 0.783,
-   "competitiveRatio": 56.6,
+   "competitiveRatio": 54.6,
    "winRate": 41.7
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0.8,
    "anchorRate": 18.6,
    "breadth": 0.845,
-   "competitiveRatio": 51.7,
+   "competitiveRatio": 50.8,
    "winRate": 59.6
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 4.2,
    "anchorRate": 8.5,
    "breadth": 0.794,
-   "competitiveRatio": 46.2,
+   "competitiveRatio": 44.5,
    "winRate": 56.1
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 4.3,
    "anchorRate": 8.6,
    "breadth": 0.803,
-   "competitiveRatio": 58.3,
+   "competitiveRatio": 57.5,
    "winRate": 40.8
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 4.3,
    "anchorRate": 0,
    "breadth": 0.712,
-   "competitiveRatio": 49.4,
+   "competitiveRatio": 48.8,
    "winRate": 50.1
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 1.7,
    "anchorRate": 5.2,
    "breadth": 0.761,
-   "competitiveRatio": 52.2,
+   "competitiveRatio": 50.1,
    "winRate": 53
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 3.5,
    "anchorRate": 15,
    "breadth": 0.819,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 52.4,
    "winRate": 55.2
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 12,
    "anchorRate": 0,
    "breadth": 0.6,
-   "competitiveRatio": 59.8,
+   "competitiveRatio": 58.9,
    "winRate": 34.9
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 18.9,
    "anchorRate": 3,
    "breadth": 0.436,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 47,
    "winRate": 32.3
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 8.3,
    "anchorRate": 3.7,
    "breadth": 0.769,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 45.9,
    "winRate": 36.4
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 13.5,
    "anchorRate": 0,
    "breadth": 0.748,
-   "competitiveRatio": 48.9,
+   "competitiveRatio": 49.2,
    "winRate": 37
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 1,
    "anchorRate": 3.9,
    "breadth": 0.735,
-   "competitiveRatio": 47.2,
+   "competitiveRatio": 46,
    "winRate": 59.4
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 8.3,
    "anchorRate": 13.5,
    "breadth": 0.663,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 45.1,
    "winRate": 32.3
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 5.7,
    "anchorRate": 11.1,
    "breadth": 0.828,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 39.6,
    "winRate": 39.1
   }
  ]

--- a/public/data/conferences/big-south-conference.json
+++ b/public/data/conferences/big-south-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 7.4,
    "anchorRate": 3.6,
    "breadth": 0.849,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 46.4,
    "winRate": 50.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.682,
-   "competitiveRatio": 53.2,
+   "competitiveRatio": 52.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 9.4,
    "anchorRate": 4.6,
    "breadth": 0.868,
-   "competitiveRatio": 45.7,
+   "competitiveRatio": 44.7,
    "winRate": 50.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 4.7,
    "anchorRate": 1.6,
    "breadth": 0.771,
-   "competitiveRatio": 50,
+   "competitiveRatio": 48.4,
    "winRate": 69.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 4.2,
    "anchorRate": 0,
    "breadth": 0.719,
-   "competitiveRatio": 47.6,
+   "competitiveRatio": 46.7,
    "winRate": 39.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 18.2,
    "anchorRate": 6.9,
    "breadth": 0.86,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 42.2,
    "winRate": 55.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 11.1,
    "anchorRate": 1.8,
    "breadth": 0.847,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.3,
    "winRate": 40.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 10.3,
    "anchorRate": 3.8,
    "breadth": 0.85,
-   "competitiveRatio": 44.7,
+   "competitiveRatio": 44.1,
    "winRate": 45.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1,
    "anchorRate": 1.9,
    "breadth": 0.723,
-   "competitiveRatio": 49.4,
+   "competitiveRatio": 49,
    "winRate": 63.2
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2.1,
    "anchorRate": 13.6,
    "breadth": 0.701,
-   "competitiveRatio": 48.4,
+   "competitiveRatio": 47.3,
    "winRate": 50.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 9,
    "anchorRate": 2.2,
    "breadth": 0.681,
-   "competitiveRatio": 48.4,
+   "competitiveRatio": 47.3,
    "winRate": 60.6
   },
   {

--- a/public/data/conferences/big-ten-conference.json
+++ b/public/data/conferences/big-ten-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 146,
     "UP": 3203,
-    "EVEN": 2141,
-    "DOWN": 4435,
+    "EVEN": 2116,
+    "DOWN": 4460,
     "ANCHOR": 1113
    },
    "bandPct": {
     "STRETCH": 1.3,
     "UP": 29,
-    "EVEN": 19.4,
-    "DOWN": 40.2,
+    "EVEN": 19.2,
+    "DOWN": 40.4,
     "ANCHOR": 10.1
    },
    "stretchRate": 1.3,
    "anchorRate": 10.1,
-   "breadth": 0.828,
-   "competitiveRatio": 48.6,
+   "breadth": 0.827,
+   "competitiveRatio": 46.1,
    "winRate": 57.2
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 119,
     "UP": 2043,
-    "EVEN": 1044,
-    "DOWN": 2043,
+    "EVEN": 1031,
+    "DOWN": 2056,
     "ANCHOR": 119
    },
    "bandPct": {
     "STRETCH": 2.2,
     "UP": 38.1,
-    "EVEN": 19.4,
-    "DOWN": 38.1,
+    "EVEN": 19.2,
+    "DOWN": 38.3,
     "ANCHOR": 2.2
    },
    "stretchRate": 2.2,
    "anchorRate": 2.2,
-   "breadth": 0.76,
-   "competitiveRatio": 49.7,
+   "breadth": 0.759,
+   "competitiveRatio": 47.2,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 27,
     "UP": 1160,
-    "EVEN": 1097,
-    "DOWN": 2392,
+    "EVEN": 1085,
+    "DOWN": 2404,
     "ANCHOR": 994
    },
    "bandPct": {
     "STRETCH": 0.5,
     "UP": 20.5,
-    "EVEN": 19.3,
-    "DOWN": 42.2,
+    "EVEN": 19.1,
+    "DOWN": 42.4,
     "ANCHOR": 17.5
    },
    "stretchRate": 0.5,
    "anchorRate": 17.5,
-   "breadth": 0.831,
-   "competitiveRatio": 47.5,
+   "breadth": 0.83,
+   "competitiveRatio": 45,
    "winRate": 64.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 31.9,
    "breadth": 0.637,
-   "competitiveRatio": 40,
+   "competitiveRatio": 36.3,
    "winRate": 80.3
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 16.8,
    "breadth": 0.73,
-   "competitiveRatio": 57.8,
+   "competitiveRatio": 55.9,
    "winRate": 62.7
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 12,
    "breadth": 0.795,
-   "competitiveRatio": 55.1,
+   "competitiveRatio": 44.6,
    "winRate": 62
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 6.7,
    "breadth": 0.756,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 41.3,
    "winRate": 73.8
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 2.6,
    "anchorRate": 12.9,
    "breadth": 0.707,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 46.5,
    "winRate": 47.5
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 5.7,
    "anchorRate": 12.8,
    "breadth": 0.892,
-   "competitiveRatio": 53.5,
+   "competitiveRatio": 53.3,
    "winRate": 57
   },
   {
@@ -279,21 +279,21 @@
    "bands": {
     "STRETCH": 4,
     "UP": 143,
-    "EVEN": 82,
-    "DOWN": 125,
+    "EVEN": 74,
+    "DOWN": 133,
     "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 1.1,
     "UP": 37.8,
-    "EVEN": 21.7,
-    "DOWN": 33.1,
+    "EVEN": 19.6,
+    "DOWN": 35.2,
     "ANCHOR": 6.3
    },
    "stretchRate": 1.1,
    "anchorRate": 6.3,
-   "breadth": 0.8,
-   "competitiveRatio": 48.5,
+   "breadth": 0.794,
+   "competitiveRatio": 46.2,
    "winRate": 52.6
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0.8,
    "anchorRate": 7.2,
    "breadth": 0.813,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 40.7,
    "winRate": 58
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0.8,
    "anchorRate": 4.8,
    "breadth": 0.744,
-   "competitiveRatio": 53.5,
+   "competitiveRatio": 47.8,
    "winRate": 55.1
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 12.6,
    "breadth": 0.577,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 39,
    "winRate": 75
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 4.4,
    "breadth": 0.734,
-   "competitiveRatio": 42.8,
+   "competitiveRatio": 40.1,
    "winRate": 63.5
   },
   {
@@ -414,21 +414,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 57,
-    "EVEN": 101,
-    "DOWN": 168,
+    "EVEN": 97,
+    "DOWN": 172,
     "ANCHOR": 36
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.7,
-    "EVEN": 27.9,
-    "DOWN": 46.4,
+    "EVEN": 26.8,
+    "DOWN": 47.5,
     "ANCHOR": 9.9
    },
    "stretchRate": 0,
    "anchorRate": 9.9,
-   "breadth": 0.766,
-   "competitiveRatio": 43.1,
+   "breadth": 0.762,
+   "competitiveRatio": 42.3,
    "winRate": 59.9
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 9.1,
    "breadth": 0.598,
-   "competitiveRatio": 57.3,
+   "competitiveRatio": 56.5,
    "winRate": 62.9
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 21.5,
    "breadth": 0.647,
-   "competitiveRatio": 52.8,
+   "competitiveRatio": 49.2,
    "winRate": 48.3
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 2.5,
    "breadth": 0.7,
-   "competitiveRatio": 46.8,
+   "competitiveRatio": 43.1,
    "winRate": 63.9
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.706,
-   "competitiveRatio": 57.7,
+   "competitiveRatio": 55.2,
    "winRate": 56.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 4,
    "anchorRate": 4.3,
    "breadth": 0.806,
-   "competitiveRatio": 59,
+   "competitiveRatio": 56.2,
    "winRate": 44.9
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 16.3,
    "breadth": 0.726,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 37.8,
    "winRate": 67
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 1.7,
    "anchorRate": 8.9,
    "breadth": 0.833,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 51.3,
    "winRate": 53
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 0,
    "anchorRate": 22.8,
    "breadth": 0.843,
-   "competitiveRatio": 46,
+   "competitiveRatio": 45.1,
    "winRate": 59.2
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 15.8,
    "anchorRate": 0,
    "breadth": 0.729,
-   "competitiveRatio": 56,
+   "competitiveRatio": 54.5,
    "winRate": 49
   },
   {
@@ -725,7 +725,7 @@
    "stretchRate": 0,
    "anchorRate": 3.3,
    "breadth": 0.733,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 47,
    "winRate": 50.7
   },
   {
@@ -752,7 +752,7 @@
    "stretchRate": 0,
    "anchorRate": 9.5,
    "breadth": 0.749,
-   "competitiveRatio": 51.8,
+   "competitiveRatio": 49.7,
    "winRate": 44.9
   },
   {
@@ -779,7 +779,7 @@
    "stretchRate": 0,
    "anchorRate": 15,
    "breadth": 0.8,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 46.2,
    "winRate": 45.9
   },
   {
@@ -806,7 +806,7 @@
    "stretchRate": 1.8,
    "anchorRate": 10.1,
    "breadth": 0.774,
-   "competitiveRatio": 46.8,
+   "competitiveRatio": 45.6,
    "winRate": 49.2
   },
   {
@@ -819,21 +819,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 62,
-    "EVEN": 107,
-    "DOWN": 103,
+    "EVEN": 94,
+    "DOWN": 116,
     "ANCHOR": 55
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19,
-    "EVEN": 32.7,
-    "DOWN": 31.5,
+    "EVEN": 28.7,
+    "DOWN": 35.5,
     "ANCHOR": 16.8
    },
    "stretchRate": 0,
    "anchorRate": 16.8,
-   "breadth": 0.835,
-   "competitiveRatio": 43.1,
+   "breadth": 0.833,
+   "competitiveRatio": 41.6,
    "winRate": 48
   },
   {
@@ -860,7 +860,7 @@
    "stretchRate": 0,
    "anchorRate": 2.8,
    "breadth": 0.742,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 44.8,
    "winRate": 56.4
   },
   {
@@ -887,7 +887,7 @@
    "stretchRate": 0,
    "anchorRate": 0.9,
    "breadth": 0.673,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 42.7,
    "winRate": 47.4
   },
   {
@@ -914,7 +914,7 @@
    "stretchRate": 5,
    "anchorRate": 3,
    "breadth": 0.683,
-   "competitiveRatio": 44,
+   "competitiveRatio": 42.7,
    "winRate": 44.4
   },
   {
@@ -941,7 +941,7 @@
    "stretchRate": 3.2,
    "anchorRate": 5.3,
    "breadth": 0.78,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.2,
    "winRate": 51.4
   }
  ]

--- a/public/data/conferences/big-west-conference.json
+++ b/public/data/conferences/big-west-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 373,
     "UP": 1934,
-    "EVEN": 1287,
-    "DOWN": 1846,
+    "EVEN": 1281,
+    "DOWN": 1852,
     "ANCHOR": 406
    },
    "bandPct": {
     "STRETCH": 6.4,
     "UP": 33.1,
-    "EVEN": 22,
-    "DOWN": 31.6,
+    "EVEN": 21.9,
+    "DOWN": 31.7,
     "ANCHOR": 6.9
    },
    "stretchRate": 6.4,
    "anchorRate": 6.9,
    "breadth": 0.885,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48,
    "winRate": 49.3
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 4.3,
    "anchorRate": 4.3,
    "breadth": 0.841,
-   "competitiveRatio": 51.8,
+   "competitiveRatio": 51.1,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 267,
     "UP": 1140,
-    "EVEN": 593,
-    "DOWN": 1052,
+    "EVEN": 587,
+    "DOWN": 1058,
     "ANCHOR": 300
    },
    "bandPct": {
     "STRETCH": 8,
     "UP": 34,
-    "EVEN": 17.7,
-    "DOWN": 31.4,
+    "EVEN": 17.5,
+    "DOWN": 31.6,
     "ANCHOR": 8.9
    },
    "stretchRate": 8,
    "anchorRate": 8.9,
-   "breadth": 0.904,
-   "competitiveRatio": 46.8,
+   "breadth": 0.903,
+   "competitiveRatio": 45.6,
    "winRate": 48.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 6.8,
    "anchorRate": 10,
    "breadth": 0.904,
-   "competitiveRatio": 52.3,
+   "competitiveRatio": 52,
    "winRate": 47.3
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 1.6,
    "anchorRate": 3.1,
    "breadth": 0.693,
-   "competitiveRatio": 54.8,
+   "competitiveRatio": 54.3,
    "winRate": 62.3
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 4.4,
    "anchorRate": 0,
    "breadth": 0.735,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 47.8,
    "winRate": 37.3
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.692,
-   "competitiveRatio": 53.1,
+   "competitiveRatio": 52.6,
    "winRate": 56.1
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 20.6,
    "anchorRate": 0,
    "breadth": 0.785,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 45.6,
    "winRate": 39
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 1.7,
    "anchorRate": 0,
    "breadth": 0.706,
-   "competitiveRatio": 49.6,
+   "competitiveRatio": 48.1,
    "winRate": 59.9
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0.9,
    "anchorRate": 11.2,
    "breadth": 0.824,
-   "competitiveRatio": 55.8,
+   "competitiveRatio": 55.2,
    "winRate": 59.8
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 8.7,
    "anchorRate": 4.1,
    "breadth": 0.682,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 36.7,
    "winRate": 23.5
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 1.7,
    "anchorRate": 13.7,
    "breadth": 0.869,
-   "competitiveRatio": 45.5,
+   "competitiveRatio": 44.9,
    "winRate": 44.6
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 1.8,
    "anchorRate": 13.3,
    "breadth": 0.866,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 48.2,
    "winRate": 63.3
   },
   {
@@ -414,21 +414,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 92,
-    "EVEN": 31,
-    "DOWN": 142,
+    "EVEN": 25,
+    "DOWN": 148,
     "ANCHOR": 58
    },
    "bandPct": {
     "STRETCH": 1.8,
     "UP": 28,
-    "EVEN": 9.4,
-    "DOWN": 43.2,
+    "EVEN": 7.6,
+    "DOWN": 45,
     "ANCHOR": 17.6
    },
    "stretchRate": 1.8,
    "anchorRate": 17.6,
-   "breadth": 0.821,
-   "competitiveRatio": 49.1,
+   "breadth": 0.802,
+   "competitiveRatio": 46,
    "winRate": 58.1
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 18.4,
    "breadth": 0.77,
-   "competitiveRatio": 49.7,
+   "competitiveRatio": 48.8,
    "winRate": 66
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 5,
    "breadth": 0.758,
-   "competitiveRatio": 58.5,
+   "competitiveRatio": 57.3,
    "winRate": 46.7
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 9.1,
    "anchorRate": 0,
    "breadth": 0.751,
-   "competitiveRatio": 53,
+   "competitiveRatio": 52.4,
    "winRate": 46.7
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 51.7,
    "anchorRate": 9.1,
    "breadth": 0.641,
-   "competitiveRatio": 34.6,
+   "competitiveRatio": 33.2,
    "winRate": 22.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 4.2,
    "anchorRate": 9.5,
    "breadth": 0.773,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 42.1,
    "winRate": 37.2
   }
  ]

--- a/public/data/conferences/centennial-conference.json
+++ b/public/data/conferences/centennial-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 616,
     "UP": 1938,
-    "EVEN": 788,
-    "DOWN": 2232,
+    "EVEN": 782,
+    "DOWN": 2238,
     "ANCHOR": 828
    },
    "bandPct": {
     "STRETCH": 9.6,
     "UP": 30.3,
-    "EVEN": 12.3,
-    "DOWN": 34.9,
+    "EVEN": 12.2,
+    "DOWN": 35,
     "ANCHOR": 12.9
    },
    "stretchRate": 9.6,
    "anchorRate": 12.9,
-   "breadth": 0.918,
-   "competitiveRatio": 35.3,
+   "breadth": 0.917,
+   "competitiveRatio": 34.7,
    "winRate": 53.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.5,
    "anchorRate": 17.5,
    "breadth": 0.951,
-   "competitiveRatio": 28,
+   "competitiveRatio": 27.7,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 131,
     "UP": 1152,
-    "EVEN": 558,
-    "DOWN": 1446,
+    "EVEN": 552,
+    "DOWN": 1452,
     "ANCHOR": 343
    },
    "bandPct": {
     "STRETCH": 3.6,
     "UP": 31.7,
-    "EVEN": 15.4,
-    "DOWN": 39.8,
+    "EVEN": 15.2,
+    "DOWN": 40,
     "ANCHOR": 9.4
    },
    "stretchRate": 3.6,
    "anchorRate": 9.4,
-   "breadth": 0.846,
-   "competitiveRatio": 40.9,
+   "breadth": 0.845,
+   "competitiveRatio": 40,
    "winRate": 56.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 37.6,
    "breadth": 0.663,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 40.2,
    "winRate": 71
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 19.5,
    "breadth": 0.791,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 47.5,
    "winRate": 65.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 32.9,
    "breadth": 0.763,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 37.9,
    "winRate": 66.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 19.7,
    "anchorRate": 9.7,
    "breadth": 0.932,
-   "competitiveRatio": 30.3,
+   "competitiveRatio": 30.6,
    "winRate": 47.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 18.2,
    "breadth": 0.785,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 45.8,
    "winRate": 59.1
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1.7,
    "anchorRate": 23.3,
    "breadth": 0.748,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 32.9,
    "winRate": 66.6
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 7.9,
    "anchorRate": 22.9,
    "breadth": 0.935,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 43.2,
    "winRate": 58.9
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 14.1,
    "anchorRate": 0,
    "breadth": 0.732,
-   "competitiveRatio": 24.1,
+   "competitiveRatio": 22.9,
    "winRate": 46.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 19.2,
    "anchorRate": 0,
    "breadth": 0.808,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 41.6,
    "winRate": 49
   },
   {
@@ -442,21 +442,21 @@
    "bands": {
     "STRETCH": 12,
     "UP": 38,
-    "EVEN": 48,
-    "DOWN": 194,
+    "EVEN": 42,
+    "DOWN": 200,
     "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 3.7,
     "UP": 11.7,
-    "EVEN": 14.7,
-    "DOWN": 59.5,
+    "EVEN": 12.9,
+    "DOWN": 61.3,
     "ANCHOR": 10.4
    },
    "stretchRate": 3.7,
    "anchorRate": 10.4,
-   "breadth": 0.745,
-   "competitiveRatio": 27.6,
+   "breadth": 0.728,
+   "competitiveRatio": 27,
    "winRate": 58
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 7.6,
    "anchorRate": 16.2,
    "breadth": 0.948,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 37.8,
    "winRate": 57.5
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 20.1,
    "anchorRate": 8.9,
    "breadth": 0.875,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 33.9,
    "winRate": 36.4
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 1.3,
    "anchorRate": 0,
    "breadth": 0.613,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 40.1,
    "winRate": 46.9
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 23.5,
    "anchorRate": 5.9,
    "breadth": 0.871,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 27.8,
    "winRate": 43.1
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 20.1,
    "anchorRate": 3.7,
    "breadth": 0.921,
-   "competitiveRatio": 18.2,
+   "competitiveRatio": 17.5,
    "winRate": 31.2
   }
  ]

--- a/public/data/conferences/central-atlantic-collegiate-conference.json
+++ b/public/data/conferences/central-atlantic-collegiate-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 8.6,
    "anchorRate": 11.5,
    "breadth": 0.904,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 36.5,
    "winRate": 49.7
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 11.9,
    "anchorRate": 11.9,
    "breadth": 0.935,
-   "competitiveRatio": 36.4,
+   "competitiveRatio": 35.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 5.4,
    "anchorRate": 11.1,
    "breadth": 0.863,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 37.4,
    "winRate": 49.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 22.8,
    "breadth": 0.814,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 33.4,
    "winRate": 56.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 20.1,
    "breadth": 0.809,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 36.7,
    "winRate": 69
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 5.9,
    "anchorRate": 18.7,
    "breadth": 0.879,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 45,
    "winRate": 57.2
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 5.9,
    "anchorRate": 0,
    "breadth": 0.712,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 36.2,
    "winRate": 47.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 30.4,
    "anchorRate": 0,
    "breadth": 0.643,
-   "competitiveRatio": 28.3,
+   "competitiveRatio": 28,
    "winRate": 27.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2,
    "anchorRate": 16.4,
    "breadth": 0.839,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41.4,
    "winRate": 40.6
   },
   {

--- a/public/data/conferences/central-intercollegiate-athletic-association.json
+++ b/public/data/conferences/central-intercollegiate-athletic-association.json
@@ -31,7 +31,7 @@
    "stretchRate": 21.3,
    "anchorRate": 9.2,
    "breadth": 0.91,
-   "competitiveRatio": 16.5,
+   "competitiveRatio": 16.1,
    "winRate": 40.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 14.1,
    "anchorRate": 14.1,
    "breadth": 0.926,
-   "competitiveRatio": 9,
+   "competitiveRatio": 8.8,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 30.7,
    "anchorRate": 3,
    "breadth": 0.817,
-   "competitiveRatio": 26.1,
+   "competitiveRatio": 25.4,
    "winRate": 28
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 9.5,
    "anchorRate": 18.6,
    "breadth": 0.842,
-   "competitiveRatio": 19.3,
+   "competitiveRatio": 18.2,
    "winRate": 61.7
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 6.7,
    "anchorRate": 10.7,
    "breadth": 0.802,
-   "competitiveRatio": 11.9,
+   "competitiveRatio": 11.5,
    "winRate": 56.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 4.6,
    "anchorRate": 13.4,
    "breadth": 0.846,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 21.7,
    "winRate": 59.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 12.2,
    "anchorRate": 19.9,
    "breadth": 0.82,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 34.9,
    "winRate": 39.3
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 38.5,
    "anchorRate": 11.8,
    "breadth": 0.927,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 26,
    "winRate": 37.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 7.1,
    "anchorRate": 0,
    "breadth": 0.502,
-   "competitiveRatio": 13.5,
+   "competitiveRatio": 12.9,
    "winRate": 36.5
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 81,
    "anchorRate": 0,
    "breadth": 0.302,
-   "competitiveRatio": 6,
+   "competitiveRatio": 5.2,
    "winRate": 7.8
   },
   {

--- a/public/data/conferences/chicagoland-collegiate-athletic-conference.json
+++ b/public/data/conferences/chicagoland-collegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 18.4,
    "anchorRate": 9.8,
    "breadth": 0.894,
-   "competitiveRatio": 30.9,
+   "competitiveRatio": 30.5,
    "winRate": 43.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 24.2,
    "anchorRate": 24.2,
    "breadth": 0.95,
-   "competitiveRatio": 15.5,
+   "competitiveRatio": 15.2,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 16.3,
    "anchorRate": 4.5,
    "breadth": 0.829,
-   "competitiveRatio": 36.7,
+   "competitiveRatio": 36.2,
    "winRate": 41.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 21.1,
    "anchorRate": 8.3,
    "breadth": 0.866,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 44.6,
    "winRate": 43.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 19.1,
    "anchorRate": 17.2,
    "breadth": 0.915,
-   "competitiveRatio": 30,
+   "competitiveRatio": 30.9,
    "winRate": 37.3
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 28.4,
    "breadth": 0.678,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 34.1,
    "winRate": 69.2
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 10.1,
    "anchorRate": 1,
    "breadth": 0.755,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 41.3,
    "winRate": 52.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 5.6,
    "anchorRate": 0,
    "breadth": 0.698,
-   "competitiveRatio": 22.5,
+   "competitiveRatio": 23,
    "winRate": 33.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 27.6,
    "anchorRate": 0,
    "breadth": 0.637,
-   "competitiveRatio": 18.6,
+   "competitiveRatio": 17.2,
    "winRate": 34.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 19.1,
    "anchorRate": 0,
    "breadth": 0.73,
-   "competitiveRatio": 18,
+   "competitiveRatio": 15.7,
    "winRate": 36
   },
   {

--- a/public/data/conferences/city-university-of-new-york-athletic-conference.json
+++ b/public/data/conferences/city-university-of-new-york-athletic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 339,
     "UP": 749,
-    "EVEN": 231,
-    "DOWN": 526,
+    "EVEN": 203,
+    "DOWN": 554,
     "ANCHOR": 296
    },
    "bandPct": {
     "STRETCH": 15.8,
     "UP": 35,
-    "EVEN": 10.8,
-    "DOWN": 24.6,
+    "EVEN": 9.5,
+    "DOWN": 25.9,
     "ANCHOR": 13.8
    },
    "stretchRate": 15.8,
    "anchorRate": 13.8,
-   "breadth": 0.943,
-   "competitiveRatio": 16,
+   "breadth": 0.936,
+   "competitiveRatio": 15.4,
    "winRate": 44.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 20.2,
    "anchorRate": 20.2,
    "breadth": 0.943,
-   "competitiveRatio": 11.3,
+   "competitiveRatio": 10.7,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 150,
     "UP": 497,
-    "EVEN": 177,
-    "DOWN": 274,
+    "EVEN": 149,
+    "DOWN": 302,
     "ANCHOR": 107
    },
    "bandPct": {
     "STRETCH": 12.4,
     "UP": 41.2,
-    "EVEN": 14.7,
-    "DOWN": 22.7,
+    "EVEN": 12.4,
+    "DOWN": 25.1,
     "ANCHOR": 8.9
    },
    "stretchRate": 12.4,
    "anchorRate": 8.9,
-   "breadth": 0.906,
-   "competitiveRatio": 19.6,
+   "breadth": 0.898,
+   "competitiveRatio": 19.1,
    "winRate": 39.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 4.3,
    "anchorRate": 68.7,
    "breadth": 0.572,
-   "competitiveRatio": 15.5,
+   "competitiveRatio": 15.1,
    "winRate": 75.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 10.5,
    "breadth": 0.719,
-   "competitiveRatio": 13.4,
+   "competitiveRatio": 12.7,
    "winRate": 66.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 9.4,
    "anchorRate": 7.7,
    "breadth": 0.882,
-   "competitiveRatio": 20.9,
+   "competitiveRatio": 20.1,
    "winRate": 53
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 7.6,
    "anchorRate": 0,
    "breadth": 0.742,
-   "competitiveRatio": 21.5,
+   "competitiveRatio": 20.6,
    "winRate": 31.8
   },
   {
@@ -253,21 +253,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 18,
-    "EVEN": 34,
-    "DOWN": 98,
+    "EVEN": 6,
+    "DOWN": 126,
     "ANCHOR": 41
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 9.4,
-    "EVEN": 17.8,
-    "DOWN": 51.3,
+    "EVEN": 3.1,
+    "DOWN": 66,
     "ANCHOR": 21.5
    },
    "stretchRate": 0,
    "anchorRate": 21.5,
-   "breadth": 0.747,
-   "competitiveRatio": 16.8,
+   "breadth": 0.582,
+   "competitiveRatio": 16.2,
    "winRate": 66.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 61.3,
    "anchorRate": 0,
    "breadth": 0.415,
-   "competitiveRatio": 11.4,
+   "competitiveRatio": 10.8,
    "winRate": 7.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 30.1,
    "anchorRate": 0,
    "breadth": 0.696,
-   "competitiveRatio": 11.1,
+   "competitiveRatio": 9.7,
    "winRate": 16.4
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 27.7,
    "anchorRate": 0,
    "breadth": 0.792,
-   "competitiveRatio": 13.5,
+   "competitiveRatio": 12.8,
    "winRate": 29.8
   }
  ]

--- a/public/data/conferences/coast-conference.json
+++ b/public/data/conferences/coast-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 7.8,
    "anchorRate": 10.6,
    "breadth": 0.897,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 24.7,
    "winRate": 48.5
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 6.5,
    "anchorRate": 6.5,
    "breadth": 0.852,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 26.1,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 9.7,
    "anchorRate": 16.8,
    "breadth": 0.94,
-   "competitiveRatio": 23.2,
+   "competitiveRatio": 22.6,
    "winRate": 46.2
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 45.6,
    "breadth": 0.699,
-   "competitiveRatio": 23.4,
+   "competitiveRatio": 22.2,
    "winRate": 64
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 13.9,
    "anchorRate": 0,
    "breadth": 0.577,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 28.3,
    "winRate": 46
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.582,
-   "competitiveRatio": 21.1,
+   "competitiveRatio": 19.5,
    "winRate": 47.1
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.642,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 30.8,
    "winRate": 62
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 43.2,
    "anchorRate": 0,
    "breadth": 0.721,
-   "competitiveRatio": 22.1,
+   "competitiveRatio": 19.8,
    "winRate": 21.6
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0,
-   "competitiveRatio": 33.3,
+   "competitiveRatio": 23.8,
    "winRate": 23.8
   }
  ]

--- a/public/data/conferences/coast-to-coast-conference.json
+++ b/public/data/conferences/coast-to-coast-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 5.6,
    "anchorRate": 9.7,
    "breadth": 0.859,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 40.4,
    "winRate": 57.9
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 7,
    "anchorRate": 7,
    "breadth": 0.884,
-   "competitiveRatio": 49,
+   "competitiveRatio": 47.7,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 5.4,
    "anchorRate": 10.1,
    "breadth": 0.853,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.3,
    "winRate": 59
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 16.2,
    "breadth": 0.76,
-   "competitiveRatio": 58.7,
+   "competitiveRatio": 57.4,
    "winRate": 59.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 17.6,
    "anchorRate": 7.2,
    "breadth": 0.918,
-   "competitiveRatio": 43.5,
+   "competitiveRatio": 41.7,
    "winRate": 45.5
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.6,
    "anchorRate": 9.5,
    "breadth": 0.814,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 47.2,
    "winRate": 60.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 6.8,
    "anchorRate": 5.1,
    "breadth": 0.841,
-   "competitiveRatio": 37.2,
+   "competitiveRatio": 36.9,
    "winRate": 49.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 7.1,
    "anchorRate": 1.8,
    "breadth": 0.792,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 40.9,
    "winRate": 57.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 7.3,
    "anchorRate": 5.5,
    "breadth": 0.864,
-   "competitiveRatio": 33.9,
+   "competitiveRatio": 32.7,
    "winRate": 55
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 8.3,
    "anchorRate": 5.7,
    "breadth": 0.817,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 43.3,
    "winRate": 61.1
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 34.7,
    "breadth": 0.432,
-   "competitiveRatio": 17.5,
+   "competitiveRatio": 16,
    "winRate": 83.6
   }
  ]

--- a/public/data/conferences/coastal-athletic-association.json
+++ b/public/data/conferences/coastal-athletic-association.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.8,
    "anchorRate": 7.2,
    "breadth": 0.853,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 45.1,
    "winRate": 53.3
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 2.2,
    "anchorRate": 2.2,
    "breadth": 0.74,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 47.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 8.5,
    "anchorRate": 9.1,
    "breadth": 0.882,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 44.2,
    "winRate": 54.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 11.8,
    "breadth": 0.634,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 46.2,
    "winRate": 62.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 1.6,
    "breadth": 0.648,
-   "competitiveRatio": 46.4,
+   "competitiveRatio": 45.6,
    "winRate": 68.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 3.3,
    "anchorRate": 21,
    "breadth": 0.689,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 38,
    "winRate": 66.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 6.8,
    "anchorRate": 17.8,
    "breadth": 0.917,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 46.7,
    "winRate": 57.4
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 3.6,
    "anchorRate": 0,
    "breadth": 0.727,
-   "competitiveRatio": 55.7,
+   "competitiveRatio": 54.2,
    "winRate": 46.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 10,
    "anchorRate": 11.2,
    "breadth": 0.915,
-   "competitiveRatio": 54.1,
+   "competitiveRatio": 52.9,
    "winRate": 54.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2.7,
    "anchorRate": 10,
    "breadth": 0.704,
-   "competitiveRatio": 53.2,
+   "competitiveRatio": 50.2,
    "winRate": 71.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 14.6,
    "anchorRate": 9.1,
    "breadth": 0.915,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 40.2,
    "winRate": 47.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 12.9,
    "anchorRate": 7.4,
    "breadth": 0.839,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 47.5,
    "winRate": 50.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 15.4,
    "anchorRate": 1.2,
    "breadth": 0.832,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 48,
    "winRate": 60.2
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 10.5,
    "anchorRate": 7,
    "breadth": 0.833,
-   "competitiveRatio": 36.9,
+   "competitiveRatio": 36,
    "winRate": 65.6
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 3.8,
    "anchorRate": 0,
    "breadth": 0.697,
-   "competitiveRatio": 52.6,
+   "competitiveRatio": 51.6,
    "winRate": 41.7
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 26.1,
    "anchorRate": 0,
    "breadth": 0.583,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36.8,
    "winRate": 29
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 2,
    "anchorRate": 3,
    "breadth": 0.662,
-   "competitiveRatio": 59.9,
+   "competitiveRatio": 58.6,
    "winRate": 58.4
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 20.7,
    "anchorRate": 0,
    "breadth": 0.582,
-   "competitiveRatio": 43.1,
+   "competitiveRatio": 41.1,
    "winRate": 29.7
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.574,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 41.3,
    "winRate": 54
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 1,
    "anchorRate": 2,
    "breadth": 0.623,
-   "competitiveRatio": 46.8,
+   "competitiveRatio": 45.4,
    "winRate": 43
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 2.1,
    "anchorRate": 14,
    "breadth": 0.744,
-   "competitiveRatio": 44,
+   "competitiveRatio": 43.6,
    "winRate": 52.7
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 2.1,
    "anchorRate": 8.4,
    "breadth": 0.708,
-   "competitiveRatio": 43,
+   "competitiveRatio": 43.4,
    "winRate": 58.5
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 3,
    "anchorRate": 16.6,
    "breadth": 0.898,
-   "competitiveRatio": 40.8,
+   "competitiveRatio": 39.6,
    "winRate": 49.7
   }
  ]

--- a/public/data/conferences/college-conference-of-illinois-and-wisconsin.json
+++ b/public/data/conferences/college-conference-of-illinois-and-wisconsin.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 548,
     "UP": 1893,
-    "EVEN": 623,
-    "DOWN": 1886,
-    "ANCHOR": 473
+    "EVEN": 612,
+    "DOWN": 1892,
+    "ANCHOR": 478
    },
    "bandPct": {
     "STRETCH": 10.1,
     "UP": 34.9,
-    "EVEN": 11.5,
-    "DOWN": 34.8,
-    "ANCHOR": 8.7
+    "EVEN": 11.3,
+    "DOWN": 34.9,
+    "ANCHOR": 8.8
    },
    "stretchRate": 10.1,
-   "anchorRate": 8.7,
-   "breadth": 0.887,
-   "competitiveRatio": 35.3,
+   "anchorRate": 8.8,
+   "breadth": 0.886,
+   "competitiveRatio": 34.5,
    "winRate": 52.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 11.9,
    "anchorRate": 11.9,
    "breadth": 0.927,
-   "competitiveRatio": 31.1,
+   "competitiveRatio": 30.3,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 266,
     "UP": 1135,
-    "EVEN": 339,
-    "DOWN": 1128,
-    "ANCHOR": 191
+    "EVEN": 328,
+    "DOWN": 1134,
+    "ANCHOR": 196
    },
    "bandPct": {
     "STRETCH": 8.7,
     "UP": 37.1,
-    "EVEN": 11.1,
-    "DOWN": 36.9,
-    "ANCHOR": 6.2
+    "EVEN": 10.7,
+    "DOWN": 37.1,
+    "ANCHOR": 6.4
    },
    "stretchRate": 8.7,
-   "anchorRate": 6.2,
-   "breadth": 0.848,
-   "competitiveRatio": 38.5,
+   "anchorRate": 6.4,
+   "breadth": 0.847,
+   "competitiveRatio": 37.7,
    "winRate": 54.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 3.4,
    "anchorRate": 19.3,
    "breadth": 0.667,
-   "competitiveRatio": 38.5,
+   "competitiveRatio": 37.1,
    "winRate": 73.5
   },
   {
@@ -145,21 +145,21 @@
    "bands": {
     "STRETCH": 47,
     "UP": 108,
-    "EVEN": 46,
+    "EVEN": 41,
     "DOWN": 180,
-    "ANCHOR": 48
+    "ANCHOR": 53
    },
    "bandPct": {
     "STRETCH": 11,
     "UP": 25.2,
-    "EVEN": 10.7,
+    "EVEN": 9.6,
     "DOWN": 42,
-    "ANCHOR": 11.2
+    "ANCHOR": 12.4
    },
    "stretchRate": 11,
-   "anchorRate": 11.2,
-   "breadth": 0.894,
-   "competitiveRatio": 32.6,
+   "anchorRate": 12.4,
+   "breadth": 0.893,
+   "competitiveRatio": 32.2,
    "winRate": 60.6
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 12,
    "anchorRate": 9,
    "breadth": 0.804,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 45.4,
    "winRate": 66.4
   },
   {
@@ -199,21 +199,21 @@
    "bands": {
     "STRETCH": 12,
     "UP": 172,
-    "EVEN": 24,
-    "DOWN": 153,
+    "EVEN": 18,
+    "DOWN": 159,
     "ANCHOR": 16
    },
    "bandPct": {
     "STRETCH": 3.2,
     "UP": 45.6,
-    "EVEN": 6.4,
-    "DOWN": 40.6,
+    "EVEN": 4.8,
+    "DOWN": 42.2,
     "ANCHOR": 4.2
    },
    "stretchRate": 3.2,
    "anchorRate": 4.2,
-   "breadth": 0.71,
-   "competitiveRatio": 43.6,
+   "breadth": 0.69,
+   "competitiveRatio": 42,
    "winRate": 61.8
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 16.2,
    "breadth": 0.818,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 32.5,
    "winRate": 73
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 12.8,
    "anchorRate": 3.2,
    "breadth": 0.83,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 40,
    "winRate": 49.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 1.7,
    "anchorRate": 0,
    "breadth": 0.537,
-   "competitiveRatio": 35.9,
+   "competitiveRatio": 35.3,
    "winRate": 54.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 10.7,
    "anchorRate": 9.5,
    "breadth": 0.85,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.1,
    "winRate": 52.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 8.3,
    "breadth": 0.717,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 35.6,
    "winRate": 42.7
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 11.4,
    "breadth": 0.789,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 36.2,
    "winRate": 48.8
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 8.5,
    "anchorRate": 6.9,
    "breadth": 0.851,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 29,
    "winRate": 43.3
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 4,
    "anchorRate": 2.4,
    "breadth": 0.746,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 35.7,
    "winRate": 50.8
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 60.4,
    "anchorRate": 0,
    "breadth": 0.557,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25.9,
    "winRate": 20.3
   },
   {

--- a/public/data/conferences/collegiate-conference-of-the-south.json
+++ b/public/data/conferences/collegiate-conference-of-the-south.json
@@ -18,20 +18,20 @@
     "STRETCH": 722,
     "UP": 1537,
     "EVEN": 557,
-    "DOWN": 1221,
-    "ANCHOR": 381
+    "DOWN": 1200,
+    "ANCHOR": 402
    },
    "bandPct": {
     "STRETCH": 16.3,
     "UP": 34.8,
     "EVEN": 12.6,
-    "DOWN": 27.6,
-    "ANCHOR": 8.6
+    "DOWN": 27.2,
+    "ANCHOR": 9.1
    },
    "stretchRate": 16.3,
-   "anchorRate": 8.6,
-   "breadth": 0.927,
-   "competitiveRatio": 27.1,
+   "anchorRate": 9.1,
+   "breadth": 0.93,
+   "competitiveRatio": 26.7,
    "winRate": 44.5
   },
   "inConference": {
@@ -40,20 +40,20 @@
     "STRETCH": 178,
     "UP": 532,
     "EVEN": 164,
-    "DOWN": 532,
-    "ANCHOR": 178
+    "DOWN": 511,
+    "ANCHOR": 199
    },
    "bandPct": {
     "STRETCH": 11.2,
     "UP": 33.6,
     "EVEN": 10.4,
-    "DOWN": 33.6,
-    "ANCHOR": 11.2
+    "DOWN": 32.3,
+    "ANCHOR": 12.6
    },
    "stretchRate": 11.2,
-   "anchorRate": 11.2,
-   "breadth": 0.907,
-   "competitiveRatio": 22,
+   "anchorRate": 12.6,
+   "breadth": 0.915,
+   "competitiveRatio": 22.1,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 19.2,
    "anchorRate": 7.2,
    "breadth": 0.926,
-   "competitiveRatio": 29.9,
+   "competitiveRatio": 29.4,
    "winRate": 41.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0.7,
    "anchorRate": 28.8,
    "breadth": 0.877,
-   "competitiveRatio": 23.8,
+   "competitiveRatio": 23.3,
    "winRate": 75.6
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 13.8,
    "anchorRate": 11.1,
    "breadth": 0.885,
-   "competitiveRatio": 37.1,
+   "competitiveRatio": 36.4,
    "winRate": 57.6
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 19.6,
    "anchorRate": 5.9,
    "breadth": 0.881,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 30.2,
    "winRate": 36.9
   },
   {
@@ -200,20 +200,20 @@
     "STRETCH": 24,
     "UP": 66,
     "EVEN": 77,
-    "DOWN": 188,
-    "ANCHOR": 30
+    "DOWN": 167,
+    "ANCHOR": 51
    },
    "bandPct": {
     "STRETCH": 6.2,
     "UP": 17.1,
     "EVEN": 20,
-    "DOWN": 48.8,
-    "ANCHOR": 7.8
+    "DOWN": 43.4,
+    "ANCHOR": 13.2
    },
    "stretchRate": 6.2,
-   "anchorRate": 7.8,
-   "breadth": 0.836,
-   "competitiveRatio": 37.9,
+   "anchorRate": 13.2,
+   "breadth": 0.887,
+   "competitiveRatio": 37.7,
    "winRate": 62.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 14,
    "anchorRate": 0,
    "breadth": 0.757,
-   "competitiveRatio": 20,
+   "competitiveRatio": 19.7,
    "winRate": 38.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 14.2,
    "breadth": 0.779,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.9,
    "winRate": 49.1
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 7.3,
    "anchorRate": 1.9,
    "breadth": 0.749,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 30.5,
    "winRate": 32
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 2,
    "anchorRate": 16.9,
    "breadth": 0.844,
-   "competitiveRatio": 18.2,
+   "competitiveRatio": 17.9,
    "winRate": 41.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 4.2,
    "anchorRate": 16.7,
    "breadth": 0.881,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 34,
    "winRate": 67
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 63.5,
    "anchorRate": 0,
    "breadth": 0.554,
-   "competitiveRatio": 20.2,
+   "competitiveRatio": 20.6,
    "winRate": 21.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 38.9,
    "anchorRate": 0,
    "breadth": 0.793,
-   "competitiveRatio": 10.5,
+   "competitiveRatio": 10.1,
    "winRate": 15.1
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 54.9,
    "anchorRate": 0,
    "breadth": 0.481,
-   "competitiveRatio": 13.4,
+   "competitiveRatio": 13.8,
    "winRate": 9.4
   },
   {

--- a/public/data/conferences/conference-carolinas.json
+++ b/public/data/conferences/conference-carolinas.json
@@ -18,21 +18,21 @@
    "bands": {
     "STRETCH": 874,
     "UP": 3515,
-    "EVEN": 1460,
-    "DOWN": 2641,
+    "EVEN": 1403,
+    "DOWN": 2698,
     "ANCHOR": 877
    },
    "bandPct": {
     "STRETCH": 9.3,
     "UP": 37.5,
-    "EVEN": 15.6,
-    "DOWN": 28.2,
+    "EVEN": 15,
+    "DOWN": 28.8,
     "ANCHOR": 9.4
    },
    "stretchRate": 9.3,
    "anchorRate": 9.4,
-   "breadth": 0.906,
-   "competitiveRatio": 41.2,
+   "breadth": 0.903,
+   "competitiveRatio": 40.3,
    "winRate": 44.8
   },
   "inConference": {
@@ -40,21 +40,21 @@
    "bands": {
     "STRETCH": 336,
     "UP": 1661,
-    "EVEN": 770,
-    "DOWN": 1661,
+    "EVEN": 746,
+    "DOWN": 1685,
     "ANCHOR": 336
    },
    "bandPct": {
     "STRETCH": 7.1,
     "UP": 34.9,
-    "EVEN": 16.2,
-    "DOWN": 34.9,
+    "EVEN": 15.7,
+    "DOWN": 35.4,
     "ANCHOR": 7.1
    },
    "stretchRate": 7.1,
    "anchorRate": 7.1,
-   "breadth": 0.872,
-   "competitiveRatio": 44.4,
+   "breadth": 0.869,
+   "competitiveRatio": 43.3,
    "winRate": 50
   },
   "nonConference": {
@@ -62,21 +62,21 @@
    "bands": {
     "STRETCH": 538,
     "UP": 1854,
-    "EVEN": 690,
-    "DOWN": 980,
+    "EVEN": 657,
+    "DOWN": 1013,
     "ANCHOR": 541
    },
    "bandPct": {
     "STRETCH": 11.7,
     "UP": 40.3,
-    "EVEN": 15,
-    "DOWN": 21.3,
+    "EVEN": 14.3,
+    "DOWN": 22,
     "ANCHOR": 11.8
    },
    "stretchRate": 11.7,
    "anchorRate": 11.8,
-   "breadth": 0.921,
-   "competitiveRatio": 38,
+   "breadth": 0.919,
+   "competitiveRatio": 37.2,
    "winRate": 39.4
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -119,21 +119,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 109,
-    "EVEN": 90,
-    "DOWN": 296,
+    "EVEN": 57,
+    "DOWN": 329,
     "ANCHOR": 211
    },
    "bandPct": {
     "STRETCH": 0.8,
     "UP": 15.3,
-    "EVEN": 12.6,
-    "DOWN": 41.6,
+    "EVEN": 8,
+    "DOWN": 46.2,
     "ANCHOR": 29.6
    },
    "stretchRate": 0.8,
    "anchorRate": 29.6,
-   "breadth": 0.817,
-   "competitiveRatio": 45.7,
+   "breadth": 0.775,
+   "competitiveRatio": 44.3,
    "winRate": 48.7
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 2.2,
    "anchorRate": 15,
    "breadth": 0.812,
-   "competitiveRatio": 39.2,
+   "competitiveRatio": 39,
    "winRate": 56.1
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 2.9,
    "anchorRate": 2.7,
    "breadth": 0.799,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 42.2,
    "winRate": 49.8
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 4.7,
    "anchorRate": 7.8,
    "breadth": 0.854,
-   "competitiveRatio": 49.9,
+   "competitiveRatio": 50.4,
    "winRate": 48.4
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 0,
    "anchorRate": 6.3,
    "breadth": 0.68,
-   "competitiveRatio": 50,
+   "competitiveRatio": 49.5,
    "winRate": 59.1
   },
   {
@@ -268,7 +268,7 @@
    "stretchRate": 49.3,
    "anchorRate": 0,
    "breadth": 0.574,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 41.3,
    "winRate": 47.5
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 0,
    "anchorRate": 14,
    "breadth": 0.809,
-   "competitiveRatio": 46.3,
+   "competitiveRatio": 44.6,
    "winRate": 53.7
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 0,
    "anchorRate": 24.7,
    "breadth": 0.832,
-   "competitiveRatio": 50.1,
+   "competitiveRatio": 48.5,
    "winRate": 54.8
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 1.7,
    "anchorRate": 11.1,
    "breadth": 0.681,
-   "competitiveRatio": 51.1,
+   "competitiveRatio": 50.8,
    "winRate": 37.5
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 6.2,
    "anchorRate": 5,
    "breadth": 0.809,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 34,
    "winRate": 42.3
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 2.5,
    "anchorRate": 21.9,
    "breadth": 0.892,
-   "competitiveRatio": 49.4,
+   "competitiveRatio": 48,
    "winRate": 58.7
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 17,
    "anchorRate": 5.1,
    "breadth": 0.868,
-   "competitiveRatio": 41.1,
+   "competitiveRatio": 40.2,
    "winRate": 36.8
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 0,
    "anchorRate": 3.1,
    "breadth": 0.741,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 43.4,
    "winRate": 53.6
   },
   {
@@ -470,21 +470,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 54,
-    "EVEN": 136,
-    "DOWN": 132,
+    "EVEN": 118,
+    "DOWN": 150,
     "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.9,
-    "EVEN": 40,
-    "DOWN": 38.8,
+    "EVEN": 34.7,
+    "DOWN": 44.1,
     "ANCHOR": 5.3
    },
    "stretchRate": 0,
    "anchorRate": 5.3,
-   "breadth": 0.734,
-   "competitiveRatio": 36.8,
+   "breadth": 0.731,
+   "competitiveRatio": 35.3,
    "winRate": 41.2
   },
   {
@@ -511,7 +511,7 @@
    "stretchRate": 1.8,
    "anchorRate": 15.8,
    "breadth": 0.877,
-   "competitiveRatio": 50.3,
+   "competitiveRatio": 49.7,
    "winRate": 53.3
   },
   {
@@ -538,7 +538,7 @@
    "stretchRate": 10.3,
    "anchorRate": 0,
    "breadth": 0.546,
-   "competitiveRatio": 38.4,
+   "competitiveRatio": 38,
    "winRate": 34.2
   },
   {
@@ -565,7 +565,7 @@
    "stretchRate": 10.8,
    "anchorRate": 5.5,
    "breadth": 0.655,
-   "competitiveRatio": 39.2,
+   "competitiveRatio": 38.6,
    "winRate": 62.8
   },
   {
@@ -592,7 +592,7 @@
    "stretchRate": 19.4,
    "anchorRate": 0,
    "breadth": 0.774,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 43.5,
    "winRate": 48.9
   },
   {
@@ -619,7 +619,7 @@
    "stretchRate": 26.2,
    "anchorRate": 3.7,
    "breadth": 0.715,
-   "competitiveRatio": 21.8,
+   "competitiveRatio": 21.5,
    "winRate": 27.7
   },
   {
@@ -673,7 +673,7 @@
    "stretchRate": 21.1,
    "anchorRate": 11.5,
    "breadth": 0.901,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 32.3,
    "winRate": 27.8
   },
   {
@@ -686,21 +686,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 84,
-    "EVEN": 98,
-    "DOWN": 109,
+    "EVEN": 92,
+    "DOWN": 115,
     "ANCHOR": 9
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 28,
-    "EVEN": 32.7,
-    "DOWN": 36.3,
+    "EVEN": 30.7,
+    "DOWN": 38.3,
     "ANCHOR": 3
    },
    "stretchRate": 0,
    "anchorRate": 3,
-   "breadth": 0.742,
-   "competitiveRatio": 46.3,
+   "breadth": 0.74,
+   "competitiveRatio": 44.3,
    "winRate": 49.7
   },
   {
@@ -727,7 +727,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.606,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 24.7,
    "winRate": 26.8
   },
   {
@@ -754,7 +754,7 @@
    "stretchRate": 17.8,
    "anchorRate": 16.7,
    "breadth": 0.95,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 29.3,
    "winRate": 27
   },
   {
@@ -781,7 +781,7 @@
    "stretchRate": 24.5,
    "anchorRate": 2.4,
    "breadth": 0.859,
-   "competitiveRatio": 36,
+   "competitiveRatio": 35.2,
    "winRate": 28.1
   },
   {

--- a/public/data/conferences/conference-of-new-england.json
+++ b/public/data/conferences/conference-of-new-england.json
@@ -31,7 +31,7 @@
    "stretchRate": 18.8,
    "anchorRate": 12.8,
    "breadth": 0.938,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25.7,
    "winRate": 45
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 20.1,
    "anchorRate": 20.1,
    "breadth": 0.953,
-   "competitiveRatio": 21.5,
+   "competitiveRatio": 20.9,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 17.9,
    "anchorRate": 7.6,
    "breadth": 0.906,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 29.2,
    "winRate": 41.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.5,
    "anchorRate": 32.8,
    "breadth": 0.776,
-   "competitiveRatio": 28.6,
+   "competitiveRatio": 27.5,
    "winRate": 74.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 13.8,
    "anchorRate": 14.7,
    "breadth": 0.92,
-   "competitiveRatio": 22.8,
+   "competitiveRatio": 22.2,
    "winRate": 48.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 14.3,
    "breadth": 0.781,
-   "competitiveRatio": 27.8,
+   "competitiveRatio": 28.1,
    "winRate": 71.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 12.9,
    "anchorRate": 15.4,
    "breadth": 0.928,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 36.6,
    "winRate": 51.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 12.1,
    "anchorRate": 13.1,
    "breadth": 0.854,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25.7,
    "winRate": 58.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 34.2,
    "breadth": 0.487,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 33.9,
    "winRate": 54.2
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 16,
    "breadth": 0.833,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 25,
    "winRate": 52
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 25.8,
    "anchorRate": 0,
    "breadth": 0.698,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 26.8,
    "winRate": 36.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 14.5,
    "anchorRate": 5.9,
    "breadth": 0.863,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 27.3,
    "winRate": 37.7
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 58.3,
    "anchorRate": 0,
    "breadth": 0.422,
-   "competitiveRatio": 16.6,
+   "competitiveRatio": 16.2,
    "winRate": 13.2
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 59.7,
    "anchorRate": 0,
    "breadth": 0.419,
-   "competitiveRatio": 13.3,
+   "competitiveRatio": 12.4,
    "winRate": 9.3
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 50.7,
    "anchorRate": 0,
    "breadth": 0.576,
-   "competitiveRatio": 24.9,
+   "competitiveRatio": 22.4,
    "winRate": 20.9
   },
   {

--- a/public/data/conferences/conference-usa.json
+++ b/public/data/conferences/conference-usa.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 199,
     "UP": 1828,
-    "EVEN": 1156,
-    "DOWN": 1849,
+    "EVEN": 1139,
+    "DOWN": 1866,
     "ANCHOR": 517
    },
    "bandPct": {
     "STRETCH": 3.6,
     "UP": 32.9,
-    "EVEN": 20.8,
-    "DOWN": 33.3,
+    "EVEN": 20.5,
+    "DOWN": 33.6,
     "ANCHOR": 9.3
    },
    "stretchRate": 3.6,
    "anchorRate": 9.3,
-   "breadth": 0.869,
-   "competitiveRatio": 45.2,
+   "breadth": 0.868,
+   "competitiveRatio": 43.8,
    "winRate": 56.2
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 3,
     "UP": 334,
-    "EVEN": 178,
-    "DOWN": 334,
+    "EVEN": 167,
+    "DOWN": 345,
     "ANCHOR": 3
    },
    "bandPct": {
     "STRETCH": 0.4,
     "UP": 39.2,
-    "EVEN": 20.9,
-    "DOWN": 39.2,
+    "EVEN": 19.6,
+    "DOWN": 40.5,
     "ANCHOR": 0.4
    },
    "stretchRate": 0.4,
    "anchorRate": 0.4,
-   "breadth": 0.684,
-   "competitiveRatio": 41.1,
+   "breadth": 0.679,
+   "competitiveRatio": 40,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 196,
     "UP": 1494,
-    "EVEN": 978,
-    "DOWN": 1515,
+    "EVEN": 972,
+    "DOWN": 1521,
     "ANCHOR": 514
    },
    "bandPct": {
     "STRETCH": 4.2,
     "UP": 31.8,
-    "EVEN": 20.8,
-    "DOWN": 32.3,
+    "EVEN": 20.7,
+    "DOWN": 32.4,
     "ANCHOR": 10.9
    },
    "stretchRate": 4.2,
    "anchorRate": 10.9,
    "breadth": 0.889,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.5,
    "winRate": 57.3
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 18,
    "breadth": 0.823,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 49.7,
    "winRate": 65.9
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 8.8,
    "breadth": 0.792,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 43.4,
    "winRate": 68.5
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 4.5,
    "breadth": 0.715,
-   "competitiveRatio": 57.9,
+   "competitiveRatio": 55.9,
    "winRate": 55.4
   },
   {
@@ -198,21 +198,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 141,
-    "EVEN": 71,
-    "DOWN": 105,
+    "EVEN": 65,
+    "DOWN": 111,
     "ANCHOR": 44
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 38.4,
-    "EVEN": 19.3,
-    "DOWN": 28.6,
+    "EVEN": 17.7,
+    "DOWN": 30.2,
     "ANCHOR": 12
    },
    "stretchRate": 1.6,
    "anchorRate": 12,
-   "breadth": 0.848,
-   "competitiveRatio": 40.9,
+   "breadth": 0.843,
+   "competitiveRatio": 39.5,
    "winRate": 56.7
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 6.2,
    "anchorRate": 4.4,
    "breadth": 0.831,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 43.4,
    "winRate": 48.4
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 1.8,
    "anchorRate": 3.5,
    "breadth": 0.781,
-   "competitiveRatio": 44,
+   "competitiveRatio": 41.9,
    "winRate": 56
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 1.8,
    "anchorRate": 27.9,
    "breadth": 0.795,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 47.9,
    "winRate": 65.6
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 4.5,
    "anchorRate": 14.4,
    "breadth": 0.859,
-   "competitiveRatio": 53.2,
+   "competitiveRatio": 50.8,
    "winRate": 63.1
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 10.8,
    "breadth": 0.814,
-   "competitiveRatio": 35.3,
+   "competitiveRatio": 34.1,
    "winRate": 63.2
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 25.8,
    "anchorRate": 7.1,
    "breadth": 0.928,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 40.6,
    "winRate": 38.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 1.3,
    "breadth": 0.664,
-   "competitiveRatio": 55.3,
+   "competitiveRatio": 55.6,
    "winRate": 56.9
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 6,
    "anchorRate": 0.7,
    "breadth": 0.754,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 37.8,
    "winRate": 36.5
   },
   {
@@ -441,21 +441,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 74,
-    "EVEN": 104,
-    "DOWN": 73,
+    "EVEN": 93,
+    "DOWN": 84,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 26.5,
-    "EVEN": 37.3,
-    "DOWN": 26.2,
+    "EVEN": 33.3,
+    "DOWN": 30.1,
     "ANCHOR": 10
    },
    "stretchRate": 0,
    "anchorRate": 10,
-   "breadth": 0.809,
-   "competitiveRatio": 44.2,
+   "breadth": 0.814,
+   "competitiveRatio": 43.5,
    "winRate": 49.5
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 1.5,
    "anchorRate": 0,
    "breadth": 0.69,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 37.2,
    "winRate": 65.1
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 4.5,
    "breadth": 0.731,
-   "competitiveRatio": 47.2,
+   "competitiveRatio": 46.5,
    "winRate": 50.9
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 2.7,
    "anchorRate": 8.1,
    "breadth": 0.858,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 37.7,
    "winRate": 59.2
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 13.1,
    "anchorRate": 18.3,
    "breadth": 0.952,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 30.6,
    "winRate": 44.8
   }
  ]

--- a/public/data/conferences/crossroads-league.json
+++ b/public/data/conferences/crossroads-league.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.8,
    "anchorRate": 16.1,
    "breadth": 0.947,
-   "competitiveRatio": 32.7,
+   "competitiveRatio": 31.8,
    "winRate": 50.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.2,
    "anchorRate": 17.2,
    "breadth": 0.971,
-   "competitiveRatio": 27.9,
+   "competitiveRatio": 26.9,
    "winRate": 49.9
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 7.8,
    "anchorRate": 14.9,
    "breadth": 0.902,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 37.1,
    "winRate": 50.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.5,
    "anchorRate": 13.8,
    "breadth": 0.852,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 46.7,
    "winRate": 54.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0.8,
    "anchorRate": 30.6,
    "breadth": 0.814,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 25.3,
    "winRate": 71.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 2.4,
    "anchorRate": 16.3,
    "breadth": 0.872,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 37.4,
    "winRate": 46.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.6,
    "anchorRate": 14,
    "breadth": 0.805,
-   "competitiveRatio": 38.4,
+   "competitiveRatio": 36.3,
    "winRate": 70.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 12.7,
    "breadth": 0.676,
-   "competitiveRatio": 33.7,
+   "competitiveRatio": 32.3,
    "winRate": 64.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 8.5,
    "anchorRate": 9.7,
    "breadth": 0.695,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 28,
    "winRate": 54.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 1.7,
    "anchorRate": 20.9,
    "breadth": 0.886,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 28.7,
    "winRate": 53.6
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 8.7,
    "anchorRate": 21.6,
    "breadth": 0.876,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.4,
    "winRate": 46.1
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 1.9,
    "anchorRate": 17.9,
    "breadth": 0.783,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.9,
    "winRate": 48.5
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 1.9,
    "anchorRate": 14.6,
    "breadth": 0.872,
-   "competitiveRatio": 30.2,
+   "competitiveRatio": 29.9,
    "winRate": 45.3
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 3.8,
    "anchorRate": 9.4,
    "breadth": 0.85,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 44.2,
    "winRate": 46.9
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 41.2,
    "breadth": 0.539,
-   "competitiveRatio": 38.5,
+   "competitiveRatio": 37.2,
    "winRate": 73.3
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 0,
    "anchorRate": 17.5,
    "breadth": 0.84,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.5,
    "winRate": 58.1
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 25.4,
    "breadth": 0.85,
-   "competitiveRatio": 33.4,
+   "competitiveRatio": 32.1,
    "winRate": 65.2
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 27.6,
    "anchorRate": 19.8,
    "breadth": 0.845,
-   "competitiveRatio": 30,
+   "competitiveRatio": 29.6,
    "winRate": 36.6
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 61.7,
    "anchorRate": 0,
    "breadth": 0.561,
-   "competitiveRatio": 14.5,
+   "competitiveRatio": 13.2,
    "winRate": 15.7
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 71.7,
    "anchorRate": 0,
    "breadth": 0.491,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.3,
    "winRate": 35.9
   }
  ]

--- a/public/data/conferences/east-coast-conference.json
+++ b/public/data/conferences/east-coast-conference.json
@@ -18,20 +18,20 @@
     "STRETCH": 266,
     "UP": 734,
     "EVEN": 184,
-    "DOWN": 842,
-    "ANCHOR": 350
+    "DOWN": 809,
+    "ANCHOR": 383
    },
    "bandPct": {
     "STRETCH": 11.2,
     "UP": 30.9,
     "EVEN": 7.7,
-    "DOWN": 35.4,
-    "ANCHOR": 14.7
+    "DOWN": 34,
+    "ANCHOR": 16.1
    },
    "stretchRate": 11.2,
-   "anchorRate": 14.7,
-   "breadth": 0.905,
-   "competitiveRatio": 35.7,
+   "anchorRate": 16.1,
+   "breadth": 0.912,
+   "competitiveRatio": 35.2,
    "winRate": 56.6
   },
   "inConference": {
@@ -40,20 +40,20 @@
     "STRETCH": 129,
     "UP": 236,
     "EVEN": 34,
-    "DOWN": 236,
-    "ANCHOR": 129
+    "DOWN": 203,
+    "ANCHOR": 162
    },
    "bandPct": {
     "STRETCH": 16.9,
     "UP": 30.9,
     "EVEN": 4.5,
-    "DOWN": 30.9,
-    "ANCHOR": 16.9
+    "DOWN": 26.6,
+    "ANCHOR": 21.2
    },
    "stretchRate": 16.9,
-   "anchorRate": 16.9,
-   "breadth": 0.91,
-   "competitiveRatio": 32.7,
+   "anchorRate": 21.2,
+   "breadth": 0.921,
+   "competitiveRatio": 32.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 8.5,
    "anchorRate": 13.7,
    "breadth": 0.891,
-   "competitiveRatio": 37.1,
+   "competitiveRatio": 36.6,
    "winRate": 59.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 28.7,
    "breadth": 0.617,
-   "competitiveRatio": 46.3,
+   "competitiveRatio": 44.7,
    "winRate": 73.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 38.6,
    "breadth": 0.779,
-   "competitiveRatio": 43,
+   "competitiveRatio": 43.5,
    "winRate": 66.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 47,
    "anchorRate": 0,
    "breadth": 0.631,
-   "competitiveRatio": 19.7,
+   "competitiveRatio": 19,
    "winRate": 32
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 12.1,
    "anchorRate": 0,
    "breadth": 0.753,
-   "competitiveRatio": 29.5,
+   "competitiveRatio": 28.2,
    "winRate": 61.4
   },
   {
@@ -227,20 +227,20 @@
     "STRETCH": 0,
     "UP": 55,
     "EVEN": 4,
-    "DOWN": 172,
-    "ANCHOR": 53
+    "DOWN": 139,
+    "ANCHOR": 86
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19.4,
     "EVEN": 1.4,
-    "DOWN": 60.6,
-    "ANCHOR": 18.7
+    "DOWN": 48.9,
+    "ANCHOR": 30.3
    },
    "stretchRate": 0,
-   "anchorRate": 18.7,
-   "breadth": 0.618,
-   "competitiveRatio": 33.1,
+   "anchorRate": 30.3,
+   "breadth": 0.677,
+   "competitiveRatio": 32.7,
    "winRate": 69.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 9.8,
    "breadth": 0.691,
-   "competitiveRatio": 40,
+   "competitiveRatio": 39.6,
    "winRate": 58.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 28.6,
    "anchorRate": 3.7,
    "breadth": 0.889,
-   "competitiveRatio": 39.9,
+   "competitiveRatio": 41.8,
    "winRate": 45.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 5.8,
    "anchorRate": 5.3,
    "breadth": 0.809,
-   "competitiveRatio": 28,
+   "competitiveRatio": 26.1,
    "winRate": 30
   }
  ]

--- a/public/data/conferences/eastern-metro-athletic-conference.json
+++ b/public/data/conferences/eastern-metro-athletic-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.9,
    "winRate": 33.8
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.9,
    "winRate": 33.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 14.1,
    "anchorRate": 0,
    "breadth": 0.697,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 34.3,
    "winRate": 40.4
   },
   {

--- a/public/data/conferences/empire-8.json
+++ b/public/data/conferences/empire-8.json
@@ -31,7 +31,7 @@
    "stretchRate": 5.2,
    "anchorRate": 1.4,
    "breadth": 0.781,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 26.3,
    "winRate": 43
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 1.5,
    "anchorRate": 1.5,
    "breadth": 0.711,
-   "competitiveRatio": 28.7,
+   "competitiveRatio": 28.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 8.4,
    "anchorRate": 1.4,
    "breadth": 0.814,
-   "competitiveRatio": 25,
+   "competitiveRatio": 24.5,
    "winRate": 37.1
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0.7,
    "anchorRate": 0,
    "breadth": 0.511,
-   "competitiveRatio": 32,
+   "competitiveRatio": 31.3,
    "winRate": 52.6
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 1.1,
    "anchorRate": 8.6,
    "breadth": 0.652,
-   "competitiveRatio": 20.4,
+   "competitiveRatio": 19.3,
    "winRate": 70.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 2.2,
    "anchorRate": 0,
    "breadth": 0.616,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 25.5,
    "winRate": 47.4
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 3.5,
    "breadth": 0.693,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 29.2,
    "winRate": 41.2
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 8.6,
    "anchorRate": 0,
    "breadth": 0.695,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.4,
    "winRate": 39.9
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.637,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 22.8,
    "winRate": 43.6
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.594,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 25.7,
    "winRate": 37.8
   }
  ]

--- a/public/data/conferences/florida-ccaa.json
+++ b/public/data/conferences/florida-ccaa.json
@@ -30,7 +30,7 @@
    "stretchRate": 19.2,
    "anchorRate": 16.2,
    "breadth": 0.952,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.3,
    "winRate": 56
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 11.1,
    "anchorRate": 7.4,
    "breadth": 0.875,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42.1,
    "winRate": 57.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 32.2,
    "breadth": 0.721,
-   "competitiveRatio": 41.7,
+   "competitiveRatio": 41.1,
    "winRate": 75
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 47.8,
    "anchorRate": 1.4,
    "breadth": 0.725,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 35.5,
    "winRate": 36.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 13.5,
    "anchorRate": 6.7,
    "breadth": 0.925,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 41.6,
    "winRate": 48.3
   }
  ]

--- a/public/data/conferences/golden-state-athletic-conference.json
+++ b/public/data/conferences/golden-state-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 22.3,
    "anchorRate": 5,
    "breadth": 0.891,
-   "competitiveRatio": 29.2,
+   "competitiveRatio": 28.3,
    "winRate": 36.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.647,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 33.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 26.5,
    "anchorRate": 5.9,
    "breadth": 0.893,
-   "competitiveRatio": 28.2,
+   "competitiveRatio": 27.3,
    "winRate": 33.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 33.2,
    "anchorRate": 11.2,
    "breadth": 0.951,
-   "competitiveRatio": 36.2,
+   "competitiveRatio": 34.6,
    "winRate": 37.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 7.4,
    "anchorRate": 4.7,
    "breadth": 0.743,
-   "competitiveRatio": 39.7,
+   "competitiveRatio": 38.1,
    "winRate": 53.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 53.3,
    "anchorRate": 0,
    "breadth": 0.571,
-   "competitiveRatio": 12.1,
+   "competitiveRatio": 11.7,
    "winRate": 11.7
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 20.5,
    "anchorRate": 8.8,
    "breadth": 0.774,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 28.5,
    "winRate": 26.4
   },
   {

--- a/public/data/conferences/great-american-conference.json
+++ b/public/data/conferences/great-american-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 108,
     "UP": 1240,
-    "EVEN": 511,
-    "DOWN": 1109,
+    "EVEN": 476,
+    "DOWN": 1144,
     "ANCHOR": 197
    },
    "bandPct": {
     "STRETCH": 3.4,
     "UP": 39.2,
-    "EVEN": 16.1,
-    "DOWN": 35,
+    "EVEN": 15,
+    "DOWN": 36.1,
     "ANCHOR": 6.2
    },
    "stretchRate": 3.4,
    "anchorRate": 6.2,
-   "breadth": 0.818,
-   "competitiveRatio": 47.8,
+   "breadth": 0.813,
+   "competitiveRatio": 46.8,
    "winRate": 54.7
   },
   "inConference": {
@@ -39,21 +39,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 310,
-    "EVEN": 208,
-    "DOWN": 310,
+    "EVEN": 173,
+    "DOWN": 345,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 37.4,
-    "EVEN": 25.1,
-    "DOWN": 37.4,
+    "EVEN": 20.9,
+    "DOWN": 41.7,
     "ANCHOR": 0
    },
    "stretchRate": 0,
    "anchorRate": 0,
-   "breadth": 0.673,
-   "competitiveRatio": 53.5,
+   "breadth": 0.658,
+   "competitiveRatio": 51.7,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 4.6,
    "anchorRate": 8.4,
    "breadth": 0.838,
-   "competitiveRatio": 45.8,
+   "competitiveRatio": 45,
    "winRate": 56.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 15.2,
    "breadth": 0.665,
-   "competitiveRatio": 56.1,
+   "competitiveRatio": 53.3,
    "winRate": 62.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 10.8,
    "anchorRate": 1.6,
    "breadth": 0.761,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 44.2,
    "winRate": 58.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 8.2,
    "anchorRate": 3,
    "breadth": 0.771,
-   "competitiveRatio": 42.8,
+   "competitiveRatio": 40.1,
    "winRate": 47.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0.8,
    "anchorRate": 5.1,
    "breadth": 0.791,
-   "competitiveRatio": 56.2,
+   "competitiveRatio": 55.6,
    "winRate": 59.6
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2.6,
    "anchorRate": 4.9,
    "breadth": 0.697,
-   "competitiveRatio": 41.1,
+   "competitiveRatio": 39.9,
    "winRate": 40.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 1.7,
    "anchorRate": 3.8,
    "breadth": 0.709,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48.1,
    "winRate": 63.6
   },
   {
@@ -307,20 +307,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 71,
-    "EVEN": 24,
-    "DOWN": 197,
+    "EVEN": 6,
+    "DOWN": 215,
     "ANCHOR": 29
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 22.1,
-    "EVEN": 7.5,
-    "DOWN": 61.4,
+    "EVEN": 1.9,
+    "DOWN": 67,
     "ANCHOR": 9
    },
    "stretchRate": 0,
    "anchorRate": 9,
-   "breadth": 0.649,
+   "breadth": 0.555,
    "competitiveRatio": 44.1,
    "winRate": 58.9
   },
@@ -334,21 +334,21 @@
    "bands": {
     "STRETCH": 16,
     "UP": 117,
-    "EVEN": 35,
-    "DOWN": 87,
+    "EVEN": 18,
+    "DOWN": 104,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 5.7,
     "UP": 41.3,
-    "EVEN": 12.4,
-    "DOWN": 30.7,
+    "EVEN": 6.4,
+    "DOWN": 36.7,
     "ANCHOR": 9.9
    },
    "stretchRate": 5.7,
    "anchorRate": 9.9,
-   "breadth": 0.856,
-   "competitiveRatio": 38.4,
+   "breadth": 0.807,
+   "competitiveRatio": 37.7,
    "winRate": 42
   }
  ]

--- a/public/data/conferences/great-lakes-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/great-lakes-intercollegiate-athletic-conference.json
@@ -18,21 +18,21 @@
    "bands": {
     "STRETCH": 271,
     "UP": 1677,
-    "EVEN": 671,
-    "DOWN": 1818,
+    "EVEN": 665,
+    "DOWN": 1824,
     "ANCHOR": 444
    },
    "bandPct": {
     "STRETCH": 5.6,
     "UP": 34.4,
-    "EVEN": 13.7,
-    "DOWN": 37.2,
+    "EVEN": 13.6,
+    "DOWN": 37.4,
     "ANCHOR": 9.1
    },
    "stretchRate": 5.6,
    "anchorRate": 9.1,
    "breadth": 0.861,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 43.8,
    "winRate": 51.1
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 8.4,
    "anchorRate": 8.4,
    "breadth": 0.903,
-   "competitiveRatio": 46.8,
+   "competitiveRatio": 46.1,
    "winRate": 50
   },
   "nonConference": {
@@ -62,21 +62,21 @@
    "bands": {
     "STRETCH": 120,
     "UP": 1087,
-    "EVEN": 357,
-    "DOWN": 1228,
+    "EVEN": 351,
+    "DOWN": 1234,
     "ANCHOR": 293
    },
    "bandPct": {
     "STRETCH": 3.9,
     "UP": 35.2,
-    "EVEN": 11.6,
-    "DOWN": 39.8,
+    "EVEN": 11.4,
+    "DOWN": 40,
     "ANCHOR": 9.5
    },
    "stretchRate": 3.9,
    "anchorRate": 9.5,
-   "breadth": 0.829,
-   "competitiveRatio": 43.7,
+   "breadth": 0.827,
+   "competitiveRatio": 42.4,
    "winRate": 51.7
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 0,
    "anchorRate": 13.7,
    "breadth": 0.821,
-   "competitiveRatio": 54.7,
+   "competitiveRatio": 53.3,
    "winRate": 60.1
   },
   {
@@ -146,21 +146,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 152,
-    "EVEN": 48,
-    "DOWN": 179,
+    "EVEN": 42,
+    "DOWN": 185,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 39.5,
-    "EVEN": 12.5,
-    "DOWN": 46.5,
+    "EVEN": 10.9,
+    "DOWN": 48.1,
     "ANCHOR": 1.6
    },
    "stretchRate": 0,
    "anchorRate": 1.6,
-   "breadth": 0.651,
-   "competitiveRatio": 38.4,
+   "breadth": 0.637,
+   "competitiveRatio": 36.6,
    "winRate": 45.2
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 0,
    "anchorRate": 13.4,
    "breadth": 0.787,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 50.4,
    "winRate": 62.1
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 0,
    "anchorRate": 22.2,
    "breadth": 0.575,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 46.9,
    "winRate": 65.6
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 0,
    "anchorRate": 8.6,
    "breadth": 0.746,
-   "competitiveRatio": 50.7,
+   "competitiveRatio": 49.6,
    "winRate": 65.7
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 0,
    "anchorRate": 12.4,
    "breadth": 0.69,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 44.2,
    "winRate": 65.3
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 1.2,
    "anchorRate": 7.3,
    "breadth": 0.797,
-   "competitiveRatio": 41.4,
+   "competitiveRatio": 42,
    "winRate": 52.9
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 3.6,
    "anchorRate": 10.6,
    "breadth": 0.877,
-   "competitiveRatio": 50.9,
+   "competitiveRatio": 49.1,
    "winRate": 47
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 0.9,
    "anchorRate": 7,
    "breadth": 0.79,
-   "competitiveRatio": 50.8,
+   "competitiveRatio": 49.5,
    "winRate": 54.1
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 21.1,
    "anchorRate": 17.1,
    "breadth": 0.97,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 33.3,
    "winRate": 39.9
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 10,
    "anchorRate": 4.1,
    "breadth": 0.794,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 30.7,
    "winRate": 39
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 13.3,
    "anchorRate": 2.3,
    "breadth": 0.811,
-   "competitiveRatio": 40.8,
+   "competitiveRatio": 41.2,
    "winRate": 42.2
   },
   {
@@ -511,7 +511,7 @@
    "stretchRate": 31.8,
    "anchorRate": 2.4,
    "breadth": 0.693,
-   "competitiveRatio": 45.5,
+   "competitiveRatio": 44.3,
    "winRate": 27.5
   }
  ]

--- a/public/data/conferences/great-lakes-valley-conference.json
+++ b/public/data/conferences/great-lakes-valley-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.8,
    "anchorRate": 8.3,
    "breadth": 0.905,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 43,
    "winRate": 49.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 9.3,
    "anchorRate": 9.3,
    "breadth": 0.889,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 44,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 12.1,
    "anchorRate": 7.4,
    "breadth": 0.913,
-   "competitiveRatio": 43,
+   "competitiveRatio": 42.1,
    "winRate": 49.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 7.3,
    "breadth": 0.738,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 51,
    "winRate": 52.5
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 14.8,
    "breadth": 0.745,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 44.9,
    "winRate": 71.5
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 6,
    "anchorRate": 5.1,
    "breadth": 0.828,
-   "competitiveRatio": 44,
+   "competitiveRatio": 43,
    "winRate": 41
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 28.8,
    "breadth": 0.844,
-   "competitiveRatio": 43.7,
+   "competitiveRatio": 42.7,
    "winRate": 54.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 21.6,
    "breadth": 0.808,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 38.1,
    "winRate": 67.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 1.6,
    "anchorRate": 8.2,
    "breadth": 0.759,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 33.9,
    "winRate": 63
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 5.5,
    "breadth": 0.766,
-   "competitiveRatio": 54.2,
+   "competitiveRatio": 53.5,
    "winRate": 40.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 5.2,
    "breadth": 0.599,
-   "competitiveRatio": 43.1,
+   "competitiveRatio": 43.5,
    "winRate": 57.5
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 11.4,
    "anchorRate": 2,
    "breadth": 0.844,
-   "competitiveRatio": 30,
+   "competitiveRatio": 28.7,
    "winRate": 41
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 16.4,
    "anchorRate": 7,
    "breadth": 0.821,
-   "competitiveRatio": 39.4,
+   "competitiveRatio": 38.4,
    "winRate": 41.1
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 16.2,
    "breadth": 0.75,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 52.9,
    "winRate": 55.9
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 20.1,
    "anchorRate": 0,
    "breadth": 0.713,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 41.8,
    "winRate": 51
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 5.2,
    "anchorRate": 6.3,
    "breadth": 0.699,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 45.8,
    "winRate": 44.1
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 27.5,
    "anchorRate": 0,
    "breadth": 0.672,
-   "competitiveRatio": 42.3,
+   "competitiveRatio": 41.4,
    "winRate": 33.3
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 0,
    "anchorRate": 7.7,
    "breadth": 0.676,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 42.1,
    "winRate": 58.6
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 11.1,
    "anchorRate": 2.4,
    "breadth": 0.718,
-   "competitiveRatio": 46,
+   "competitiveRatio": 44.4,
    "winRate": 43.3
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 100,
    "anchorRate": 0,
    "breadth": 0,
-   "competitiveRatio": 32.7,
+   "competitiveRatio": 33.5,
    "winRate": 28.3
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 4.8,
    "anchorRate": 4.8,
    "breadth": 0.848,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48.6,
    "winRate": 46.2
   }
  ]

--- a/public/data/conferences/great-midwest-athletic-conference.json
+++ b/public/data/conferences/great-midwest-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.4,
    "anchorRate": 10.5,
    "breadth": 0.897,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 36.6,
    "winRate": 49.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 16,
    "anchorRate": 16,
    "breadth": 0.94,
-   "competitiveRatio": 29,
+   "competitiveRatio": 29.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 6,
    "anchorRate": 6.2,
    "breadth": 0.831,
-   "competitiveRatio": 42.4,
+   "competitiveRatio": 42.2,
    "winRate": 49
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 17.2,
    "breadth": 0.703,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 47.7,
    "winRate": 62
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 8,
    "breadth": 0.752,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 39.1,
    "winRate": 66.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 13.6,
    "anchorRate": 4.1,
    "breadth": 0.851,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 42.5,
    "winRate": 44.9
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 9,
    "breadth": 0.759,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 41.4,
    "winRate": 50.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 27.7,
    "breadth": 0.717,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 41.8,
    "winRate": 73.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 3.3,
    "anchorRate": 4.7,
    "breadth": 0.667,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 50.7,
    "winRate": 46.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 11.9,
    "breadth": 0.716,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 45.8,
    "winRate": 55.4
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 6.8,
    "anchorRate": 8.8,
    "breadth": 0.908,
-   "competitiveRatio": 40.2,
+   "competitiveRatio": 41.6,
    "winRate": 48.7
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 11.9,
    "anchorRate": 5.3,
    "breadth": 0.882,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 30.2,
    "winRate": 42.9
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 9.6,
    "breadth": 0.733,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48.1,
    "winRate": 52.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 14.6,
    "anchorRate": 11.7,
    "breadth": 0.892,
-   "competitiveRatio": 33.7,
+   "competitiveRatio": 34.3,
    "winRate": 47.1
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 26.1,
    "breadth": 0.723,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 40.8,
    "winRate": 63.2
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 41.8,
    "anchorRate": 2.3,
    "breadth": 0.779,
-   "competitiveRatio": 20.7,
+   "competitiveRatio": 19.5,
    "winRate": 18.8
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 32.2,
    "anchorRate": 8.8,
    "breadth": 0.876,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 34.5,
    "winRate": 29.7
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 49,
    "anchorRate": 0,
    "breadth": 0.748,
-   "competitiveRatio": 9.4,
+   "competitiveRatio": 8.3,
    "winRate": 17.2
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 76.5,
    "anchorRate": 0,
    "breadth": 0.422,
-   "competitiveRatio": 6.6,
+   "competitiveRatio": 6,
    "winRate": 7.7
   }
  ]

--- a/public/data/conferences/great-northeast-athletic-conference.json
+++ b/public/data/conferences/great-northeast-athletic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 183,
     "UP": 616,
-    "EVEN": 285,
-    "DOWN": 593,
+    "EVEN": 276,
+    "DOWN": 602,
     "ANCHOR": 112
    },
    "bandPct": {
     "STRETCH": 10.2,
     "UP": 34.4,
-    "EVEN": 15.9,
-    "DOWN": 33.1,
+    "EVEN": 15.4,
+    "DOWN": 33.7,
     "ANCHOR": 6.3
    },
    "stretchRate": 10.2,
    "anchorRate": 6.3,
-   "breadth": 0.89,
-   "competitiveRatio": 30.2,
+   "breadth": 0.888,
+   "competitiveRatio": 29.4,
    "winRate": 51.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 8.4,
    "anchorRate": 8.4,
    "breadth": 0.907,
-   "competitiveRatio": 24.3,
+   "competitiveRatio": 23.4,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 165,
     "UP": 547,
-    "EVEN": 245,
-    "DOWN": 524,
+    "EVEN": 236,
+    "DOWN": 533,
     "ANCHOR": 94
    },
    "bandPct": {
     "STRETCH": 10.5,
     "UP": 34.7,
-    "EVEN": 15.6,
-    "DOWN": 33.3,
+    "EVEN": 15,
+    "DOWN": 33.8,
     "ANCHOR": 6
    },
    "stretchRate": 10.5,
    "anchorRate": 6,
-   "breadth": 0.887,
-   "competitiveRatio": 31,
+   "breadth": 0.884,
+   "competitiveRatio": 30.2,
    "winRate": 51.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 7.3,
    "anchorRate": 9,
    "breadth": 0.826,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 33.9,
    "winRate": 50.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 1.7,
    "anchorRate": 14.1,
    "breadth": 0.764,
-   "competitiveRatio": 28.3,
+   "competitiveRatio": 27.3,
    "winRate": 59.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.1,
    "anchorRate": 2.9,
    "breadth": 0.761,
-   "competitiveRatio": 28.3,
+   "competitiveRatio": 27.2,
    "winRate": 49.1
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 51.1,
    "anchorRate": 0,
    "breadth": 0.626,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 37.7,
    "winRate": 50.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.649,
-   "competitiveRatio": 21.6,
+   "competitiveRatio": 21.2,
    "winRate": 42.3
   },
   {
@@ -280,21 +280,21 @@
    "bands": {
     "STRETCH": 9,
     "UP": 18,
-    "EVEN": 20,
-    "DOWN": 51,
+    "EVEN": 11,
+    "DOWN": 60,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 8.7,
     "UP": 17.3,
-    "EVEN": 19.2,
-    "DOWN": 49,
+    "EVEN": 10.6,
+    "DOWN": 57.7,
     "ANCHOR": 5.8
    },
    "stretchRate": 8.7,
    "anchorRate": 5.8,
-   "breadth": 0.837,
-   "competitiveRatio": 26,
+   "breadth": 0.767,
+   "competitiveRatio": 25,
    "winRate": 38.5
   }
  ]

--- a/public/data/conferences/great-plains-athletic-conference.json
+++ b/public/data/conferences/great-plains-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 16.7,
    "anchorRate": 15,
    "breadth": 0.938,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 30.6,
    "winRate": 51.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 21,
    "anchorRate": 21,
    "breadth": 0.935,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 13.5,
    "anchorRate": 10.4,
    "breadth": 0.916,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 31.5,
    "winRate": 52.1
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0.7,
    "anchorRate": 39.7,
    "breadth": 0.764,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 38.6,
    "winRate": 79
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 41.6,
    "breadth": 0.584,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.5,
    "winRate": 77.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 13.3,
    "anchorRate": 12,
    "breadth": 0.857,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 31,
    "winRate": 40.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 12,
    "breadth": 0.777,
-   "competitiveRatio": 24.6,
+   "competitiveRatio": 24.4,
    "winRate": 53.2
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 37,
    "breadth": 0.687,
-   "competitiveRatio": 37.6,
+   "competitiveRatio": 35.4,
    "winRate": 58.1
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 15.1,
    "anchorRate": 0,
    "breadth": 0.745,
-   "competitiveRatio": 26.9,
+   "competitiveRatio": 27.2,
    "winRate": 48.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2,
    "anchorRate": 10.9,
    "breadth": 0.663,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 26.8,
    "winRate": 63.9
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 17.4,
    "anchorRate": 12.8,
    "breadth": 0.956,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 36.2,
    "winRate": 40.4
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 64.6,
    "anchorRate": 0,
    "breadth": 0.585,
-   "competitiveRatio": 19.8,
+   "competitiveRatio": 19.4,
    "winRate": 15.7
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 73.4,
    "anchorRate": 0,
    "breadth": 0.474,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 33.3,
    "winRate": 47.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 34.2,
    "anchorRate": 0,
    "breadth": 0.81,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 43.9,
    "winRate": 38.4
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 53.7,
    "anchorRate": 0,
    "breadth": 0.633,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 23.2,
    "winRate": 27.4
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 0,
    "anchorRate": 7.9,
    "breadth": 0.778,
-   "competitiveRatio": 36,
+   "competitiveRatio": 35.3,
    "winRate": 41.7
   }
  ]

--- a/public/data/conferences/gulf-south-conference.json
+++ b/public/data/conferences/gulf-south-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 5,
    "anchorRate": 11.1,
    "breadth": 0.869,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 44,
    "winRate": 52.5
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 8.2,
    "anchorRate": 8.2,
    "breadth": 0.851,
-   "competitiveRatio": 47,
+   "competitiveRatio": 46.7,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 2.7,
    "anchorRate": 13.1,
    "breadth": 0.865,
-   "competitiveRatio": 43,
+   "competitiveRatio": 42.1,
    "winRate": 54.4
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 28,
    "breadth": 0.73,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 40.8,
    "winRate": 72.9
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 23.4,
    "breadth": 0.686,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 51,
    "winRate": 64.8
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 11.9,
    "breadth": 0.722,
-   "competitiveRatio": 49.6,
+   "competitiveRatio": 47.6,
    "winRate": 59.3
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 21.8,
    "breadth": 0.727,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 49.7,
    "winRate": 44.7
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 6.9,
    "breadth": 0.745,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 40.3,
    "winRate": 71.9
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 1.8,
    "breadth": 0.653,
-   "competitiveRatio": 45.7,
+   "competitiveRatio": 45.1,
    "winRate": 53.4
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 10,
    "anchorRate": 10.9,
    "breadth": 0.849,
-   "competitiveRatio": 37.6,
+   "competitiveRatio": 38.5,
    "winRate": 36.1
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 6.1,
    "breadth": 0.726,
-   "competitiveRatio": 46.2,
+   "competitiveRatio": 44.9,
    "winRate": 49
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 7.4,
    "breadth": 0.725,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 37.2,
    "winRate": 53.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 18.2,
    "breadth": 0.798,
-   "competitiveRatio": 51.5,
+   "competitiveRatio": 50.5,
    "winRate": 74.4
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 32.4,
    "anchorRate": 10.1,
    "breadth": 0.928,
-   "competitiveRatio": 40.8,
+   "competitiveRatio": 41.1,
    "winRate": 40.4
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 1.1,
    "anchorRate": 6.4,
    "breadth": 0.655,
-   "competitiveRatio": 33.5,
+   "competitiveRatio": 34.5,
    "winRate": 36.7
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 21.5,
    "anchorRate": 0,
    "breadth": 0.755,
-   "competitiveRatio": 48,
+   "competitiveRatio": 45.8,
    "winRate": 46.6
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 29.6,
    "anchorRate": 5.2,
    "breadth": 0.795,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 32.2,
    "winRate": 33.3
   }
  ]

--- a/public/data/conferences/heart-of-america-athletic-conference.json
+++ b/public/data/conferences/heart-of-america-athletic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 315,
     "UP": 978,
-    "EVEN": 526,
-    "DOWN": 918,
+    "EVEN": 499,
+    "DOWN": 945,
     "ANCHOR": 440
    },
    "bandPct": {
     "STRETCH": 9.9,
     "UP": 30.8,
-    "EVEN": 16.6,
-    "DOWN": 28.9,
+    "EVEN": 15.7,
+    "DOWN": 29.7,
     "ANCHOR": 13.8
    },
    "stretchRate": 9.9,
    "anchorRate": 13.8,
-   "breadth": 0.946,
-   "competitiveRatio": 36.6,
+   "breadth": 0.943,
+   "competitiveRatio": 36,
    "winRate": 48
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 12.4,
    "anchorRate": 12.4,
    "breadth": 0.945,
-   "competitiveRatio": 34,
+   "competitiveRatio": 33.9,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 231,
     "UP": 772,
-    "EVEN": 428,
-    "DOWN": 712,
+    "EVEN": 401,
+    "DOWN": 739,
     "ANCHOR": 356
    },
    "bandPct": {
     "STRETCH": 9.2,
     "UP": 30.9,
-    "EVEN": 17.1,
-    "DOWN": 28.5,
+    "EVEN": 16,
+    "DOWN": 29.6,
     "ANCHOR": 14.2
    },
    "stretchRate": 9.2,
    "anchorRate": 14.2,
-   "breadth": 0.945,
-   "competitiveRatio": 37.3,
+   "breadth": 0.941,
+   "competitiveRatio": 36.6,
    "winRate": 47.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -118,21 +118,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 72,
-    "EVEN": 88,
-    "DOWN": 138,
+    "EVEN": 84,
+    "DOWN": 142,
     "ANCHOR": 96
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 18,
-    "EVEN": 22,
-    "DOWN": 34.5,
+    "EVEN": 21,
+    "DOWN": 35.5,
     "ANCHOR": 24
    },
    "stretchRate": 1.5,
    "anchorRate": 24,
-   "breadth": 0.879,
-   "competitiveRatio": 45.5,
+   "breadth": 0.876,
+   "competitiveRatio": 44.5,
    "winRate": 63
   },
   {
@@ -145,21 +145,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 96,
-    "EVEN": 29,
-    "DOWN": 133,
+    "EVEN": 6,
+    "DOWN": 156,
     "ANCHOR": 125
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 24.7,
-    "EVEN": 7.5,
-    "DOWN": 34.2,
+    "EVEN": 1.5,
+    "DOWN": 40.1,
     "ANCHOR": 32.1
    },
    "stretchRate": 1.5,
    "anchorRate": 32.1,
-   "breadth": 0.829,
-   "competitiveRatio": 46.8,
+   "breadth": 0.749,
+   "competitiveRatio": 46.3,
    "winRate": 63.8
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 13,
    "anchorRate": 4.5,
    "breadth": 0.87,
-   "competitiveRatio": 30.2,
+   "competitiveRatio": 28.4,
    "winRate": 45.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 7.1,
    "anchorRate": 4.7,
    "breadth": 0.837,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 38.6,
    "winRate": 47.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 13.4,
    "anchorRate": 12.7,
    "breadth": 0.933,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 33.5,
    "winRate": 36.3
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 9.5,
    "anchorRate": 26.9,
    "breadth": 0.961,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 37.1,
    "winRate": 54.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 21.4,
    "anchorRate": 7,
    "breadth": 0.931,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 34.1,
    "winRate": 35.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 29.7,
    "anchorRate": 12.2,
    "breadth": 0.951,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 44.3,
    "winRate": 47.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 3.2,
    "anchorRate": 15.1,
    "breadth": 0.832,
-   "competitiveRatio": 30,
+   "competitiveRatio": 30.9,
    "winRate": 58.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 7.5,
    "anchorRate": 0,
    "breadth": 0.682,
-   "competitiveRatio": 21.4,
+   "competitiveRatio": 20.9,
    "winRate": 24.4
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 5.4,
    "anchorRate": 2,
    "breadth": 0.75,
-   "competitiveRatio": 27.9,
+   "competitiveRatio": 27.2,
    "winRate": 40.8
   },
   {

--- a/public/data/conferences/heartland-collegiate-athletic-conference.json
+++ b/public/data/conferences/heartland-collegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.4,
    "anchorRate": 9.6,
    "breadth": 0.935,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 29.5,
    "winRate": 42.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 11.4,
    "anchorRate": 11.4,
    "breadth": 0.956,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 29.7,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 13.1,
    "anchorRate": 8.4,
    "breadth": 0.908,
-   "competitiveRatio": 29.6,
+   "competitiveRatio": 29.4,
    "winRate": 37.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 4.8,
    "anchorRate": 4.6,
    "breadth": 0.654,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 32.3,
    "winRate": 38.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 3.3,
    "anchorRate": 16.4,
    "breadth": 0.801,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40,
    "winRate": 62.2
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 3.7,
    "breadth": 0.531,
-   "competitiveRatio": 26.6,
+   "competitiveRatio": 27.1,
    "winRate": 34
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 2.3,
    "breadth": 0.734,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.3,
    "winRate": 50
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 7.4,
    "anchorRate": 9.8,
    "breadth": 0.907,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 31.5,
    "winRate": 44.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 3.2,
    "anchorRate": 20.8,
    "breadth": 0.894,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 34.5,
    "winRate": 44.4
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 3.6,
    "anchorRate": 12.3,
    "breadth": 0.847,
-   "competitiveRatio": 30.2,
+   "competitiveRatio": 31.5,
    "winRate": 56.2
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 11.6,
    "anchorRate": 8.9,
    "breadth": 0.724,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 28.3,
    "winRate": 41.9
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 2.5,
    "anchorRate": 5.8,
    "breadth": 0.835,
-   "competitiveRatio": 30,
+   "competitiveRatio": 29.6,
    "winRate": 45.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 54,
    "anchorRate": 0,
    "breadth": 0.507,
-   "competitiveRatio": 6.7,
+   "competitiveRatio": 9,
    "winRate": 6.3
   },
   {

--- a/public/data/conferences/horizon-league-conference.json
+++ b/public/data/conferences/horizon-league-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 22.4,
    "anchorRate": 5.7,
    "breadth": 0.878,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 40.1,
    "winRate": 33.2
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 22.9,
    "anchorRate": 4.9,
    "breadth": 0.868,
-   "competitiveRatio": 42,
+   "competitiveRatio": 40.9,
    "winRate": 31.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 9.2,
    "anchorRate": 14.3,
    "breadth": 0.852,
-   "competitiveRatio": 56.5,
+   "competitiveRatio": 55.2,
    "winRate": 35
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 6,
    "anchorRate": 0,
    "breadth": 0.779,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 43.4,
    "winRate": 39.1
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 23.4,
    "anchorRate": 0,
    "breadth": 0.587,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 31.4,
    "winRate": 29.5
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 73.9,
    "anchorRate": 3.9,
    "breadth": 0.425,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 28.9,
    "winRate": 20.8
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 5.7,
    "anchorRate": 10.2,
    "breadth": 0.776,
-   "competitiveRatio": 36.7,
+   "competitiveRatio": 36.3,
    "winRate": 41.5
   }
  ]

--- a/public/data/conferences/horizon-league.json
+++ b/public/data/conferences/horizon-league.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 628,
     "UP": 1324,
-    "EVEN": 562,
-    "DOWN": 933,
+    "EVEN": 556,
+    "DOWN": 939,
     "ANCHOR": 276
    },
    "bandPct": {
     "STRETCH": 16.9,
     "UP": 35.6,
-    "EVEN": 15.1,
-    "DOWN": 25.1,
+    "EVEN": 14.9,
+    "DOWN": 25.2,
     "ANCHOR": 7.4
    },
    "stretchRate": 16.9,
    "anchorRate": 7.4,
-   "breadth": 0.928,
-   "competitiveRatio": 48.9,
+   "breadth": 0.927,
+   "competitiveRatio": 47.6,
    "winRate": 45.4
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 13.8,
    "anchorRate": 13.8,
    "breadth": 0.963,
-   "competitiveRatio": 51,
+   "competitiveRatio": 50.4,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 499,
     "UP": 1057,
-    "EVEN": 418,
-    "DOWN": 666,
+    "EVEN": 412,
+    "DOWN": 672,
     "ANCHOR": 147
    },
    "bandPct": {
     "STRETCH": 17.9,
     "UP": 37.9,
-    "EVEN": 15,
-    "DOWN": 23.9,
+    "EVEN": 14.8,
+    "DOWN": 24.1,
     "ANCHOR": 5.3
    },
    "stretchRate": 17.9,
    "anchorRate": 5.3,
-   "breadth": 0.906,
-   "competitiveRatio": 48.2,
+   "breadth": 0.905,
+   "competitiveRatio": 46.6,
    "winRate": 43.9
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 5.3,
    "anchorRate": 18.7,
    "breadth": 0.814,
-   "competitiveRatio": 57.2,
+   "competitiveRatio": 55.9,
    "winRate": 60.6
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 5.8,
    "anchorRate": 0,
    "breadth": 0.73,
-   "competitiveRatio": 51.8,
+   "competitiveRatio": 50.5,
    "winRate": 50.8
   },
   {
@@ -171,21 +171,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 145,
-    "EVEN": 91,
-    "DOWN": 132,
+    "EVEN": 85,
+    "DOWN": 138,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 38.8,
-    "EVEN": 24.3,
-    "DOWN": 35.3,
+    "EVEN": 22.7,
+    "DOWN": 36.9,
     "ANCHOR": 0
    },
    "stretchRate": 1.6,
    "anchorRate": 0,
-   "breadth": 0.712,
-   "competitiveRatio": 48.5,
+   "breadth": 0.707,
+   "competitiveRatio": 47.3,
    "winRate": 50.5
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 32.3,
    "anchorRate": 1.6,
    "breadth": 0.81,
-   "competitiveRatio": 49.5,
+   "competitiveRatio": 46.2,
    "winRate": 32.3
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 3.3,
    "anchorRate": 19.1,
    "breadth": 0.857,
-   "competitiveRatio": 55.1,
+   "competitiveRatio": 53.2,
    "winRate": 58.5
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 10.1,
    "anchorRate": 9.8,
    "breadth": 0.917,
-   "competitiveRatio": 53.6,
+   "competitiveRatio": 52.5,
    "winRate": 46.1
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 2.9,
    "anchorRate": 1.6,
    "breadth": 0.773,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 48.5,
    "winRate": 40.3
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 74.3,
    "anchorRate": 0,
    "breadth": 0.5,
-   "competitiveRatio": 45.8,
+   "competitiveRatio": 45.4,
    "winRate": 40.1
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 17.2,
    "anchorRate": 0,
    "breadth": 0.616,
-   "competitiveRatio": 36.7,
+   "competitiveRatio": 37.1,
    "winRate": 34.1
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 15.3,
    "anchorRate": 14.6,
    "breadth": 0.962,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 41.4,
    "winRate": 36.9
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 37.2,
    "anchorRate": 13.8,
    "breadth": 0.852,
-   "competitiveRatio": 35.8,
+   "competitiveRatio": 35,
    "winRate": 36.4
   }
  ]

--- a/public/data/conferences/illinois-skyway-colleg-conf.json
+++ b/public/data/conferences/illinois-skyway-colleg-conf.json
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {

--- a/public/data/conferences/independent.json
+++ b/public/data/conferences/independent.json
@@ -33,7 +33,7 @@
    "stretchRate": 18.5,
    "anchorRate": 6.6,
    "breadth": 0.903,
-   "competitiveRatio": 25.5,
+   "competitiveRatio": 25,
    "winRate": 40.4
   },
   "inConference": {
@@ -77,7 +77,7 @@
    "stretchRate": 18.9,
    "anchorRate": 6.7,
    "breadth": 0.905,
-   "competitiveRatio": 25.6,
+   "competitiveRatio": 25.1,
    "winRate": 40.2
   }
  },
@@ -86,21 +86,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -134,7 +134,7 @@
    "stretchRate": 8.1,
    "anchorRate": 0,
    "breadth": 0.755,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 37.5,
    "winRate": 49.5
   },
   {
@@ -161,7 +161,7 @@
    "stretchRate": 2.2,
    "anchorRate": 15.9,
    "breadth": 0.882,
-   "competitiveRatio": 30.3,
+   "competitiveRatio": 29.9,
    "winRate": 70.3
   },
   {
@@ -188,7 +188,7 @@
    "stretchRate": 15.6,
    "anchorRate": 0,
    "breadth": 0.714,
-   "competitiveRatio": 25.9,
+   "competitiveRatio": 26.3,
    "winRate": 22.2
   },
   {
@@ -215,7 +215,7 @@
    "stretchRate": 50.2,
    "anchorRate": 0,
    "breadth": 0.653,
-   "competitiveRatio": 40.8,
+   "competitiveRatio": 39.7,
    "winRate": 27.7
   },
   {
@@ -242,7 +242,7 @@
    "stretchRate": 0,
    "anchorRate": 48.4,
    "breadth": 0.639,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 23.3,
    "winRate": 88.4
   },
   {
@@ -269,7 +269,7 @@
    "stretchRate": 54.5,
    "anchorRate": 0,
    "breadth": 0.616,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 18.7,
    "winRate": 24.7
   },
   {
@@ -296,7 +296,7 @@
    "stretchRate": 1.4,
    "anchorRate": 18,
    "breadth": 0.868,
-   "competitiveRatio": 19,
+   "competitiveRatio": 18.1,
    "winRate": 76.8
   },
   {
@@ -323,7 +323,7 @@
    "stretchRate": 6,
    "anchorRate": 0,
    "breadth": 0.202,
-   "competitiveRatio": 22.7,
+   "competitiveRatio": 22.2,
    "winRate": 29.6
   },
   {
@@ -431,7 +431,7 @@
    "stretchRate": 3.2,
    "anchorRate": 0,
    "breadth": 0.746,
-   "competitiveRatio": 16.5,
+   "competitiveRatio": 15.2,
    "winRate": 27.2
   },
   {
@@ -458,7 +458,7 @@
    "stretchRate": 42.7,
    "anchorRate": 0,
    "breadth": 0.506,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 25.2,
    "winRate": 28.7
   },
   {
@@ -485,7 +485,7 @@
    "stretchRate": 19.8,
    "anchorRate": 0,
    "breadth": 0.798,
-   "competitiveRatio": 42.1,
+   "competitiveRatio": 40.5,
    "winRate": 36.4
   },
   {
@@ -512,7 +512,7 @@
    "stretchRate": 10.7,
    "anchorRate": 0,
    "breadth": 0.778,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 25.9,
    "winRate": 42.9
   },
   {

--- a/public/data/conferences/index.json
+++ b/public/data/conferences/index.json
@@ -1,26 +1,48 @@
 {
  "generatedFor": "courthive-public conference pages",
+ "policy": "absolute",
+ "deltaBands": [
+  {
+   "key": "ANCHOR",
+   "max": -4
+  },
+  {
+   "key": "DOWN",
+   "max": -0.5
+  },
+  {
+   "key": "EVEN",
+   "max": 0.5
+  },
+  {
+   "key": "UP",
+   "max": 4
+  },
+  {
+   "key": "STRETCH"
+  }
+ ],
  "threshold": 4,
  "baseline": {
   "matches": 531414,
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "conferences": [
@@ -33,9 +55,9 @@
    "programCount": 31,
    "matches": 12461,
    "stretchRate": 0.7,
-   "anchorRate": 15.9,
-   "breadth": 0.836,
-   "competitiveRatio": 48.7,
+   "anchorRate": 16.1,
+   "breadth": 0.837,
+   "competitiveRatio": 45.4,
    "nonConferenceShare": 42.4
   },
   {
@@ -48,8 +70,8 @@
    "matches": 12327,
    "stretchRate": 1.9,
    "anchorRate": 15,
-   "breadth": 0.868,
-   "competitiveRatio": 46.8,
+   "breadth": 0.867,
+   "competitiveRatio": 44.1,
    "nonConferenceShare": 47.7
   },
   {
@@ -62,8 +84,8 @@
    "matches": 11038,
    "stretchRate": 1.3,
    "anchorRate": 10.1,
-   "breadth": 0.828,
-   "competitiveRatio": 48.6,
+   "breadth": 0.827,
+   "competitiveRatio": 46.1,
    "nonConferenceShare": 51.4
   },
   {
@@ -77,8 +99,8 @@
    "matches": 9367,
    "stretchRate": 9.3,
    "anchorRate": 9.4,
-   "breadth": 0.906,
-   "competitiveRatio": 41.2,
+   "breadth": 0.903,
+   "competitiveRatio": 40.3,
    "nonConferenceShare": 49.1
   },
   {
@@ -92,7 +114,7 @@
    "stretchRate": 2,
    "anchorRate": 12.8,
    "breadth": 0.842,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 44.8,
    "nonConferenceShare": 56.4
   },
   {
@@ -104,9 +126,9 @@
    "programCount": 24,
    "matches": 8033,
    "stretchRate": 3.5,
-   "anchorRate": 7.1,
+   "anchorRate": 7.2,
    "breadth": 0.839,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 47.5,
    "nonConferenceShare": 71.9
   },
   {
@@ -120,7 +142,7 @@
    "stretchRate": 13.5,
    "anchorRate": 9.8,
    "breadth": 0.907,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 30,
    "nonConferenceShare": 34.8
   },
   {
@@ -135,7 +157,7 @@
    "stretchRate": 8.9,
    "anchorRate": 15.8,
    "breadth": 0.922,
-   "competitiveRatio": 35.5,
+   "competitiveRatio": 34.5,
    "nonConferenceShare": 54
   },
   {
@@ -148,8 +170,8 @@
    "matches": 7321,
    "stretchRate": 9.4,
    "anchorRate": 14.1,
-   "breadth": 0.918,
-   "competitiveRatio": 42.9,
+   "breadth": 0.916,
+   "competitiveRatio": 42.4,
    "nonConferenceShare": 41.4
   },
   {
@@ -164,7 +186,7 @@
    "stretchRate": 11.2,
    "anchorRate": 11.5,
    "breadth": 0.923,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 39.3,
    "nonConferenceShare": 33.4
   },
   {
@@ -176,9 +198,9 @@
    "programCount": 23,
    "matches": 7223,
    "stretchRate": 5.8,
-   "anchorRate": 5.4,
-   "breadth": 0.84,
-   "competitiveRatio": 44.3,
+   "anchorRate": 5.5,
+   "breadth": 0.841,
+   "competitiveRatio": 43.4,
    "nonConferenceShare": 72.4
   },
   {
@@ -191,8 +213,8 @@
    "matches": 6856,
    "stretchRate": 5.3,
    "anchorRate": 5.8,
-   "breadth": 0.848,
-   "competitiveRatio": 46.1,
+   "breadth": 0.847,
+   "competitiveRatio": 44.1,
    "nonConferenceShare": 61.5
   },
   {
@@ -207,7 +229,7 @@
    "stretchRate": 11.6,
    "anchorRate": 11.8,
    "breadth": 0.931,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.7,
    "nonConferenceShare": 57.9
   },
   {
@@ -221,7 +243,7 @@
    "stretchRate": 11.2,
    "anchorRate": 10.9,
    "breadth": 0.926,
-   "competitiveRatio": 28.8,
+   "competitiveRatio": 28.4,
    "nonConferenceShare": 44.4
   },
   {
@@ -235,7 +257,7 @@
    "stretchRate": 6.8,
    "anchorRate": 7.2,
    "breadth": 0.853,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 45.1,
    "nonConferenceShare": 72.1
   },
   {
@@ -249,7 +271,7 @@
    "stretchRate": 13.2,
    "anchorRate": 14.2,
    "breadth": 0.949,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36.8,
    "nonConferenceShare": 46.3
   },
   {
@@ -263,7 +285,7 @@
    "stretchRate": 1.6,
    "anchorRate": 4.5,
    "breadth": 0.776,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 46.7,
    "nonConferenceShare": 59.6
   },
   {
@@ -277,7 +299,7 @@
    "stretchRate": 11.1,
    "anchorRate": 8.7,
    "breadth": 0.908,
-   "competitiveRatio": 31.4,
+   "competitiveRatio": 31,
    "nonConferenceShare": 57.6
   },
   {
@@ -290,8 +312,8 @@
    "matches": 6402,
    "stretchRate": 9.6,
    "anchorRate": 12.9,
-   "breadth": 0.918,
-   "competitiveRatio": 35.3,
+   "breadth": 0.917,
+   "competitiveRatio": 34.7,
    "nonConferenceShare": 56.7
   },
   {
@@ -305,7 +327,7 @@
    "stretchRate": 8.3,
    "anchorRate": 4.7,
    "breadth": 0.864,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46.6,
    "nonConferenceShare": 66.4
   },
   {
@@ -319,7 +341,7 @@
    "stretchRate": 13.6,
    "anchorRate": 8,
    "breadth": 0.906,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.8,
    "nonConferenceShare": 52.8
   },
   {
@@ -333,7 +355,7 @@
    "stretchRate": 5.9,
    "anchorRate": 14,
    "breadth": 0.88,
-   "competitiveRatio": 41.4,
+   "competitiveRatio": 40.3,
    "nonConferenceShare": 50.2
   },
   {
@@ -347,7 +369,7 @@
    "stretchRate": 7.7,
    "anchorRate": 6.7,
    "breadth": 0.852,
-   "competitiveRatio": 43,
+   "competitiveRatio": 42.5,
    "nonConferenceShare": 67.2
   },
   {
@@ -361,7 +383,7 @@
    "stretchRate": 10.8,
    "anchorRate": 8.3,
    "breadth": 0.905,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 43,
    "nonConferenceShare": 53.9
   },
   {
@@ -375,7 +397,7 @@
    "stretchRate": 10.4,
    "anchorRate": 10.5,
    "breadth": 0.897,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 36.6,
    "nonConferenceShare": 56.2
   },
   {
@@ -389,7 +411,7 @@
    "stretchRate": 8.2,
    "anchorRate": 4.4,
    "breadth": 0.866,
-   "competitiveRatio": 48.4,
+   "competitiveRatio": 46.8,
    "nonConferenceShare": 61.2
   },
   {
@@ -403,7 +425,7 @@
    "stretchRate": 12.8,
    "anchorRate": 16.1,
    "breadth": 0.947,
-   "competitiveRatio": 32.7,
+   "competitiveRatio": 31.8,
    "nonConferenceShare": 47.2
   },
   {
@@ -417,7 +439,7 @@
    "stretchRate": 6.4,
    "anchorRate": 6.9,
    "breadth": 0.885,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48,
    "nonConferenceShare": 57.3
   },
   {
@@ -430,8 +452,8 @@
    "matches": 5841,
    "stretchRate": 7.7,
    "anchorRate": 12.5,
-   "breadth": 0.913,
-   "competitiveRatio": 43,
+   "breadth": 0.908,
+   "competitiveRatio": 42.3,
    "nonConferenceShare": 58.7
   },
   {
@@ -445,7 +467,7 @@
    "stretchRate": 6.1,
    "anchorRate": 7.4,
    "breadth": 0.841,
-   "competitiveRatio": 28.6,
+   "competitiveRatio": 27.9,
    "nonConferenceShare": 43.9
   },
   {
@@ -458,8 +480,8 @@
    "matches": 5821,
    "stretchRate": 15,
    "anchorRate": 5.7,
-   "breadth": 0.871,
-   "competitiveRatio": 28.5,
+   "breadth": 0.87,
+   "competitiveRatio": 27.9,
    "nonConferenceShare": 70.7
   },
   {
@@ -473,7 +495,7 @@
    "stretchRate": 12.1,
    "anchorRate": 4.4,
    "breadth": 0.865,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.2,
    "nonConferenceShare": 57.9
   },
   {
@@ -487,7 +509,7 @@
    "stretchRate": 5.2,
    "anchorRate": 9.1,
    "breadth": 0.865,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 50.1,
    "nonConferenceShare": 54
   },
   {
@@ -499,9 +521,9 @@
    "programCount": 16,
    "matches": 5708,
    "stretchRate": 0.5,
-   "anchorRate": 13.3,
-   "breadth": 0.822,
-   "competitiveRatio": 49.1,
+   "anchorRate": 13.6,
+   "breadth": 0.823,
+   "competitiveRatio": 47.5,
    "nonConferenceShare": 61.5
   },
   {
@@ -513,9 +535,9 @@
    "programCount": 16,
    "matches": 5600,
    "stretchRate": 4.1,
-   "anchorRate": 24.2,
-   "breadth": 0.892,
-   "competitiveRatio": 39.9,
+   "anchorRate": 24.8,
+   "breadth": 0.893,
+   "competitiveRatio": 38.7,
    "nonConferenceShare": 78
   },
   {
@@ -528,8 +550,8 @@
    "matches": 5549,
    "stretchRate": 3.6,
    "anchorRate": 9.3,
-   "breadth": 0.869,
-   "competitiveRatio": 45.2,
+   "breadth": 0.868,
+   "competitiveRatio": 43.8,
    "nonConferenceShare": 84.6
   },
   {
@@ -543,7 +565,7 @@
    "stretchRate": 11.3,
    "anchorRate": 11.1,
    "breadth": 0.914,
-   "competitiveRatio": 28.7,
+   "competitiveRatio": 28.5,
    "nonConferenceShare": 53.5
   },
   {
@@ -557,7 +579,7 @@
    "stretchRate": 6.3,
    "anchorRate": 5.9,
    "breadth": 0.864,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 46.5,
    "nonConferenceShare": 67.4
   },
   {
@@ -569,9 +591,9 @@
    "programCount": 17,
    "matches": 5423,
    "stretchRate": 10.1,
-   "anchorRate": 8.7,
-   "breadth": 0.887,
-   "competitiveRatio": 35.3,
+   "anchorRate": 8.8,
+   "breadth": 0.886,
+   "competitiveRatio": 34.5,
    "nonConferenceShare": 56.4
   },
   {
@@ -585,7 +607,7 @@
    "stretchRate": 6.8,
    "anchorRate": 10,
    "breadth": 0.898,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36,
    "nonConferenceShare": 53.7
   },
   {
@@ -599,7 +621,7 @@
    "stretchRate": 5,
    "anchorRate": 11.1,
    "breadth": 0.869,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 44,
    "nonConferenceShare": 58.3
   },
   {
@@ -613,7 +635,7 @@
    "stretchRate": 17,
    "anchorRate": 9.1,
    "breadth": 0.917,
-   "competitiveRatio": 31.2,
+   "competitiveRatio": 30.9,
    "nonConferenceShare": 65
   },
   {
@@ -627,7 +649,7 @@
    "stretchRate": 12,
    "anchorRate": 14.5,
    "breadth": 0.938,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41,
    "nonConferenceShare": 60.5
   },
   {
@@ -640,8 +662,8 @@
    "matches": 5236,
    "stretchRate": 15.4,
    "anchorRate": 15.5,
-   "breadth": 0.967,
-   "competitiveRatio": 31.6,
+   "breadth": 0.966,
+   "competitiveRatio": 30.8,
    "nonConferenceShare": 53.1
   },
   {
@@ -655,7 +677,7 @@
    "stretchRate": 12.7,
    "anchorRate": 8.1,
    "breadth": 0.914,
-   "competitiveRatio": 31.8,
+   "competitiveRatio": 31.2,
    "nonConferenceShare": 59.3
   },
   {
@@ -668,8 +690,8 @@
    "matches": 5105,
    "stretchRate": 16.6,
    "anchorRate": 18.7,
-   "breadth": 0.955,
-   "competitiveRatio": 31.6,
+   "breadth": 0.95,
+   "competitiveRatio": 31.2,
    "nonConferenceShare": 63.8
   },
   {
@@ -684,8 +706,22 @@
    "stretchRate": 6.5,
    "anchorRate": 4.8,
    "breadth": 0.852,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 43.5,
    "nonConferenceShare": 66
+  },
+  {
+   "conference": "Mid-American Conference",
+   "slug": "mid-american-conference",
+   "divisions": [
+    "DIV_I"
+   ],
+   "programCount": 13,
+   "matches": 5057,
+   "stretchRate": 3.8,
+   "anchorRate": 4,
+   "breadth": 0.81,
+   "competitiveRatio": 51.4,
+   "nonConferenceShare": 57.5
   },
   {
    "conference": "Midwest Conference",
@@ -697,8 +733,8 @@
    "matches": 4974,
    "stretchRate": 11.8,
    "anchorRate": 12.8,
-   "breadth": 0.927,
-   "competitiveRatio": 29.1,
+   "breadth": 0.925,
+   "competitiveRatio": 28.3,
    "nonConferenceShare": 67.8
   },
   {
@@ -713,7 +749,7 @@
    "stretchRate": 5.6,
    "anchorRate": 9.1,
    "breadth": 0.861,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 43.8,
    "nonConferenceShare": 63.2
   },
   {
@@ -725,9 +761,9 @@
    "programCount": 17,
    "matches": 4827,
    "stretchRate": 8.9,
-   "anchorRate": 7.5,
-   "breadth": 0.875,
-   "competitiveRatio": 23.5,
+   "anchorRate": 7.6,
+   "breadth": 0.876,
+   "competitiveRatio": 23,
    "nonConferenceShare": 46.5
   },
   {
@@ -742,7 +778,7 @@
    "stretchRate": 8.3,
    "anchorRate": 9.5,
    "breadth": 0.91,
-   "competitiveRatio": 44,
+   "competitiveRatio": 42.9,
    "nonConferenceShare": 90.1
   },
   {
@@ -755,8 +791,8 @@
    "matches": 4755,
    "stretchRate": 15.5,
    "anchorRate": 6.6,
-   "breadth": 0.881,
-   "competitiveRatio": 27.3,
+   "breadth": 0.88,
+   "competitiveRatio": 27.1,
    "nonConferenceShare": 53.4
   },
   {
@@ -770,7 +806,7 @@
    "stretchRate": 3.7,
    "anchorRate": 10.4,
    "breadth": 0.844,
-   "competitiveRatio": 46.9,
+   "competitiveRatio": 45.5,
    "nonConferenceShare": 63.7
   },
   {
@@ -784,7 +820,7 @@
    "stretchRate": 12.1,
    "anchorRate": 4.9,
    "breadth": 0.877,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 33.2,
    "nonConferenceShare": 39.7
   },
   {
@@ -798,7 +834,7 @@
    "stretchRate": 12,
    "anchorRate": 12.6,
    "breadth": 0.923,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 35.3,
    "nonConferenceShare": 62.7
   },
   {
@@ -812,7 +848,7 @@
    "stretchRate": 4,
    "anchorRate": 9.4,
    "breadth": 0.839,
-   "competitiveRatio": 46.3,
+   "competitiveRatio": 44.9,
    "nonConferenceShare": 63.6
   },
   {
@@ -826,7 +862,7 @@
    "stretchRate": 9.2,
    "anchorRate": 5.6,
    "breadth": 0.895,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 46.9,
    "nonConferenceShare": 68.4
   },
   {
@@ -840,7 +876,7 @@
    "stretchRate": 12.4,
    "anchorRate": 9.6,
    "breadth": 0.935,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 29.5,
    "nonConferenceShare": 60
   },
   {
@@ -852,9 +888,9 @@
    "programCount": 14,
    "matches": 4418,
    "stretchRate": 16.3,
-   "anchorRate": 8.6,
-   "breadth": 0.927,
-   "competitiveRatio": 27.1,
+   "anchorRate": 9.1,
+   "breadth": 0.93,
+   "competitiveRatio": 26.7,
    "nonConferenceShare": 64.1
   },
   {
@@ -866,9 +902,9 @@
    "programCount": 14,
    "matches": 4364,
    "stretchRate": 15.4,
-   "anchorRate": 11.9,
+   "anchorRate": 12,
    "breadth": 0.927,
-   "competitiveRatio": 36,
+   "competitiveRatio": 34.4,
    "nonConferenceShare": 57.4
   },
   {
@@ -882,7 +918,7 @@
    "stretchRate": 18.8,
    "anchorRate": 12.8,
    "breadth": 0.938,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25.7,
    "nonConferenceShare": 58.2
   },
   {
@@ -896,7 +932,7 @@
    "stretchRate": 19.2,
    "anchorRate": 9.7,
    "breadth": 0.934,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 24.1,
    "nonConferenceShare": 50.3
   },
   {
@@ -909,8 +945,8 @@
    "matches": 4213,
    "stretchRate": 18.4,
    "anchorRate": 9.6,
-   "breadth": 0.937,
-   "competitiveRatio": 34.8,
+   "breadth": 0.936,
+   "competitiveRatio": 34.7,
    "nonConferenceShare": 66.9
   },
   {
@@ -924,7 +960,7 @@
    "stretchRate": 16.7,
    "anchorRate": 15,
    "breadth": 0.938,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 30.6,
    "nonConferenceShare": 56.5
   },
   {
@@ -938,7 +974,7 @@
    "stretchRate": 10.6,
    "anchorRate": 8.2,
    "breadth": 0.911,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 46.6,
    "nonConferenceShare": 77.1
   },
   {
@@ -953,7 +989,7 @@
    "stretchRate": 7.7,
    "anchorRate": 4.3,
    "breadth": 0.85,
-   "competitiveRatio": 39,
+   "competitiveRatio": 38.4,
    "nonConferenceShare": 41.8
   },
   {
@@ -967,7 +1003,7 @@
    "stretchRate": 16.6,
    "anchorRate": 10.5,
    "breadth": 0.963,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 37.4,
    "nonConferenceShare": 62.7
   },
   {
@@ -981,7 +1017,7 @@
    "stretchRate": 21.6,
    "anchorRate": 16.5,
    "breadth": 0.971,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.6,
    "nonConferenceShare": 49.2
   },
   {
@@ -995,7 +1031,7 @@
    "stretchRate": 12.2,
    "anchorRate": 13.1,
    "breadth": 0.928,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 32.8,
    "nonConferenceShare": 76.4
   },
   {
@@ -1009,7 +1045,7 @@
    "stretchRate": 6.3,
    "anchorRate": 11.8,
    "breadth": 0.88,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.8,
    "nonConferenceShare": 62.8
   },
   {
@@ -1023,22 +1059,8 @@
    "stretchRate": 7.6,
    "anchorRate": 11.1,
    "breadth": 0.879,
-   "competitiveRatio": 32.4,
+   "competitiveRatio": 31.6,
    "nonConferenceShare": 71.1
-  },
-  {
-   "conference": "Mid-American Conference",
-   "slug": "mid-american-conference",
-   "divisions": [
-    "DIV_I"
-   ],
-   "programCount": 10,
-   "matches": 3830,
-   "stretchRate": 4,
-   "anchorRate": 3,
-   "breadth": 0.799,
-   "competitiveRatio": 53.2,
-   "nonConferenceShare": 69.3
   },
   {
    "conference": "Horizon League",
@@ -1050,8 +1072,8 @@
    "matches": 3723,
    "stretchRate": 16.9,
    "anchorRate": 7.4,
-   "breadth": 0.928,
-   "competitiveRatio": 48.9,
+   "breadth": 0.927,
+   "competitiveRatio": 47.6,
    "nonConferenceShare": 74.9
   },
   {
@@ -1063,9 +1085,9 @@
    "programCount": 11,
    "matches": 3489,
    "stretchRate": 6.2,
-   "anchorRate": 10.8,
-   "breadth": 0.897,
-   "competitiveRatio": 35.7,
+   "anchorRate": 10.9,
+   "breadth": 0.898,
+   "competitiveRatio": 35.3,
    "nonConferenceShare": 79
   },
   {
@@ -1079,7 +1101,7 @@
    "stretchRate": 5.2,
    "anchorRate": 9.4,
    "breadth": 0.882,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28.7,
    "nonConferenceShare": 34
   },
   {
@@ -1093,7 +1115,7 @@
    "stretchRate": 6.2,
    "anchorRate": 3.8,
    "breadth": 0.796,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.3,
    "nonConferenceShare": 49
   },
   {
@@ -1106,8 +1128,8 @@
    "matches": 3356,
    "stretchRate": 37,
    "anchorRate": 6.9,
-   "breadth": 0.863,
-   "competitiveRatio": 24.4,
+   "breadth": 0.862,
+   "competitiveRatio": 23.8,
    "nonConferenceShare": 66
   },
   {
@@ -1121,7 +1143,7 @@
    "stretchRate": 15.5,
    "anchorRate": 11,
    "breadth": 0.896,
-   "competitiveRatio": 29.4,
+   "competitiveRatio": 28.7,
    "nonConferenceShare": 61.3
   },
   {
@@ -1135,7 +1157,7 @@
    "stretchRate": 10.3,
    "anchorRate": 6.4,
    "breadth": 0.9,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 29.2,
    "nonConferenceShare": 70.7
   },
   {
@@ -1148,7 +1170,7 @@
    "matches": 3207,
    "stretchRate": 12.5,
    "anchorRate": 6.3,
-   "breadth": 0.898,
+   "breadth": 0.892,
    "competitiveRatio": 33.2,
    "nonConferenceShare": 39.8
   },
@@ -1165,7 +1187,7 @@
    "stretchRate": 18.5,
    "anchorRate": 6.6,
    "breadth": 0.903,
-   "competitiveRatio": 25.5,
+   "competitiveRatio": 25,
    "nonConferenceShare": 98
   },
   {
@@ -1178,8 +1200,8 @@
    "matches": 3177,
    "stretchRate": 9.9,
    "anchorRate": 13.8,
-   "breadth": 0.946,
-   "competitiveRatio": 36.6,
+   "breadth": 0.943,
+   "competitiveRatio": 36,
    "nonConferenceShare": 78.7
   },
   {
@@ -1192,8 +1214,8 @@
    "matches": 3165,
    "stretchRate": 3.4,
    "anchorRate": 6.2,
-   "breadth": 0.818,
-   "competitiveRatio": 47.8,
+   "breadth": 0.813,
+   "competitiveRatio": 46.8,
    "nonConferenceShare": 73.8
   },
   {
@@ -1207,7 +1229,7 @@
    "stretchRate": 8.1,
    "anchorRate": 8.5,
    "breadth": 0.82,
-   "competitiveRatio": 24.8,
+   "competitiveRatio": 24.3,
    "nonConferenceShare": 51.4
   },
   {
@@ -1219,9 +1241,9 @@
    "programCount": 9,
    "matches": 3134,
    "stretchRate": 4,
-   "anchorRate": 3.9,
-   "breadth": 0.827,
-   "competitiveRatio": 47,
+   "anchorRate": 4.1,
+   "breadth": 0.83,
+   "competitiveRatio": 45.9,
    "nonConferenceShare": 66.1
   },
   {
@@ -1235,7 +1257,7 @@
    "stretchRate": 7.4,
    "anchorRate": 3.6,
    "breadth": 0.849,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 46.4,
    "nonConferenceShare": 78.5
   },
   {
@@ -1249,7 +1271,7 @@
    "stretchRate": 5.6,
    "anchorRate": 9.7,
    "breadth": 0.859,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 40.4,
    "nonConferenceShare": 87.5
   },
   {
@@ -1262,8 +1284,8 @@
    "matches": 3041,
    "stretchRate": 10.2,
    "anchorRate": 8.4,
-   "breadth": 0.919,
-   "competitiveRatio": 25.6,
+   "breadth": 0.917,
+   "competitiveRatio": 24.5,
    "nonConferenceShare": 48.9
   },
   {
@@ -1277,7 +1299,7 @@
    "stretchRate": 9.6,
    "anchorRate": 14.6,
    "breadth": 0.933,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 28.5,
    "nonConferenceShare": 65.2
   },
   {
@@ -1291,7 +1313,7 @@
    "stretchRate": 21.6,
    "anchorRate": 10.1,
    "breadth": 0.942,
-   "competitiveRatio": 27.8,
+   "competitiveRatio": 27.3,
    "nonConferenceShare": 63
   },
   {
@@ -1305,7 +1327,7 @@
    "stretchRate": 20.2,
    "anchorRate": 12.4,
    "breadth": 0.927,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 24.2,
    "nonConferenceShare": 39.7
   },
   {
@@ -1319,7 +1341,7 @@
    "stretchRate": 5.2,
    "anchorRate": 1.4,
    "breadth": 0.781,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 26.3,
    "nonConferenceShare": 54.3
   },
   {
@@ -1333,7 +1355,7 @@
    "stretchRate": 10.3,
    "anchorRate": 4.1,
    "breadth": 0.873,
-   "competitiveRatio": 25.5,
+   "competitiveRatio": 24.7,
    "nonConferenceShare": 64.8
   },
   {
@@ -1347,7 +1369,7 @@
    "stretchRate": 8.6,
    "anchorRate": 11.5,
    "breadth": 0.904,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 36.5,
    "nonConferenceShare": 51
   },
   {
@@ -1359,9 +1381,9 @@
    "programCount": 8,
    "matches": 2376,
    "stretchRate": 11.2,
-   "anchorRate": 14.7,
-   "breadth": 0.905,
-   "competitiveRatio": 35.7,
+   "anchorRate": 16.1,
+   "breadth": 0.912,
+   "competitiveRatio": 35.2,
    "nonConferenceShare": 67.8
   },
   {
@@ -1375,7 +1397,7 @@
    "stretchRate": 14.2,
    "anchorRate": 8.2,
    "breadth": 0.883,
-   "competitiveRatio": 21.1,
+   "competitiveRatio": 20.7,
    "nonConferenceShare": 41.2
   },
   {
@@ -1388,8 +1410,8 @@
    "matches": 2141,
    "stretchRate": 15.8,
    "anchorRate": 13.8,
-   "breadth": 0.943,
-   "competitiveRatio": 16,
+   "breadth": 0.936,
+   "competitiveRatio": 15.4,
    "nonConferenceShare": 56.3
   },
   {
@@ -1403,7 +1425,7 @@
    "stretchRate": 10.4,
    "anchorRate": 8.9,
    "breadth": 0.911,
-   "competitiveRatio": 40,
+   "competitiveRatio": 38.8,
    "nonConferenceShare": 69.9
   },
   {
@@ -1417,7 +1439,7 @@
    "stretchRate": 21.3,
    "anchorRate": 9.2,
    "breadth": 0.91,
-   "competitiveRatio": 16.5,
+   "competitiveRatio": 16.1,
    "nonConferenceShare": 43.6
   },
   {
@@ -1431,7 +1453,7 @@
    "stretchRate": 1.3,
    "anchorRate": 0.6,
    "breadth": 0.728,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 25.2,
    "nonConferenceShare": 60
   },
   {
@@ -1445,7 +1467,7 @@
    "stretchRate": 6.4,
    "anchorRate": 1.2,
    "breadth": 0.756,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25.1,
    "nonConferenceShare": 69.6
   },
   {
@@ -1459,7 +1481,7 @@
    "stretchRate": 14.7,
    "anchorRate": 30,
    "breadth": 0.935,
-   "competitiveRatio": 21.3,
+   "competitiveRatio": 21.2,
    "nonConferenceShare": 74.7
   },
   {
@@ -1473,7 +1495,7 @@
    "stretchRate": 10.6,
    "anchorRate": 6.8,
    "breadth": 0.897,
-   "competitiveRatio": 19.4,
+   "competitiveRatio": 19.1,
    "nonConferenceShare": 42.3
   },
   {
@@ -1486,8 +1508,8 @@
    "matches": 1789,
    "stretchRate": 10.2,
    "anchorRate": 6.3,
-   "breadth": 0.89,
-   "competitiveRatio": 30.2,
+   "breadth": 0.888,
+   "competitiveRatio": 29.4,
    "nonConferenceShare": 88
   },
   {
@@ -1501,7 +1523,7 @@
    "stretchRate": 18.4,
    "anchorRate": 9.8,
    "breadth": 0.894,
-   "competitiveRatio": 30.9,
+   "competitiveRatio": 30.5,
    "nonConferenceShare": 72.9
   },
   {
@@ -1515,7 +1537,7 @@
    "stretchRate": 14.5,
    "anchorRate": 11.9,
    "breadth": 0.904,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.7,
    "nonConferenceShare": 64.5
   },
   {
@@ -1529,7 +1551,7 @@
    "stretchRate": 22.4,
    "anchorRate": 5.7,
    "breadth": 0.878,
-   "competitiveRatio": 41.2,
+   "competitiveRatio": 40.1,
    "nonConferenceShare": 92
   },
   {
@@ -1543,7 +1565,7 @@
    "stretchRate": 6.7,
    "anchorRate": 18.4,
    "breadth": 0.911,
-   "competitiveRatio": 23.2,
+   "competitiveRatio": 22.4,
    "nonConferenceShare": 72.2
   },
   {
@@ -1557,7 +1579,7 @@
    "stretchRate": 22.3,
    "anchorRate": 5,
    "breadth": 0.891,
-   "competitiveRatio": 29.2,
+   "competitiveRatio": 28.3,
    "nonConferenceShare": 84.4
   },
   {
@@ -1571,7 +1593,7 @@
    "stretchRate": 31.5,
    "anchorRate": 4.4,
    "breadth": 0.867,
-   "competitiveRatio": 21.8,
+   "competitiveRatio": 21.1,
    "nonConferenceShare": 74.6
   },
   {
@@ -1585,22 +1607,8 @@
    "stretchRate": 7.8,
    "anchorRate": 10.6,
    "breadth": 0.897,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 24.7,
    "nonConferenceShare": 39.8
-  },
-  {
-   "conference": "Mid American Conference",
-   "slug": "mid-american-conference",
-   "divisions": [
-    "DIV_I"
-   ],
-   "programCount": 3,
-   "matches": 1227,
-   "stretchRate": 2.9,
-   "anchorRate": 7.2,
-   "breadth": 0.831,
-   "competitiveRatio": 52.7,
-   "nonConferenceShare": 97.1
   },
   {
    "conference": "Region 5",
@@ -1613,7 +1621,7 @@
    "stretchRate": 11.9,
    "anchorRate": 11.2,
    "breadth": 0.928,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 33.9,
    "nonConferenceShare": 94.8
   },
   {
@@ -1627,7 +1635,7 @@
    "stretchRate": 12,
    "anchorRate": 6.4,
    "breadth": 0.82,
-   "competitiveRatio": 17.8,
+   "competitiveRatio": 17.9,
    "nonConferenceShare": 74.2
   },
   {
@@ -1640,8 +1648,8 @@
    "matches": 1077,
    "stretchRate": 8.6,
    "anchorRate": 11,
-   "breadth": 0.861,
-   "competitiveRatio": 41.5,
+   "breadth": 0.858,
+   "competitiveRatio": 40.1,
    "nonConferenceShare": 81.4
   },
   {
@@ -1655,7 +1663,7 @@
    "stretchRate": 11.3,
    "anchorRate": 5,
    "breadth": 0.885,
-   "competitiveRatio": 20.5,
+   "competitiveRatio": 20.3,
    "nonConferenceShare": 91.7
   },
   {
@@ -1669,7 +1677,7 @@
    "stretchRate": 13.9,
    "anchorRate": 0,
    "breadth": 0.782,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 22.8,
    "nonConferenceShare": 84.7
   },
   {
@@ -1683,7 +1691,7 @@
    "stretchRate": 3,
    "anchorRate": 16.7,
    "breadth": 0.887,
-   "competitiveRatio": 22,
+   "competitiveRatio": 21.4,
    "nonConferenceShare": 78.7
   },
   {
@@ -1697,7 +1705,7 @@
    "stretchRate": 35.2,
    "anchorRate": 9.8,
    "breadth": 0.906,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 32.5,
    "nonConferenceShare": 93.1
   },
   {
@@ -1711,7 +1719,7 @@
    "stretchRate": 7.9,
    "anchorRate": 2.8,
    "breadth": 0.846,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 34.5,
    "nonConferenceShare": 100
   },
   {
@@ -1725,7 +1733,7 @@
    "stretchRate": 17.1,
    "anchorRate": 1.4,
    "breadth": 0.711,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.8,
    "nonConferenceShare": 100
   },
   {
@@ -1739,7 +1747,7 @@
    "stretchRate": 19.2,
    "anchorRate": 16.2,
    "breadth": 0.952,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.3,
    "nonConferenceShare": 79.4
   },
   {
@@ -1753,7 +1761,7 @@
    "stretchRate": 34.1,
    "anchorRate": 18.3,
    "breadth": 0.873,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.2,
    "nonConferenceShare": 39
   },
   {
@@ -1767,7 +1775,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.9,
    "nonConferenceShare": 100
   },
   {
@@ -1781,7 +1789,7 @@
    "stretchRate": 44.5,
    "anchorRate": 6.8,
    "breadth": 0.815,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.1,
    "nonConferenceShare": 100
   },
   {
@@ -1795,7 +1803,7 @@
    "stretchRate": 4,
    "anchorRate": 10.6,
    "breadth": 0.865,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 33.9,
    "nonConferenceShare": 100
   },
   {
@@ -1823,7 +1831,7 @@
    "stretchRate": 58.7,
    "anchorRate": 0,
    "breadth": 0.541,
-   "competitiveRatio": 18.5,
+   "competitiveRatio": 17.5,
    "nonConferenceShare": 100
   },
   {
@@ -1851,7 +1859,7 @@
    "stretchRate": 26.4,
    "anchorRate": 0,
    "breadth": 0.479,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 22.7,
    "nonConferenceShare": 100
   },
   {

--- a/public/data/conferences/inland-empire-athletic-conference.json
+++ b/public/data/conferences/inland-empire-athletic-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 13.9,
    "anchorRate": 0,
    "breadth": 0.782,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 22.8,
    "winRate": 40.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 23.8,
+   "competitiveRatio": 22.2,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 16.4,
    "anchorRate": 0,
    "breadth": 0.742,
-   "competitiveRatio": 23.4,
+   "competitiveRatio": 22.9,
    "winRate": 39
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 22.9,
    "anchorRate": 0,
    "breadth": 0.821,
-   "competitiveRatio": 24.6,
+   "competitiveRatio": 23.4,
    "winRate": 36.7
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.539,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 29.6,
    "winRate": 46.4
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 5,
    "anchorRate": 0,
    "breadth": 0.751,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 22.7,
    "winRate": 46.3
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 62,
    "anchorRate": 0,
    "breadth": 0.413,
-   "competitiveRatio": 10.3,
+   "competitiveRatio": 9,
    "winRate": 7.6
   }
  ]

--- a/public/data/conferences/ivy-league.json
+++ b/public/data/conferences/ivy-league.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 31,
     "UP": 1374,
-    "EVEN": 1128,
-    "DOWN": 2417,
-    "ANCHOR": 758
+    "EVEN": 1108,
+    "DOWN": 2419,
+    "ANCHOR": 776
    },
    "bandPct": {
     "STRETCH": 0.5,
     "UP": 24.1,
-    "EVEN": 19.8,
-    "DOWN": 42.3,
-    "ANCHOR": 13.3
+    "EVEN": 19.4,
+    "DOWN": 42.4,
+    "ANCHOR": 13.6
    },
    "stretchRate": 0.5,
-   "anchorRate": 13.3,
-   "breadth": 0.822,
-   "competitiveRatio": 49.1,
+   "anchorRate": 13.6,
+   "breadth": 0.823,
+   "competitiveRatio": 47.5,
    "winRate": 59.8
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 0.9,
    "anchorRate": 0.9,
    "breadth": 0.732,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49.5,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 12,
     "UP": 635,
-    "EVEN": 448,
-    "DOWN": 1678,
-    "ANCHOR": 739
+    "EVEN": 428,
+    "DOWN": 1680,
+    "ANCHOR": 757
    },
    "bandPct": {
     "STRETCH": 0.3,
     "UP": 18.1,
-    "EVEN": 12.8,
+    "EVEN": 12.2,
     "DOWN": 47.8,
-    "ANCHOR": 21
+    "ANCHOR": 21.6
    },
    "stretchRate": 0.3,
-   "anchorRate": 21,
-   "breadth": 0.79,
-   "competitiveRatio": 47.9,
+   "anchorRate": 21.6,
+   "breadth": 0.788,
+   "competitiveRatio": 46.3,
    "winRate": 66
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 24.8,
    "breadth": 0.554,
-   "competitiveRatio": 54.8,
+   "competitiveRatio": 53.7,
    "winRate": 64.7
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 7.1,
    "anchorRate": 18.9,
    "breadth": 0.85,
-   "competitiveRatio": 51.7,
+   "competitiveRatio": 50.3,
    "winRate": 49
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 12.3,
    "breadth": 0.828,
-   "competitiveRatio": 57,
+   "competitiveRatio": 55.1,
    "winRate": 64.3
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 24.8,
    "breadth": 0.79,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 40.4,
    "winRate": 63.2
   },
   {
@@ -225,21 +225,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 135,
-    "EVEN": 45,
-    "DOWN": 100,
+    "EVEN": 40,
+    "DOWN": 105,
     "ANCHOR": 97
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 35.8,
-    "EVEN": 11.9,
-    "DOWN": 26.5,
+    "EVEN": 10.6,
+    "DOWN": 27.9,
     "ANCHOR": 25.7
    },
    "stretchRate": 0,
    "anchorRate": 25.7,
-   "breadth": 0.822,
-   "competitiveRatio": 49.6,
+   "breadth": 0.815,
+   "competitiveRatio": 47.5,
    "winRate": 55.2
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 14.9,
    "breadth": 0.812,
-   "competitiveRatio": 47.2,
+   "competitiveRatio": 44.2,
    "winRate": 72.1
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 5.1,
    "breadth": 0.686,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 43.3,
    "winRate": 55.6
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 10.1,
    "breadth": 0.774,
-   "competitiveRatio": 56.3,
+   "competitiveRatio": 56.1,
    "winRate": 57.5
   },
   {
@@ -333,21 +333,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 64,
-    "EVEN": 89,
-    "DOWN": 165,
+    "EVEN": 80,
+    "DOWN": 174,
     "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 18.2,
-    "EVEN": 25.4,
-    "DOWN": 47,
+    "EVEN": 22.8,
+    "DOWN": 49.6,
     "ANCHOR": 9.4
    },
    "stretchRate": 0,
    "anchorRate": 9.4,
-   "breadth": 0.768,
-   "competitiveRatio": 55,
+   "breadth": 0.756,
+   "competitiveRatio": 53.3,
    "winRate": 65.2
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 12.3,
    "breadth": 0.812,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 39.4,
    "winRate": 60.7
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 3.7,
    "breadth": 0.675,
-   "competitiveRatio": 50.2,
+   "competitiveRatio": 48.6,
    "winRate": 48.6
   },
   {
@@ -414,21 +414,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 12,
-    "EVEN": 97,
-    "DOWN": 175,
+    "EVEN": 91,
+    "DOWN": 181,
     "ANCHOR": 36
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 3.8,
-    "EVEN": 30.3,
-    "DOWN": 54.7,
+    "EVEN": 28.4,
+    "DOWN": 56.6,
     "ANCHOR": 11.3
    },
    "stretchRate": 0,
    "anchorRate": 11.3,
-   "breadth": 0.659,
-   "competitiveRatio": 41.6,
+   "breadth": 0.652,
+   "competitiveRatio": 38.4,
    "winRate": 61.6
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 5.7,
    "breadth": 0.637,
-   "competitiveRatio": 45.7,
+   "competitiveRatio": 44.8,
    "winRate": 64.4
   },
   {
@@ -469,20 +469,20 @@
     "STRETCH": 0,
     "UP": 162,
     "EVEN": 24,
-    "DOWN": 98,
-    "ANCHOR": 30
+    "DOWN": 80,
+    "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 51.6,
     "EVEN": 7.6,
-    "DOWN": 31.2,
-    "ANCHOR": 9.6
+    "DOWN": 25.5,
+    "ANCHOR": 15.3
    },
    "stretchRate": 0,
-   "anchorRate": 9.6,
-   "breadth": 0.699,
-   "competitiveRatio": 45.2,
+   "anchorRate": 15.3,
+   "breadth": 0.729,
+   "competitiveRatio": 44.9,
    "winRate": 52.9
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 1,
    "breadth": 0.611,
-   "competitiveRatio": 52.3,
+   "competitiveRatio": 49.3,
    "winRate": 59.6
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 12.6,
    "breadth": 0.756,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 46.9,
    "winRate": 62.2
   }
  ]

--- a/public/data/conferences/kansas-collegiate-athletic-conference.json
+++ b/public/data/conferences/kansas-collegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 13.5,
    "anchorRate": 9.8,
    "breadth": 0.907,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 30,
    "winRate": 45.8
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 10.9,
    "anchorRate": 10.9,
    "breadth": 0.899,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 29.5,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 18.3,
    "anchorRate": 7.7,
    "breadth": 0.904,
-   "competitiveRatio": 31.6,
+   "competitiveRatio": 30.8,
    "winRate": 38
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 15.9,
    "anchorRate": 18.8,
    "breadth": 0.945,
-   "competitiveRatio": 35,
+   "competitiveRatio": 32.9,
    "winRate": 64.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0.5,
    "anchorRate": 20.8,
    "breadth": 0.731,
-   "competitiveRatio": 27.6,
+   "competitiveRatio": 26.8,
    "winRate": 59.5
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 27.9,
    "breadth": 0.72,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 34.2,
    "winRate": 70.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 5.9,
    "anchorRate": 16,
    "breadth": 0.846,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28.3,
    "winRate": 65.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 17.3,
    "breadth": 0.699,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 27.4,
    "winRate": 63.3
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 17.4,
    "anchorRate": 5.8,
    "breadth": 0.88,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 31.5,
    "winRate": 61.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 3.4,
    "anchorRate": 26.2,
    "breadth": 0.809,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 33.6,
    "winRate": 46.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 10.3,
    "anchorRate": 6.6,
    "breadth": 0.791,
-   "competitiveRatio": 32.5,
+   "competitiveRatio": 32.2,
    "winRate": 43.3
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 6.1,
    "anchorRate": 16.8,
    "breadth": 0.846,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 34.2,
    "winRate": 46.4
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 1.8,
    "anchorRate": 5.3,
    "breadth": 0.768,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 39.3,
    "winRate": 39.6
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 1.8,
    "anchorRate": 0,
    "breadth": 0.701,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 32,
    "winRate": 37.8
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 1.8,
    "anchorRate": 0,
    "breadth": 0.681,
-   "competitiveRatio": 36,
+   "competitiveRatio": 35.1,
    "winRate": 39.9
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 19.9,
    "anchorRate": 6.1,
    "breadth": 0.768,
-   "competitiveRatio": 35.3,
+   "competitiveRatio": 35.6,
    "winRate": 47.4
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 21.1,
    "anchorRate": 5.6,
    "breadth": 0.751,
-   "competitiveRatio": 33,
+   "competitiveRatio": 32.6,
    "winRate": 34.4
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 35.4,
    "anchorRate": 0,
    "breadth": 0.599,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 35,
    "winRate": 27.3
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 2.1,
    "anchorRate": 14.1,
    "breadth": 0.789,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 36.1,
    "winRate": 45.6
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 0,
    "anchorRate": 13.2,
    "breadth": 0.703,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 29.8,
    "winRate": 42.6
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 0.9,
    "anchorRate": 10.9,
    "breadth": 0.781,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.3,
    "winRate": 64.6
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 2.7,
    "anchorRate": 0,
    "breadth": 0.688,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 27,
    "winRate": 27.5
   },
   {
@@ -726,7 +726,7 @@
    "stretchRate": 92.8,
    "anchorRate": 0,
    "breadth": 0.16,
-   "competitiveRatio": 11,
+   "competitiveRatio": 11.5,
    "winRate": 7.7
   },
   {
@@ -753,7 +753,7 @@
    "stretchRate": 21.7,
    "anchorRate": 10,
    "breadth": 0.73,
-   "competitiveRatio": 21.2,
+   "competitiveRatio": 19.6,
    "winRate": 22.8
   },
   {
@@ -807,7 +807,7 @@
    "stretchRate": 34.6,
    "anchorRate": 0,
    "breadth": 0.727,
-   "competitiveRatio": 23.3,
+   "competitiveRatio": 22.6,
    "winRate": 22.6
   }
  ]

--- a/public/data/conferences/kansas-jayhawk-community-college-conference.json
+++ b/public/data/conferences/kansas-jayhawk-community-college-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 4,
    "anchorRate": 10.6,
    "breadth": 0.865,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 33.9,
    "winRate": 42.8
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 4,
    "anchorRate": 10.6,
    "breadth": 0.865,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 33.9,
    "winRate": 42.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 14.6,
    "breadth": 0.779,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41.7,
    "winRate": 50
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 9.9,
    "anchorRate": 4.9,
    "breadth": 0.834,
-   "competitiveRatio": 23.9,
+   "competitiveRatio": 22.5,
    "winRate": 32.4
   }
  ]

--- a/public/data/conferences/landmark-conference.json
+++ b/public/data/conferences/landmark-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.1,
    "anchorRate": 7.4,
    "breadth": 0.841,
-   "competitiveRatio": 28.6,
+   "competitiveRatio": 27.9,
    "winRate": 49
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 5.8,
    "anchorRate": 5.8,
    "breadth": 0.828,
-   "competitiveRatio": 27.8,
+   "competitiveRatio": 27.1,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 6.4,
    "anchorRate": 9.4,
    "breadth": 0.853,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 29.1,
    "winRate": 47.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 8.8,
    "anchorRate": 6.4,
    "breadth": 0.85,
-   "competitiveRatio": 36.7,
+   "competitiveRatio": 33.2,
    "winRate": 59.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 16.9,
    "breadth": 0.726,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 29.2,
    "winRate": 64.5
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 6.4,
    "breadth": 0.64,
-   "competitiveRatio": 30,
+   "competitiveRatio": 29.7,
    "winRate": 51.2
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 10.8,
    "breadth": 0.691,
-   "competitiveRatio": 37.4,
+   "competitiveRatio": 36,
    "winRate": 57.9
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0.9,
    "anchorRate": 32.2,
    "breadth": 0.601,
-   "competitiveRatio": 23.7,
+   "competitiveRatio": 23.4,
    "winRate": 75.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 6.3,
    "anchorRate": 3,
    "breadth": 0.693,
-   "competitiveRatio": 28.3,
+   "competitiveRatio": 27.7,
    "winRate": 52.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 16.6,
    "anchorRate": 5.5,
    "breadth": 0.84,
-   "competitiveRatio": 28,
+   "competitiveRatio": 27.1,
    "winRate": 51.1
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.45,
-   "competitiveRatio": 28.8,
+   "competitiveRatio": 28.1,
    "winRate": 53.3
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 9.2,
    "breadth": 0.68,
-   "competitiveRatio": 32.2,
+   "competitiveRatio": 31.2,
    "winRate": 60.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 4.2,
    "anchorRate": 0,
    "breadth": 0.644,
-   "competitiveRatio": 30,
+   "competitiveRatio": 28.6,
    "winRate": 39.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 37.1,
    "anchorRate": 0,
    "breadth": 0.674,
-   "competitiveRatio": 18.1,
+   "competitiveRatio": 18.4,
    "winRate": 17.7
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 22,
    "anchorRate": 0,
    "breadth": 0.656,
-   "competitiveRatio": 25.2,
+   "competitiveRatio": 24.5,
    "winRate": 28.7
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 6.9,
    "anchorRate": 0,
    "breadth": 0.647,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 24.3,
    "winRate": 29.7
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 7,
    "anchorRate": 4.7,
    "breadth": 0.785,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.8,
    "winRate": 41.1
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 0,
    "anchorRate": 11.2,
    "breadth": 0.768,
-   "competitiveRatio": 30.3,
+   "competitiveRatio": 29.9,
    "winRate": 42.7
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 2.5,
    "anchorRate": 12.1,
    "breadth": 0.816,
-   "competitiveRatio": 36.3,
+   "competitiveRatio": 32.9,
    "winRate": 57.9
   },
   {

--- a/public/data/conferences/liberty-league.json
+++ b/public/data/conferences/liberty-league.json
@@ -18,20 +18,20 @@
     "STRETCH": 367,
     "UP": 1715,
     "EVEN": 900,
-    "DOWN": 1850,
-    "ANCHOR": 537
+    "DOWN": 1848,
+    "ANCHOR": 539
    },
    "bandPct": {
     "STRETCH": 6.8,
     "UP": 31.9,
     "EVEN": 16.8,
-    "DOWN": 34.5,
+    "DOWN": 34.4,
     "ANCHOR": 10
    },
    "stretchRate": 6.8,
    "anchorRate": 10,
    "breadth": 0.898,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36,
    "winRate": 51.3
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 8.7,
    "anchorRate": 8.7,
    "breadth": 0.918,
-   "competitiveRatio": 35.8,
+   "competitiveRatio": 33.8,
    "winRate": 50
   },
   "nonConference": {
@@ -62,20 +62,20 @@
     "STRETCH": 151,
     "UP": 948,
     "EVEN": 382,
-    "DOWN": 1083,
-    "ANCHOR": 321
+    "DOWN": 1081,
+    "ANCHOR": 323
    },
    "bandPct": {
     "STRETCH": 5.2,
     "UP": 32.9,
     "EVEN": 13.2,
     "DOWN": 37.5,
-    "ANCHOR": 11.1
+    "ANCHOR": 11.2
    },
    "stretchRate": 5.2,
-   "anchorRate": 11.1,
+   "anchorRate": 11.2,
    "breadth": 0.87,
-   "competitiveRatio": 38.9,
+   "competitiveRatio": 37.9,
    "winRate": 52.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 6.8,
    "anchorRate": 7.9,
    "breadth": 0.834,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 47.3,
    "winRate": 52.7
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 9.7,
    "breadth": 0.716,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 37.5,
    "winRate": 70.5
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 5.1,
    "anchorRate": 4.9,
    "breadth": 0.845,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 39.4,
    "winRate": 59.1
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 3.5,
    "anchorRate": 8.8,
    "breadth": 0.811,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 48.2,
    "winRate": 44.1
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 9.9,
    "anchorRate": 8.1,
    "breadth": 0.923,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 45.7,
    "winRate": 60
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1.8,
    "anchorRate": 10.2,
    "breadth": 0.714,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 35.2,
    "winRate": 52.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 34.7,
    "breadth": 0.641,
-   "competitiveRatio": 34.3,
+   "competitiveRatio": 31.6,
    "winRate": 69
   },
   {
@@ -308,20 +308,20 @@
     "STRETCH": 0,
     "UP": 100,
     "EVEN": 83,
-    "DOWN": 121,
-    "ANCHOR": 17
+    "DOWN": 119,
+    "ANCHOR": 19
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 31.2,
     "EVEN": 25.9,
-    "DOWN": 37.7,
-    "ANCHOR": 5.3
+    "DOWN": 37.1,
+    "ANCHOR": 5.9
    },
    "stretchRate": 0,
-   "anchorRate": 5.3,
-   "breadth": 0.768,
-   "competitiveRatio": 31.6,
+   "anchorRate": 5.9,
+   "breadth": 0.776,
+   "competitiveRatio": 30.6,
    "winRate": 53
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 1.9,
    "anchorRate": 9,
    "breadth": 0.701,
-   "competitiveRatio": 40.2,
+   "competitiveRatio": 38.3,
    "winRate": 41.7
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 9.2,
    "breadth": 0.662,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 38.9,
    "winRate": 66.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 16.8,
    "breadth": 0.818,
-   "competitiveRatio": 49.4,
+   "competitiveRatio": 48.7,
    "winRate": 46.2
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 5.8,
    "anchorRate": 18.6,
    "breadth": 0.939,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 40.1,
    "winRate": 46.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 3.9,
    "anchorRate": 1.3,
    "breadth": 0.663,
-   "competitiveRatio": 35.5,
+   "competitiveRatio": 33.9,
    "winRate": 42.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 13.6,
    "breadth": 0.731,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 36.2,
    "winRate": 63.2
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 5.4,
    "anchorRate": 3.7,
    "breadth": 0.816,
-   "competitiveRatio": 24.1,
+   "competitiveRatio": 22.7,
    "winRate": 36.5
   },
   {

--- a/public/data/conferences/little-east-conference.json
+++ b/public/data/conferences/little-east-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 8.1,
    "anchorRate": 8.5,
    "breadth": 0.82,
-   "competitiveRatio": 24.8,
+   "competitiveRatio": 24.3,
    "winRate": 49.9
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 7.1,
    "anchorRate": 7.1,
    "breadth": 0.737,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 9,
    "anchorRate": 9.8,
    "breadth": 0.877,
-   "competitiveRatio": 24,
+   "competitiveRatio": 23.3,
    "winRate": 49.9
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -159,7 +159,7 @@
    "stretchRate": 5.7,
    "anchorRate": 0,
    "breadth": 0.54,
-   "competitiveRatio": 29.2,
+   "competitiveRatio": 28.6,
    "winRate": 37.8
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.1,
    "anchorRate": 18.5,
    "breadth": 0.697,
-   "competitiveRatio": 23.3,
+   "competitiveRatio": 22.6,
    "winRate": 71.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 41.6,
    "breadth": 0.456,
-   "competitiveRatio": 12.4,
+   "competitiveRatio": 11.6,
    "winRate": 86.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 10.2,
    "anchorRate": 0,
    "breadth": 0.786,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 27.7,
    "winRate": 48.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 5.2,
    "breadth": 0.451,
-   "competitiveRatio": 29.2,
+   "competitiveRatio": 28.3,
    "winRate": 67.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 5.5,
    "anchorRate": 13.5,
    "breadth": 0.738,
-   "competitiveRatio": 29.6,
+   "competitiveRatio": 27.6,
    "winRate": 61
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 0,
    "anchorRate": 6.6,
    "breadth": 0.713,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.5,
    "winRate": 39.7
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 18.9,
    "anchorRate": 0,
    "breadth": 0.401,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 24.3,
    "winRate": 25
   }
  ]

--- a/public/data/conferences/lone-star-conference.json
+++ b/public/data/conferences/lone-star-conference.json
@@ -32,7 +32,7 @@
    "stretchRate": 11.6,
    "anchorRate": 11.8,
    "breadth": 0.931,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.7,
    "winRate": 50.9
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 15.6,
    "anchorRate": 15.6,
    "breadth": 0.98,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.6,
    "winRate": 50
   },
   "nonConference": {
@@ -76,7 +76,7 @@
    "stretchRate": 8.7,
    "anchorRate": 9.1,
    "breadth": 0.875,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.8,
    "winRate": 51.6
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 0,
    "anchorRate": 16.7,
    "breadth": 0.795,
-   "competitiveRatio": 46,
+   "competitiveRatio": 44.6,
    "winRate": 57.4
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 0,
    "anchorRate": 15.3,
    "breadth": 0.799,
-   "competitiveRatio": 40.9,
+   "competitiveRatio": 40.2,
    "winRate": 71.6
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 0,
    "anchorRate": 22.3,
    "breadth": 0.739,
-   "competitiveRatio": 55.3,
+   "competitiveRatio": 52.2,
    "winRate": 68.6
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 2.1,
    "anchorRate": 6.3,
    "breadth": 0.734,
-   "competitiveRatio": 60.2,
+   "competitiveRatio": 59.7,
    "winRate": 57.9
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 0,
    "anchorRate": 29.5,
    "breadth": 0.713,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49.2,
    "winRate": 67.1
   },
   {
@@ -268,7 +268,7 @@
    "stretchRate": 0,
    "anchorRate": 23.7,
    "breadth": 0.845,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 36.9,
    "winRate": 62.4
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 0,
    "anchorRate": 22.3,
    "breadth": 0.588,
-   "competitiveRatio": 40.4,
+   "competitiveRatio": 39.8,
    "winRate": 71.6
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 1.5,
    "anchorRate": 9.2,
    "breadth": 0.822,
-   "competitiveRatio": 39.9,
+   "competitiveRatio": 39.2,
    "winRate": 64.4
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 0,
    "anchorRate": 3.1,
    "breadth": 0.685,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 45.3,
    "winRate": 49.7
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 21.9,
    "anchorRate": 8.1,
    "breadth": 0.932,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 48,
    "winRate": 55.6
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 0,
    "anchorRate": 4.4,
    "breadth": 0.726,
-   "competitiveRatio": 45,
+   "competitiveRatio": 43.5,
    "winRate": 53.8
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 2.7,
    "anchorRate": 11.9,
    "breadth": 0.782,
-   "competitiveRatio": 53,
+   "competitiveRatio": 51.5,
    "winRate": 51.2
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 33,
    "anchorRate": 6.8,
    "breadth": 0.83,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 35.1,
    "winRate": 38.1
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 31.4,
    "anchorRate": 1.9,
    "breadth": 0.734,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 31.6,
    "winRate": 18.9
   },
   {
@@ -511,7 +511,7 @@
    "stretchRate": 0,
    "anchorRate": 16.5,
    "breadth": 0.71,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 44.3,
    "winRate": 53.8
   },
   {
@@ -538,7 +538,7 @@
    "stretchRate": 40.1,
    "anchorRate": 3.2,
    "breadth": 0.803,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 38.6,
    "winRate": 25.9
   },
   {
@@ -619,7 +619,7 @@
    "stretchRate": 58.4,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 4.6,
+   "competitiveRatio": 3.6,
    "winRate": 2.5
   }
  ]

--- a/public/data/conferences/metro-atlantic-athletic-conference.json
+++ b/public/data/conferences/metro-atlantic-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.1,
    "anchorRate": 4.4,
    "breadth": 0.865,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.2,
    "winRate": 42.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 6.4,
    "anchorRate": 6.4,
    "breadth": 0.845,
-   "competitiveRatio": 47.8,
+   "competitiveRatio": 47.1,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 16.2,
    "anchorRate": 2.9,
    "breadth": 0.852,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42.1,
    "winRate": 37.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.5,
    "anchorRate": 4.6,
    "breadth": 0.692,
-   "competitiveRatio": 51.5,
+   "competitiveRatio": 51.8,
    "winRate": 43.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 20,
    "anchorRate": 7.3,
    "breadth": 0.94,
-   "competitiveRatio": 48.3,
+   "competitiveRatio": 47.3,
    "winRate": 45.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 9.1,
    "anchorRate": 5,
    "breadth": 0.757,
-   "competitiveRatio": 41,
+   "competitiveRatio": 40.4,
    "winRate": 58.2
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 3.4,
    "anchorRate": 3.4,
    "breadth": 0.653,
-   "competitiveRatio": 40.7,
+   "competitiveRatio": 39.5,
    "winRate": 35
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0.9,
    "anchorRate": 5.1,
    "breadth": 0.785,
-   "competitiveRatio": 43.6,
+   "competitiveRatio": 42.1,
    "winRate": 48.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2.6,
    "anchorRate": 10.3,
    "breadth": 0.83,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 42.9,
    "winRate": 44
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 11.9,
    "anchorRate": 4,
    "breadth": 0.892,
-   "competitiveRatio": 48.9,
+   "competitiveRatio": 48,
    "winRate": 46.8
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 7.1,
    "anchorRate": 8.6,
    "breadth": 0.885,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 49.4,
    "winRate": 48.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 4.8,
    "anchorRate": 0,
    "breadth": 0.496,
-   "competitiveRatio": 49.4,
+   "competitiveRatio": 48.1,
    "winRate": 40.4
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 2.9,
    "anchorRate": 6.5,
    "breadth": 0.777,
-   "competitiveRatio": 40.8,
+   "competitiveRatio": 39.8,
    "winRate": 43.7
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 6.8,
    "breadth": 0.768,
-   "competitiveRatio": 35,
+   "competitiveRatio": 34.6,
    "winRate": 51.1
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 14.9,
    "anchorRate": 0,
    "breadth": 0.783,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 49.7,
    "winRate": 41.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 15.3,
    "anchorRate": 0,
    "breadth": 0.529,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 52.3,
    "winRate": 36
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 19.6,
    "anchorRate": 0,
    "breadth": 0.559,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 42.5,
    "winRate": 33.2
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 52.6,
    "anchorRate": 0,
    "breadth": 0.589,
-   "competitiveRatio": 50.2,
+   "competitiveRatio": 47.5,
    "winRate": 41.7
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 50.2,
    "anchorRate": 0,
    "breadth": 0.588,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.8,
    "winRate": 18.3
   }
  ]

--- a/public/data/conferences/michigan-intercollegiate-athletic-association.json
+++ b/public/data/conferences/michigan-intercollegiate-athletic-association.json
@@ -31,7 +31,7 @@
    "stretchRate": 11.3,
    "anchorRate": 11.1,
    "breadth": 0.914,
-   "competitiveRatio": 28.7,
+   "competitiveRatio": 28.5,
    "winRate": 50.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 13.3,
    "anchorRate": 13.3,
    "breadth": 0.92,
-   "competitiveRatio": 22.7,
+   "competitiveRatio": 22.8,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 9.5,
    "anchorRate": 9.2,
    "breadth": 0.901,
-   "competitiveRatio": 34,
+   "competitiveRatio": 33.5,
    "winRate": 50.9
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.6,
    "anchorRate": 11.4,
    "breadth": 0.734,
-   "competitiveRatio": 34,
+   "competitiveRatio": 34.2,
    "winRate": 67.5
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 17,
    "breadth": 0.767,
-   "competitiveRatio": 24.6,
+   "competitiveRatio": 24.1,
    "winRate": 66.6
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 27.4,
    "breadth": 0.824,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 30.7,
    "winRate": 62.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.7,
    "anchorRate": 15,
    "breadth": 0.861,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 40.7,
    "winRate": 52.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 25.6,
    "breadth": 0.697,
-   "competitiveRatio": 25,
+   "competitiveRatio": 24.7,
    "winRate": 60.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 10.3,
    "anchorRate": 20.5,
    "breadth": 0.848,
-   "competitiveRatio": 28.2,
+   "competitiveRatio": 27.9,
    "winRate": 63.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 7.1,
    "anchorRate": 10.6,
    "breadth": 0.857,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 27.9,
    "winRate": 56.5
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 3.6,
    "anchorRate": 15.5,
    "breadth": 0.904,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 33.6,
    "winRate": 59.7
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 1.8,
    "anchorRate": 16.6,
    "breadth": 0.88,
-   "competitiveRatio": 23.3,
+   "competitiveRatio": 23,
    "winRate": 68.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 1.9,
    "anchorRate": 3.2,
    "breadth": 0.699,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 30.8,
    "winRate": 51.9
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 11.9,
    "anchorRate": 0,
    "breadth": 0.712,
-   "competitiveRatio": 31,
+   "competitiveRatio": 32,
    "winRate": 35.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 13.2,
    "anchorRate": 6,
    "breadth": 0.815,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 32.2,
    "winRate": 40.4
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 35.3,
    "anchorRate": 0,
    "breadth": 0.789,
-   "competitiveRatio": 17.1,
+   "competitiveRatio": 18.1,
    "winRate": 25.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 52,
    "anchorRate": 0,
    "breadth": 0.624,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 25.1,
    "winRate": 18.9
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 38.5,
    "anchorRate": 0,
    "breadth": 0.643,
-   "competitiveRatio": 19,
+   "competitiveRatio": 17.9,
    "winRate": 19.6
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 2.5,
    "anchorRate": 2.5,
    "breadth": 0.707,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 26.5,
    "winRate": 45.4
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 36.6,
    "anchorRate": 0,
    "breadth": 0.664,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 30.2,
    "winRate": 26.8
   }
  ]

--- a/public/data/conferences/mid-america-intercollegiate-athletics-association.json
+++ b/public/data/conferences/mid-america-intercollegiate-athletics-association.json
@@ -31,7 +31,7 @@
    "stretchRate": 3.7,
    "anchorRate": 10.4,
    "breadth": 0.844,
-   "competitiveRatio": 46.9,
+   "competitiveRatio": 45.5,
    "winRate": 55.9
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 6,
    "anchorRate": 6,
    "breadth": 0.786,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 47.5,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 2.5,
    "anchorRate": 13,
    "breadth": 0.849,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.4,
    "winRate": 59.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 20,
    "breadth": 0.729,
-   "competitiveRatio": 52.8,
+   "competitiveRatio": 49.9,
    "winRate": 70.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 12.7,
    "breadth": 0.689,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 48,
    "winRate": 65.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 2,
    "anchorRate": 6,
    "breadth": 0.737,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 45.8,
    "winRate": 64
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 16,
    "breadth": 0.542,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 43.3,
    "winRate": 65.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.6,
    "anchorRate": 14.5,
    "breadth": 0.879,
-   "competitiveRatio": 54.4,
+   "competitiveRatio": 52,
    "winRate": 50.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 9.7,
    "breadth": 0.78,
-   "competitiveRatio": 59.2,
+   "competitiveRatio": 56.1,
    "winRate": 55.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0.9,
    "anchorRate": 1.4,
    "breadth": 0.647,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.3,
    "winRate": 45.7
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 14.6,
    "breadth": 0.712,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48.7,
    "winRate": 61.8
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 3,
    "breadth": 0.61,
-   "competitiveRatio": 47,
+   "competitiveRatio": 46,
    "winRate": 48.2
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 21,
    "anchorRate": 1.8,
    "breadth": 0.816,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28.4,
    "winRate": 42.1
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 7,
    "anchorRate": 5.3,
    "breadth": 0.696,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 38.7,
    "winRate": 49.8
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 24.9,
    "anchorRate": 2.2,
    "breadth": 0.785,
-   "competitiveRatio": 45.4,
+   "competitiveRatio": 45.7,
    "winRate": 32.7
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 6.3,
    "breadth": 0.617,
-   "competitiveRatio": 55.8,
+   "competitiveRatio": 54.7,
    "winRate": 45.3
   }
  ]

--- a/public/data/conferences/mid-american-conference.json
+++ b/public/data/conferences/mid-american-conference.json
@@ -1,81 +1,82 @@
 {
- "conference": "Mid American Conference",
+ "conference": "Mid-American Conference",
  "slug": "mid-american-conference",
  "divisions": [
   "DIV_I"
  ],
  "seasons": [
+  "2023",
   "2024",
   "2025",
   "2026"
  ],
- "programCount": 3,
+ "programCount": 13,
  "fingerprint": {
   "overall": {
-   "matches": 1227,
+   "matches": 5057,
    "bands": {
-    "STRETCH": 36,
-    "UP": 306,
-    "EVEN": 276,
-    "DOWN": 521,
-    "ANCHOR": 88
+    "STRETCH": 191,
+    "UP": 1442,
+    "EVEN": 1072,
+    "DOWN": 2149,
+    "ANCHOR": 203
    },
    "bandPct": {
-    "STRETCH": 2.9,
-    "UP": 24.9,
-    "EVEN": 22.5,
+    "STRETCH": 3.8,
+    "UP": 28.5,
+    "EVEN": 21.2,
     "DOWN": 42.5,
-    "ANCHOR": 7.2
+    "ANCHOR": 4
    },
-   "stretchRate": 2.9,
-   "anchorRate": 7.2,
-   "breadth": 0.831,
-   "competitiveRatio": 52.7,
-   "winRate": 54.4
+   "stretchRate": 3.8,
+   "anchorRate": 4,
+   "breadth": 0.81,
+   "competitiveRatio": 51.4,
+   "winRate": 53.3
   },
   "inConference": {
-   "matches": 36,
+   "matches": 2150,
    "bands": {
     "STRETCH": 0,
-    "UP": 18,
-    "EVEN": 0,
-    "DOWN": 18,
+    "UP": 721,
+    "EVEN": 708,
+    "DOWN": 721,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 0,
-    "UP": 50,
-    "EVEN": 0,
-    "DOWN": 50,
+    "UP": 33.5,
+    "EVEN": 32.9,
+    "DOWN": 33.5,
     "ANCHOR": 0
    },
    "stretchRate": 0,
    "anchorRate": 0,
-   "breadth": 0.431,
-   "competitiveRatio": 61.1,
+   "breadth": 0.683,
+   "competitiveRatio": 58.4,
    "winRate": 50
   },
   "nonConference": {
-   "matches": 1191,
+   "matches": 2907,
    "bands": {
-    "STRETCH": 36,
-    "UP": 288,
-    "EVEN": 276,
-    "DOWN": 503,
-    "ANCHOR": 88
+    "STRETCH": 191,
+    "UP": 721,
+    "EVEN": 364,
+    "DOWN": 1428,
+    "ANCHOR": 203
    },
    "bandPct": {
-    "STRETCH": 3,
-    "UP": 24.2,
-    "EVEN": 23.2,
-    "DOWN": 42.2,
-    "ANCHOR": 7.4
+    "STRETCH": 6.6,
+    "UP": 24.8,
+    "EVEN": 12.5,
+    "DOWN": 49.1,
+    "ANCHOR": 7
    },
-   "stretchRate": 3,
-   "anchorRate": 7.4,
-   "breadth": 0.835,
-   "competitiveRatio": 52.4,
-   "winRate": 54.6
+   "stretchRate": 6.6,
+   "anchorRate": 7,
+   "breadth": 0.82,
+   "competitiveRatio": 46.3,
+   "winRate": 55.8
   }
  },
  "baseline": {
@@ -83,30 +84,57 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 0,
-  "nonConference": 3,
-  "delta": 3,
-  "nonConferenceShare": 97.1
+  "nonConference": 6.6,
+  "delta": 6.6,
+  "nonConferenceShare": 57.5
  },
  "members": [
+  {
+   "teamId": "BBD5A1C8-1ADD-41DC-9F5C-9D85AB1EE071",
+   "name": "Buffalo",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 19.86,
+   "matches": 468,
+   "bands": {
+    "STRETCH": 3,
+    "UP": 63,
+    "EVEN": 115,
+    "DOWN": 269,
+    "ANCHOR": 18
+   },
+   "bandPct": {
+    "STRETCH": 0.6,
+    "UP": 13.5,
+    "EVEN": 24.6,
+    "DOWN": 57.5,
+    "ANCHOR": 3.8
+   },
+   "stretchRate": 0.6,
+   "anchorRate": 3.8,
+   "breadth": 0.678,
+   "competitiveRatio": 46,
+   "winRate": 65.4
+  },
   {
    "teamId": "CDAB065A-302D-4A01-A46F-5345609F3DA9",
    "name": "NIU",
@@ -131,8 +159,35 @@
    "stretchRate": 4.1,
    "anchorRate": 2.5,
    "breadth": 0.742,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 49.4,
    "winRate": 59.8
+  },
+  {
+   "teamId": "A9C27CEE-81A3-4A9C-8696-9E4749B77D6F",
+   "name": "Western Michigan",
+   "gender": "M",
+   "division": "DIV_I",
+   "lineupWTN": 13.27,
+   "matches": 428,
+   "bands": {
+    "STRETCH": 30,
+    "UP": 58,
+    "EVEN": 95,
+    "DOWN": 225,
+    "ANCHOR": 20
+   },
+   "bandPct": {
+    "STRETCH": 7,
+    "UP": 13.6,
+    "EVEN": 22.2,
+    "DOWN": 52.6,
+    "ANCHOR": 4.7
+   },
+   "stretchRate": 7,
+   "anchorRate": 4.7,
+   "breadth": 0.791,
+   "competitiveRatio": 52.1,
+   "winRate": 57.7
   },
   {
    "teamId": "F3EE0A57-4F18-4FDD-B4EA-CA9154C36E3E",
@@ -158,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 1.5,
    "breadth": 0.717,
-   "competitiveRatio": 58.2,
+   "competitiveRatio": 56.4,
    "winRate": 49.4
   },
   {
@@ -185,8 +240,224 @@
    "stretchRate": 4.6,
    "anchorRate": 18.1,
    "breadth": 0.892,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49.7,
    "winRate": 53.6
+  },
+  {
+   "teamId": "F130F733-CC1E-447D-942F-79A294911A84",
+   "name": "Western Michigan",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 20.39,
+   "matches": 385,
+   "bands": {
+    "STRETCH": 12,
+    "UP": 143,
+    "EVEN": 53,
+    "DOWN": 171,
+    "ANCHOR": 6
+   },
+   "bandPct": {
+    "STRETCH": 3.1,
+    "UP": 37.1,
+    "EVEN": 13.8,
+    "DOWN": 44.4,
+    "ANCHOR": 1.6
+   },
+   "stretchRate": 3.1,
+   "anchorRate": 1.6,
+   "breadth": 0.73,
+   "competitiveRatio": 48.8,
+   "winRate": 52.7
+  },
+  {
+   "teamId": "FCD69B73-3301-4FB6-8849-9301C12659B4",
+   "name": "Toledo",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 19.81,
+   "matches": 377,
+   "bands": {
+    "STRETCH": 6,
+    "UP": 77,
+    "EVEN": 119,
+    "DOWN": 175,
+    "ANCHOR": 0
+   },
+   "bandPct": {
+    "STRETCH": 1.6,
+    "UP": 20.4,
+    "EVEN": 31.6,
+    "DOWN": 46.4,
+    "ANCHOR": 0
+   },
+   "stretchRate": 1.6,
+   "anchorRate": 0,
+   "breadth": 0.69,
+   "competitiveRatio": 55.2,
+   "winRate": 62.3
+  },
+  {
+   "teamId": "329F8010-4943-4F10-A356-7F8F65459F19",
+   "name": "Buffalo",
+   "gender": "M",
+   "division": "DIV_I",
+   "lineupWTN": 12.78,
+   "matches": 373,
+   "bands": {
+    "STRETCH": 24,
+    "UP": 38,
+    "EVEN": 59,
+    "DOWN": 210,
+    "ANCHOR": 42
+   },
+   "bandPct": {
+    "STRETCH": 6.4,
+    "UP": 10.2,
+    "EVEN": 15.8,
+    "DOWN": 56.3,
+    "ANCHOR": 11.3
+   },
+   "stretchRate": 6.4,
+   "anchorRate": 11.3,
+   "breadth": 0.789,
+   "competitiveRatio": 50.9,
+   "winRate": 53.6
+  },
+  {
+   "teamId": "43F36F5B-2163-450E-878E-9971DA0DBF52",
+   "name": "Toledo",
+   "gender": "M",
+   "division": "DIV_I",
+   "lineupWTN": 13.89,
+   "matches": 369,
+   "bands": {
+    "STRETCH": 44,
+    "UP": 96,
+    "EVEN": 63,
+    "DOWN": 154,
+    "ANCHOR": 12
+   },
+   "bandPct": {
+    "STRETCH": 11.9,
+    "UP": 26,
+    "EVEN": 17.1,
+    "DOWN": 41.7,
+    "ANCHOR": 3.3
+   },
+   "stretchRate": 11.9,
+   "anchorRate": 3.3,
+   "breadth": 0.859,
+   "competitiveRatio": 56.1,
+   "winRate": 48.2
+  },
+  {
+   "teamId": "458C9A0E-AB7B-44F9-947D-1D832A3C5F75",
+   "name": "Eastern Michigan",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 21.26,
+   "matches": 369,
+   "bands": {
+    "STRETCH": 6,
+    "UP": 199,
+    "EVEN": 79,
+    "DOWN": 85,
+    "ANCHOR": 0
+   },
+   "bandPct": {
+    "STRETCH": 1.6,
+    "UP": 53.9,
+    "EVEN": 21.4,
+    "DOWN": 23,
+    "ANCHOR": 0
+   },
+   "stretchRate": 1.6,
+   "anchorRate": 0,
+   "breadth": 0.664,
+   "competitiveRatio": 48,
+   "winRate": 49.3
+  },
+  {
+   "teamId": "76487A7A-DE11-448C-BED1-006F9B605564",
+   "name": "Ball State",
+   "gender": "M",
+   "division": "DIV_I",
+   "lineupWTN": 15.09,
+   "matches": 368,
+   "bands": {
+    "STRETCH": 30,
+    "UP": 210,
+    "EVEN": 84,
+    "DOWN": 33,
+    "ANCHOR": 11
+   },
+   "bandPct": {
+    "STRETCH": 8.2,
+    "UP": 57.1,
+    "EVEN": 22.8,
+    "DOWN": 9,
+    "ANCHOR": 3
+   },
+   "stretchRate": 8.2,
+   "anchorRate": 3,
+   "breadth": 0.735,
+   "competitiveRatio": 57.1,
+   "winRate": 50
+  },
+  {
+   "teamId": "6591809E-2984-42A7-B5CA-DF174141F4D9",
+   "name": "Bowling Green",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 21.1,
+   "matches": 354,
+   "bands": {
+    "STRETCH": 0,
+    "UP": 179,
+    "EVEN": 70,
+    "DOWN": 99,
+    "ANCHOR": 6
+   },
+   "bandPct": {
+    "STRETCH": 0,
+    "UP": 50.6,
+    "EVEN": 19.8,
+    "DOWN": 28,
+    "ANCHOR": 1.7
+   },
+   "stretchRate": 0,
+   "anchorRate": 1.7,
+   "breadth": 0.678,
+   "competitiveRatio": 49.3,
+   "winRate": 39.5
+  },
+  {
+   "teamId": "08718B41-A5CD-4539-9462-F5780259C995",
+   "name": "Ball State",
+   "gender": "W",
+   "division": "DIV_I",
+   "lineupWTN": 19.42,
+   "matches": 339,
+   "bands": {
+    "STRETCH": 0,
+    "UP": 73,
+    "EVEN": 59,
+    "DOWN": 207,
+    "ANCHOR": 0
+   },
+   "bandPct": {
+    "STRETCH": 0,
+    "UP": 21.5,
+    "EVEN": 17.4,
+    "DOWN": 61.1,
+    "ANCHOR": 0
+   },
+   "stretchRate": 0,
+   "anchorRate": 0,
+   "breadth": 0.582,
+   "competitiveRatio": 51,
+   "winRate": 45.4
   }
  ]
 }

--- a/public/data/conferences/mid-eastern-athletic-conference.json
+++ b/public/data/conferences/mid-eastern-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 16.6,
    "anchorRate": 10.5,
    "breadth": 0.963,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 37.4,
    "winRate": 43.7
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 15.2,
    "anchorRate": 15.2,
    "breadth": 0.988,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 36.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 17.3,
    "anchorRate": 7.6,
    "breadth": 0.933,
-   "competitiveRatio": 39,
+   "competitiveRatio": 38,
    "winRate": 39.9
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 8.9,
    "anchorRate": 20.1,
    "breadth": 0.945,
-   "competitiveRatio": 45.6,
+   "competitiveRatio": 44.5,
    "winRate": 59.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 14,
    "anchorRate": 14.3,
    "breadth": 0.981,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 44.7,
    "winRate": 52.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 14.2,
    "anchorRate": 10.7,
    "breadth": 0.89,
-   "competitiveRatio": 39.6,
+   "competitiveRatio": 37.4,
    "winRate": 39.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0.8,
    "anchorRate": 14.7,
    "breadth": 0.802,
-   "competitiveRatio": 33.1,
+   "competitiveRatio": 31.7,
    "winRate": 47.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 11.3,
    "anchorRate": 9.1,
    "breadth": 0.926,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 36.6,
    "winRate": 47.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 4,
    "anchorRate": 4.7,
    "breadth": 0.843,
-   "competitiveRatio": 42.8,
+   "competitiveRatio": 41.5,
    "winRate": 44.8
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 17.8,
    "anchorRate": 1.7,
    "breadth": 0.715,
-   "competitiveRatio": 34,
+   "competitiveRatio": 32.7,
    "winRate": 55.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 9.4,
    "anchorRate": 34.7,
    "breadth": 0.883,
-   "competitiveRatio": 39.1,
+   "competitiveRatio": 37,
    "winRate": 63.6
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 80.4,
    "anchorRate": 0.7,
    "breadth": 0.436,
-   "competitiveRatio": 23.1,
+   "competitiveRatio": 22,
    "winRate": 9.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 21.2,
    "anchorRate": 6.6,
    "breadth": 0.922,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 40.7,
    "winRate": 30.8
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 2.2,
    "breadth": 0.644,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 44.4,
    "winRate": 47.2
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 53.8,
    "anchorRate": 0,
    "breadth": 0.519,
-   "competitiveRatio": 21.7,
+   "competitiveRatio": 21.1,
    "winRate": 11
   }
  ]

--- a/public/data/conferences/mid-south-conference.json
+++ b/public/data/conferences/mid-south-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 674,
     "UP": 1460,
-    "EVEN": 417,
-    "DOWN": 1295,
-    "ANCHOR": 518
+    "EVEN": 412,
+    "DOWN": 1294,
+    "ANCHOR": 524
    },
    "bandPct": {
     "STRETCH": 15.4,
     "UP": 33.5,
-    "EVEN": 9.6,
+    "EVEN": 9.4,
     "DOWN": 29.7,
-    "ANCHOR": 11.9
+    "ANCHOR": 12
    },
    "stretchRate": 15.4,
-   "anchorRate": 11.9,
+   "anchorRate": 12,
    "breadth": 0.927,
-   "competitiveRatio": 36,
+   "competitiveRatio": 34.4,
    "winRate": 50.8
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 16.9,
    "anchorRate": 16.9,
    "breadth": 0.932,
-   "competitiveRatio": 34.3,
+   "competitiveRatio": 33.1,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 360,
     "UP": 904,
-    "EVEN": 297,
-    "DOWN": 739,
-    "ANCHOR": 204
+    "EVEN": 292,
+    "DOWN": 738,
+    "ANCHOR": 210
    },
    "bandPct": {
     "STRETCH": 14.4,
     "UP": 36.1,
-    "EVEN": 11.9,
+    "EVEN": 11.7,
     "DOWN": 29.5,
-    "ANCHOR": 8.1
+    "ANCHOR": 8.4
    },
    "stretchRate": 14.4,
-   "anchorRate": 8.1,
+   "anchorRate": 8.4,
    "breadth": 0.91,
-   "competitiveRatio": 37.2,
+   "competitiveRatio": 35.4,
    "winRate": 51.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 26.9,
    "anchorRate": 0,
    "breadth": 0.696,
-   "competitiveRatio": 51.5,
+   "competitiveRatio": 44.4,
    "winRate": 50.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 8.2,
    "anchorRate": 13.1,
    "breadth": 0.785,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42,
    "winRate": 68.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.1,
    "anchorRate": 21.3,
    "breadth": 0.772,
-   "competitiveRatio": 32,
+   "competitiveRatio": 31.2,
    "winRate": 65.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 33.5,
    "anchorRate": 5.1,
    "breadth": 0.774,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41.3,
    "winRate": 38
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 57.1,
    "anchorRate": 0,
    "breadth": 0.574,
-   "competitiveRatio": 22.7,
+   "competitiveRatio": 22.3,
    "winRate": 22.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 20.3,
    "breadth": 0.848,
-   "competitiveRatio": 27.5,
+   "competitiveRatio": 26.6,
    "winRate": 54.8
   },
   {
@@ -307,21 +307,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 11,
-    "EVEN": 24,
-    "DOWN": 177,
+    "EVEN": 19,
+    "DOWN": 182,
     "ANCHOR": 82
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 3.7,
-    "EVEN": 8.2,
-    "DOWN": 60.2,
+    "EVEN": 6.5,
+    "DOWN": 61.9,
     "ANCHOR": 27.9
    },
    "stretchRate": 0,
    "anchorRate": 27.9,
-   "breadth": 0.615,
-   "competitiveRatio": 27.6,
+   "breadth": 0.592,
+   "competitiveRatio": 26.9,
    "winRate": 81
   },
   {
@@ -335,20 +335,20 @@
     "STRETCH": 0,
     "UP": 155,
     "EVEN": 12,
-    "DOWN": 102,
-    "ANCHOR": 24
+    "DOWN": 96,
+    "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 52.9,
     "EVEN": 4.1,
-    "DOWN": 34.8,
-    "ANCHOR": 8.2
+    "DOWN": 32.8,
+    "ANCHOR": 10.2
    },
    "stretchRate": 0,
-   "anchorRate": 8.2,
-   "breadth": 0.646,
-   "competitiveRatio": 32.6,
+   "anchorRate": 10.2,
+   "breadth": 0.663,
+   "competitiveRatio": 31.6,
    "winRate": 57.7
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 10.6,
    "anchorRate": 5.1,
    "breadth": 0.857,
-   "competitiveRatio": 41,
+   "competitiveRatio": 40.7,
    "winRate": 45.5
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 6.9,
    "anchorRate": 2.1,
    "breadth": 0.776,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 43.2,
    "winRate": 46.2
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 26.1,
    "anchorRate": 2.1,
    "breadth": 0.729,
-   "competitiveRatio": 36.7,
+   "competitiveRatio": 35,
    "winRate": 30
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 4.9,
    "anchorRate": 43.1,
    "breadth": 0.704,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 35.6,
    "winRate": 78.3
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 34.9,
    "anchorRate": 2.4,
    "breadth": 0.736,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 21.8,
    "winRate": 23.4
   }
  ]

--- a/public/data/conferences/middle-atlantic-conference.json
+++ b/public/data/conferences/middle-atlantic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 13.6,
    "anchorRate": 8,
    "breadth": 0.906,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.8,
    "winRate": 45.9
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 12.3,
    "anchorRate": 12.3,
    "breadth": 0.938,
-   "competitiveRatio": 24.7,
+   "competitiveRatio": 24,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 14.7,
    "anchorRate": 4.2,
    "breadth": 0.86,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 31.1,
    "winRate": 42.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 9.4,
    "anchorRate": 4.4,
    "breadth": 0.876,
-   "competitiveRatio": 35.3,
+   "competitiveRatio": 34.4,
    "winRate": 50
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 9.6,
    "anchorRate": 34.6,
    "breadth": 0.843,
-   "competitiveRatio": 34.9,
+   "competitiveRatio": 34.3,
    "winRate": 66
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 4.4,
    "anchorRate": 10.1,
    "breadth": 0.811,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 30.5,
    "winRate": 62.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1,
    "anchorRate": 11.7,
    "breadth": 0.716,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.2,
    "winRate": 80.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1,
    "anchorRate": 39.2,
    "breadth": 0.624,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 28.7,
    "winRate": 64
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 8.6,
    "breadth": 0.71,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 29.4,
    "winRate": 52.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 2.2,
    "anchorRate": 8.4,
    "breadth": 0.842,
-   "competitiveRatio": 37.1,
+   "competitiveRatio": 37.5,
    "winRate": 52
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 8.9,
    "anchorRate": 0,
    "breadth": 0.77,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25.7,
    "winRate": 40
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 9.1,
    "anchorRate": 0,
    "breadth": 0.67,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 32.8,
    "winRate": 39.9
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 33.9,
    "anchorRate": 0,
    "breadth": 0.701,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 31.1,
    "winRate": 39
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 7.2,
    "anchorRate": 0,
    "breadth": 0.619,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 29.3,
    "winRate": 39.2
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 21.7,
    "anchorRate": 0,
    "breadth": 0.501,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 21.1,
    "winRate": 21.7
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 10,
    "anchorRate": 9.5,
    "breadth": 0.866,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 30.4,
    "winRate": 52.3
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 10.1,
    "anchorRate": 0,
    "breadth": 0.807,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 21.5,
    "winRate": 33.2
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 2.2,
    "anchorRate": 0,
    "breadth": 0.691,
-   "competitiveRatio": 27.4,
+   "competitiveRatio": 26.9,
    "winRate": 41.7
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 0,
    "anchorRate": 31.8,
    "breadth": 0.575,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 23.6,
    "winRate": 62.7
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 5.5,
    "anchorRate": 0,
    "breadth": 0.622,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.7,
    "winRate": 44.3
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 52.7,
    "anchorRate": 0,
    "breadth": 0.498,
-   "competitiveRatio": 22.2,
+   "competitiveRatio": 21.7,
    "winRate": 26.1
   },
   {
@@ -780,7 +780,7 @@
    "stretchRate": 9.8,
    "anchorRate": 0,
    "breadth": 0.795,
-   "competitiveRatio": 17.4,
+   "competitiveRatio": 16.5,
    "winRate": 36.9
   }
  ]

--- a/public/data/conferences/midwest-conference.json
+++ b/public/data/conferences/midwest-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 585,
     "UP": 1414,
-    "EVEN": 589,
-    "DOWN": 1749,
+    "EVEN": 571,
+    "DOWN": 1767,
     "ANCHOR": 637
    },
    "bandPct": {
     "STRETCH": 11.8,
     "UP": 28.4,
-    "EVEN": 11.8,
-    "DOWN": 35.2,
+    "EVEN": 11.5,
+    "DOWN": 35.5,
     "ANCHOR": 12.8
    },
    "stretchRate": 11.8,
    "anchorRate": 12.8,
-   "breadth": 0.927,
-   "competitiveRatio": 29.1,
+   "breadth": 0.925,
+   "competitiveRatio": 28.3,
    "winRate": 48.3
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.5,
    "anchorRate": 17.5,
    "breadth": 0.966,
-   "competitiveRatio": 21,
+   "competitiveRatio": 20.6,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 305,
     "UP": 977,
-    "EVEN": 421,
-    "DOWN": 1312,
+    "EVEN": 403,
+    "DOWN": 1330,
     "ANCHOR": 357
    },
    "bandPct": {
     "STRETCH": 9,
     "UP": 29,
-    "EVEN": 12.5,
-    "DOWN": 38.9,
+    "EVEN": 12,
+    "DOWN": 39.4,
     "ANCHOR": 10.6
    },
    "stretchRate": 9,
    "anchorRate": 10.6,
-   "breadth": 0.895,
-   "competitiveRatio": 32.9,
+   "breadth": 0.892,
+   "competitiveRatio": 31.9,
    "winRate": 47.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 5.2,
    "anchorRate": 35.8,
    "breadth": 0.819,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 35.3,
    "winRate": 65.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 6.8,
    "anchorRate": 26,
    "breadth": 0.921,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 28,
    "winRate": 64
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 10.2,
    "anchorRate": 9.4,
    "breadth": 0.894,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 35,
    "winRate": 55.9
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 11.9,
    "anchorRate": 0,
    "breadth": 0.747,
-   "competitiveRatio": 24.1,
+   "competitiveRatio": 24.4,
    "winRate": 26.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 32.7,
    "anchorRate": 3.1,
    "breadth": 0.846,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.3,
    "winRate": 32
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 22.3,
    "anchorRate": 0,
    "breadth": 0.686,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 29.3,
    "winRate": 23.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 20.8,
    "breadth": 0.767,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 25.2,
    "winRate": 72.1
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 3.3,
    "anchorRate": 24.2,
    "breadth": 0.817,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 35.3,
    "winRate": 65
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 6.9,
    "anchorRate": 2.4,
    "breadth": 0.8,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 23.6,
    "winRate": 51.6
   },
   {
@@ -388,21 +388,21 @@
    "bands": {
     "STRETCH": 49,
     "UP": 96,
-    "EVEN": 54,
-    "DOWN": 93,
+    "EVEN": 36,
+    "DOWN": 111,
     "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 15.1,
     "UP": 29.5,
-    "EVEN": 16.6,
-    "DOWN": 28.6,
+    "EVEN": 11.1,
+    "DOWN": 34.2,
     "ANCHOR": 10.2
    },
    "stretchRate": 15.1,
    "anchorRate": 10.2,
-   "breadth": 0.953,
-   "competitiveRatio": 28.4,
+   "breadth": 0.925,
+   "competitiveRatio": 27.5,
    "winRate": 43.4
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 13.1,
    "anchorRate": 5.5,
    "breadth": 0.882,
-   "competitiveRatio": 22.5,
+   "competitiveRatio": 22.9,
    "winRate": 33.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 16.9,
    "anchorRate": 0,
    "breadth": 0.673,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 25.8,
    "winRate": 35.2
   },
   {

--- a/public/data/conferences/minnesota-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/minnesota-intercollegiate-athletic-conference.json
@@ -32,7 +32,7 @@
    "stretchRate": 8.9,
    "anchorRate": 15.8,
    "breadth": 0.922,
-   "competitiveRatio": 35.5,
+   "competitiveRatio": 34.5,
    "winRate": 56.2
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 14.8,
    "anchorRate": 14.8,
    "breadth": 0.969,
-   "competitiveRatio": 33.3,
+   "competitiveRatio": 32.8,
    "winRate": 50
   },
   "nonConference": {
@@ -76,7 +76,7 @@
    "stretchRate": 3.8,
    "anchorRate": 16.7,
    "breadth": 0.848,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 36.1,
    "winRate": 61.4
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 0,
    "anchorRate": 47.7,
    "breadth": 0.593,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.7,
    "winRate": 70.2
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 0,
    "anchorRate": 42.9,
    "breadth": 0.755,
-   "competitiveRatio": 38.7,
+   "competitiveRatio": 37.1,
    "winRate": 66.7
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 6,
    "anchorRate": 33.3,
    "breadth": 0.804,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 43.1,
    "winRate": 69.7
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 0,
    "anchorRate": 18.8,
    "breadth": 0.765,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 34.6,
    "winRate": 73.4
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 4.8,
    "anchorRate": 0,
    "breadth": 0.683,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 33.1,
    "winRate": 50.9
   },
   {
@@ -268,7 +268,7 @@
    "stretchRate": 5.6,
    "anchorRate": 10.7,
    "breadth": 0.62,
-   "competitiveRatio": 42.8,
+   "competitiveRatio": 41.4,
    "winRate": 65
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 0,
    "anchorRate": 33.2,
    "breadth": 0.782,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.3,
    "winRate": 75.9
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 5.2,
    "anchorRate": 6.9,
    "breadth": 0.651,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 44.3,
    "winRate": 48.8
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 6.1,
    "anchorRate": 10.4,
    "breadth": 0.618,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 30.2,
    "winRate": 63.8
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 22.3,
    "anchorRate": 1.5,
    "breadth": 0.841,
-   "competitiveRatio": 28.2,
+   "competitiveRatio": 27.3,
    "winRate": 49.3
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 17.7,
    "anchorRate": 1.5,
    "breadth": 0.764,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 29.5,
    "winRate": 22.8
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 19.6,
    "anchorRate": 1.8,
    "breadth": 0.895,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 30.7,
    "winRate": 41.9
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 16.3,
    "anchorRate": 1.5,
    "breadth": 0.884,
-   "competitiveRatio": 30.8,
+   "competitiveRatio": 30.2,
    "winRate": 49.2
   },
   {
@@ -511,7 +511,7 @@
    "stretchRate": 0,
    "anchorRate": 33,
    "breadth": 0.808,
-   "competitiveRatio": 24.2,
+   "competitiveRatio": 23.5,
    "winRate": 82
   },
   {
@@ -538,7 +538,7 @@
    "stretchRate": 7.4,
    "anchorRate": 12.9,
    "breadth": 0.9,
-   "competitiveRatio": 42,
+   "competitiveRatio": 41,
    "winRate": 49.2
   },
   {
@@ -565,7 +565,7 @@
    "stretchRate": 12.8,
    "anchorRate": 5.2,
    "breadth": 0.915,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 35.6,
    "winRate": 53.4
   },
   {
@@ -592,7 +592,7 @@
    "stretchRate": 7.1,
    "anchorRate": 7.8,
    "breadth": 0.875,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.2,
    "winRate": 44.6
   },
   {
@@ -646,7 +646,7 @@
    "stretchRate": 29.3,
    "anchorRate": 2.1,
    "breadth": 0.812,
-   "competitiveRatio": 34.6,
+   "competitiveRatio": 34.3,
    "winRate": 38.6
   },
   {
@@ -673,7 +673,7 @@
    "stretchRate": 10.9,
    "anchorRate": 1.8,
    "breadth": 0.73,
-   "competitiveRatio": 37.6,
+   "competitiveRatio": 36.5,
    "winRate": 42.5
   }
  ]

--- a/public/data/conferences/mississippi-assn-for-comm-juco.json
+++ b/public/data/conferences/mississippi-assn-for-comm-juco.json
@@ -31,7 +31,7 @@
    "stretchRate": 11.3,
    "anchorRate": 5,
    "breadth": 0.885,
-   "competitiveRatio": 20.5,
+   "competitiveRatio": 20.3,
    "winRate": 37.7
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 12.3,
    "anchorRate": 5.5,
    "breadth": 0.899,
-   "competitiveRatio": 20.7,
+   "competitiveRatio": 20.5,
    "winRate": 36.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 13.4,
    "anchorRate": 6.7,
    "breadth": 0.936,
-   "competitiveRatio": 19.8,
+   "competitiveRatio": 19.4,
    "winRate": 36.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 2.6,
    "breadth": 0.659,
-   "competitiveRatio": 20.6,
+   "competitiveRatio": 21,
    "winRate": 51.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 18.4,
    "anchorRate": 9.6,
    "breadth": 0.827,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 21.5,
    "winRate": 35.5
   },
   {

--- a/public/data/conferences/missouri-valley-conference.json
+++ b/public/data/conferences/missouri-valley-conference.json
@@ -18,20 +18,20 @@
     "STRETCH": 126,
     "UP": 1167,
     "EVEN": 813,
-    "DOWN": 907,
-    "ANCHOR": 121
+    "DOWN": 901,
+    "ANCHOR": 127
    },
    "bandPct": {
     "STRETCH": 4,
     "UP": 37.2,
     "EVEN": 25.9,
-    "DOWN": 28.9,
-    "ANCHOR": 3.9
+    "DOWN": 28.7,
+    "ANCHOR": 4.1
    },
    "stretchRate": 4,
-   "anchorRate": 3.9,
-   "breadth": 0.827,
-   "competitiveRatio": 47,
+   "anchorRate": 4.1,
+   "breadth": 0.83,
+   "competitiveRatio": 45.9,
    "winRate": 47.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 1.6,
    "anchorRate": 1.6,
    "breadth": 0.762,
-   "competitiveRatio": 48.5,
+   "competitiveRatio": 47.5,
    "winRate": 50
   },
   "nonConference": {
@@ -62,20 +62,20 @@
     "STRETCH": 109,
     "UP": 817,
     "EVEN": 485,
-    "DOWN": 557,
-    "ANCHOR": 104
+    "DOWN": 551,
+    "ANCHOR": 110
    },
    "bandPct": {
     "STRETCH": 5.3,
     "UP": 39.4,
     "EVEN": 23.4,
-    "DOWN": 26.9,
-    "ANCHOR": 5
+    "DOWN": 26.6,
+    "ANCHOR": 5.3
    },
    "stretchRate": 5.3,
-   "anchorRate": 5,
-   "breadth": 0.848,
-   "competitiveRatio": 46.2,
+   "anchorRate": 5.3,
+   "breadth": 0.851,
+   "competitiveRatio": 45.1,
    "winRate": 46.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.1,
    "anchorRate": 6.2,
    "breadth": 0.775,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 42.7,
    "winRate": 60.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 4.9,
    "anchorRate": 3.3,
    "breadth": 0.831,
-   "competitiveRatio": 43.6,
+   "competitiveRatio": 42.5,
    "winRate": 37.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.6,
    "anchorRate": 7.6,
    "breadth": 0.763,
-   "competitiveRatio": 54.9,
+   "competitiveRatio": 53.5,
    "winRate": 48.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.7,
    "anchorRate": 3.4,
    "breadth": 0.765,
-   "competitiveRatio": 46.4,
+   "competitiveRatio": 45.8,
    "winRate": 58.1
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 4.3,
    "anchorRate": 8,
    "breadth": 0.807,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 54.2,
    "winRate": 58.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2.9,
    "anchorRate": 0,
    "breadth": 0.706,
-   "competitiveRatio": 51.2,
+   "competitiveRatio": 50.3,
    "winRate": 41.2
   },
   {
@@ -281,20 +281,20 @@
     "STRETCH": 0,
     "UP": 153,
     "EVEN": 75,
-    "DOWN": 83,
-    "ANCHOR": 18
+    "DOWN": 77,
+    "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 46.5,
     "EVEN": 22.8,
-    "DOWN": 25.2,
-    "ANCHOR": 5.5
+    "DOWN": 23.4,
+    "ANCHOR": 7.3
    },
    "stretchRate": 0,
-   "anchorRate": 5.5,
-   "breadth": 0.745,
-   "competitiveRatio": 40.4,
+   "anchorRate": 7.3,
+   "breadth": 0.76,
+   "competitiveRatio": 38.8,
    "winRate": 49.8
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 7.6,
    "anchorRate": 0,
    "breadth": 0.788,
-   "competitiveRatio": 47.2,
+   "competitiveRatio": 45.7,
    "winRate": 46.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 13,
    "anchorRate": 0,
    "breadth": 0.297,
-   "competitiveRatio": 39.6,
+   "competitiveRatio": 38.6,
    "winRate": 24.5
   }
  ]

--- a/public/data/conferences/mountain-east-conference.json
+++ b/public/data/conferences/mountain-east-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.3,
    "anchorRate": 11.8,
    "breadth": 0.88,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 39.8,
    "winRate": 50.7
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 3.6,
    "anchorRate": 12.4,
    "breadth": 0.864,
-   "competitiveRatio": 42.4,
+   "competitiveRatio": 41.6,
    "winRate": 51.1
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 3.3,
    "anchorRate": 5,
    "breadth": 0.769,
-   "competitiveRatio": 42.1,
+   "competitiveRatio": 40.7,
    "winRate": 49.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 29.3,
    "breadth": 0.754,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.7,
    "winRate": 69.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 8.4,
    "breadth": 0.677,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 42.6,
    "winRate": 56.8
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 10.5,
    "breadth": 0.754,
-   "competitiveRatio": 49.8,
+   "competitiveRatio": 49.2,
    "winRate": 62.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 10.8,
    "breadth": 0.762,
-   "competitiveRatio": 33.1,
+   "competitiveRatio": 32.5,
    "winRate": 47.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 1,
    "anchorRate": 13.6,
    "breadth": 0.838,
-   "competitiveRatio": 50.7,
+   "competitiveRatio": 49.3,
    "winRate": 44.9
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 6.3,
    "anchorRate": 19.5,
    "breadth": 0.889,
-   "competitiveRatio": 39.2,
+   "competitiveRatio": 38.8,
    "winRate": 46.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 10.8,
    "anchorRate": 8.1,
    "breadth": 0.858,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 42.9,
    "winRate": 38.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 10.6,
    "anchorRate": 0,
    "breadth": 0.557,
-   "competitiveRatio": 35.6,
+   "competitiveRatio": 35.1,
    "winRate": 39.8
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 27.2,
    "anchorRate": 0,
    "breadth": 0.649,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 21.2,
    "winRate": 26.5
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 73.9,
    "anchorRate": 0,
    "breadth": 0.46,
-   "competitiveRatio": 10.9,
+   "competitiveRatio": 10.1,
    "winRate": 10.9
   }
  ]

--- a/public/data/conferences/mountain-west-conference.json
+++ b/public/data/conferences/mountain-west-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 103,
     "UP": 2191,
-    "EVEN": 1219,
-    "DOWN": 2732,
+    "EVEN": 1214,
+    "DOWN": 2737,
     "ANCHOR": 295
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 33.5,
     "EVEN": 18.6,
-    "DOWN": 41.8,
+    "DOWN": 41.9,
     "ANCHOR": 4.5
    },
    "stretchRate": 1.6,
    "anchorRate": 4.5,
    "breadth": 0.776,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 46.7,
    "winRate": 53.8
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 1009,
-    "EVEN": 622,
-    "DOWN": 1009,
+    "EVEN": 617,
+    "DOWN": 1014,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 38.2,
-    "EVEN": 23.6,
-    "DOWN": 38.2,
+    "EVEN": 23.4,
+    "DOWN": 38.4,
     "ANCHOR": 0
    },
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 49.6,
+   "competitiveRatio": 46.3,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 2.6,
    "anchorRate": 7.6,
    "breadth": 0.809,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 46.9,
    "winRate": 56.3
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0.7,
    "anchorRate": 6.1,
    "breadth": 0.623,
-   "competitiveRatio": 60.7,
+   "competitiveRatio": 55.6,
    "winRate": 64.4
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 4.1,
    "anchorRate": 0,
    "breadth": 0.726,
-   "competitiveRatio": 56,
+   "competitiveRatio": 53.3,
    "winRate": 64.9
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 4.2,
    "anchorRate": 3.4,
    "breadth": 0.775,
-   "competitiveRatio": 54.8,
+   "competitiveRatio": 50,
    "winRate": 54.2
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 17.8,
    "breadth": 0.673,
-   "competitiveRatio": 43.8,
+   "competitiveRatio": 40.1,
    "winRate": 64.5
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 6.9,
    "anchorRate": 1.7,
    "breadth": 0.787,
-   "competitiveRatio": 54.2,
+   "competitiveRatio": 49.3,
    "winRate": 45.7
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 3.5,
    "anchorRate": 1.7,
    "breadth": 0.673,
-   "competitiveRatio": 42.3,
+   "competitiveRatio": 39.7,
    "winRate": 47.8
   },
   {
@@ -279,21 +279,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 59,
-    "EVEN": 32,
-    "DOWN": 243,
+    "EVEN": 27,
+    "DOWN": 248,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1.8,
     "UP": 17.4,
-    "EVEN": 9.4,
-    "DOWN": 71.5,
+    "EVEN": 7.9,
+    "DOWN": 72.9,
     "ANCHOR": 0
    },
    "stretchRate": 1.8,
    "anchorRate": 0,
-   "breadth": 0.52,
-   "competitiveRatio": 36.5,
+   "breadth": 0.501,
+   "competitiveRatio": 35.9,
    "winRate": 65
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 4.5,
    "breadth": 0.612,
-   "competitiveRatio": 45.5,
+   "competitiveRatio": 44,
    "winRate": 67.9
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 1.8,
    "anchorRate": 1.2,
    "breadth": 0.707,
-   "competitiveRatio": 58.3,
+   "competitiveRatio": 52.6,
    "winRate": 45.9
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 1.9,
    "anchorRate": 9,
    "breadth": 0.829,
-   "competitiveRatio": 39.4,
+   "competitiveRatio": 38.5,
    "winRate": 51.6
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 1.3,
    "anchorRate": 4.7,
    "breadth": 0.797,
-   "competitiveRatio": 58.2,
+   "competitiveRatio": 57,
    "winRate": 47.8
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 0,
    "anchorRate": 3.5,
    "breadth": 0.528,
-   "competitiveRatio": 42,
+   "competitiveRatio": 41.4,
    "winRate": 67.6
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 1.9,
    "breadth": 0.722,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 47.3,
    "winRate": 39.3
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 1,
    "anchorRate": 7.4,
    "breadth": 0.795,
-   "competitiveRatio": 55.2,
+   "competitiveRatio": 53.2,
    "winRate": 59
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 1,
    "anchorRate": 3.3,
    "breadth": 0.716,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 38.2,
    "winRate": 38.9
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 2,
    "anchorRate": 9.9,
    "breadth": 0.782,
-   "competitiveRatio": 52.5,
+   "competitiveRatio": 49.8,
    "winRate": 45.2
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 0,
    "anchorRate": 8.7,
    "breadth": 0.779,
-   "competitiveRatio": 52,
+   "competitiveRatio": 50.3,
    "winRate": 47
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.509,
-   "competitiveRatio": 47.6,
+   "competitiveRatio": 45.9,
    "winRate": 54.4
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.56,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 44.6,
    "winRate": 38.3
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 0,
    "anchorRate": 5.2,
    "breadth": 0.672,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 44.3,
    "winRate": 58.1
   }
  ]

--- a/public/data/conferences/new-england-small-college-athletic-conference.json
+++ b/public/data/conferences/new-england-small-college-athletic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 688,
     "UP": 2049,
-    "EVEN": 878,
-    "DOWN": 2673,
+    "EVEN": 855,
+    "DOWN": 2696,
     "ANCHOR": 1033
    },
    "bandPct": {
     "STRETCH": 9.4,
     "UP": 28,
-    "EVEN": 12,
-    "DOWN": 36.5,
+    "EVEN": 11.7,
+    "DOWN": 36.8,
     "ANCHOR": 14.1
    },
    "stretchRate": 9.4,
    "anchorRate": 14.1,
-   "breadth": 0.918,
-   "competitiveRatio": 42.9,
+   "breadth": 0.916,
+   "competitiveRatio": 42.4,
    "winRate": 55.6
   },
   "inConference": {
@@ -39,20 +39,20 @@
    "bands": {
     "STRETCH": 609,
     "UP": 1303,
-    "EVEN": 468,
-    "DOWN": 1303,
+    "EVEN": 456,
+    "DOWN": 1315,
     "ANCHOR": 609
    },
    "bandPct": {
     "STRETCH": 14.2,
     "UP": 30.4,
-    "EVEN": 10.9,
-    "DOWN": 30.4,
+    "EVEN": 10.6,
+    "DOWN": 30.6,
     "ANCHOR": 14.2
    },
    "stretchRate": 14.2,
    "anchorRate": 14.2,
-   "breadth": 0.944,
+   "breadth": 0.942,
    "competitiveRatio": 42.2,
    "winRate": 50
   },
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 79,
     "UP": 746,
-    "EVEN": 410,
-    "DOWN": 1370,
+    "EVEN": 399,
+    "DOWN": 1381,
     "ANCHOR": 424
    },
    "bandPct": {
     "STRETCH": 2.6,
     "UP": 24.6,
-    "EVEN": 13.5,
-    "DOWN": 45.2,
+    "EVEN": 13.2,
+    "DOWN": 45.6,
     "ANCHOR": 14
    },
    "stretchRate": 2.6,
    "anchorRate": 14,
-   "breadth": 0.836,
-   "competitiveRatio": 43.9,
+   "breadth": 0.833,
+   "competitiveRatio": 42.7,
    "winRate": 63.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.2,
    "anchorRate": 28.7,
    "breadth": 0.507,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.3,
    "winRate": 77.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 17.1,
    "breadth": 0.73,
-   "competitiveRatio": 54.3,
+   "competitiveRatio": 52.4,
    "winRate": 73.2
   },
   {
@@ -172,21 +172,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 0,
-    "EVEN": 22,
-    "DOWN": 216,
+    "EVEN": 11,
+    "DOWN": 227,
     "ANCHOR": 139
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 0,
-    "EVEN": 5.8,
-    "DOWN": 57.3,
+    "EVEN": 2.9,
+    "DOWN": 60.2,
     "ANCHOR": 36.9
    },
    "stretchRate": 0,
    "anchorRate": 36.9,
-   "breadth": 0.53,
-   "competitiveRatio": 38.2,
+   "breadth": 0.482,
+   "competitiveRatio": 36.9,
    "winRate": 80.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 16.4,
    "breadth": 0.793,
-   "competitiveRatio": 43.7,
+   "competitiveRatio": 42.6,
    "winRate": 72.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 20.9,
    "breadth": 0.853,
-   "competitiveRatio": 43,
+   "competitiveRatio": 43.3,
    "winRate": 59.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 22.2,
    "breadth": 0.827,
-   "competitiveRatio": 47.9,
+   "competitiveRatio": 47.3,
    "winRate": 63.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 17.9,
    "breadth": 0.686,
-   "competitiveRatio": 50.4,
+   "competitiveRatio": 51.3,
    "winRate": 67
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 29.4,
    "breadth": 0.858,
-   "competitiveRatio": 42.5,
+   "competitiveRatio": 42.2,
    "winRate": 65.1
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 24.2,
    "breadth": 0.858,
-   "competitiveRatio": 39.7,
+   "competitiveRatio": 38.2,
    "winRate": 72
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 31.7,
    "anchorRate": 3.6,
    "breadth": 0.83,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 44.7,
    "winRate": 33.4
   },
   {
@@ -388,21 +388,21 @@
    "bands": {
     "STRETCH": 18,
     "UP": 93,
-    "EVEN": 36,
-    "DOWN": 150,
+    "EVEN": 24,
+    "DOWN": 162,
     "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 5.5,
     "UP": 28.4,
-    "EVEN": 11,
-    "DOWN": 45.9,
+    "EVEN": 7.3,
+    "DOWN": 49.5,
     "ANCHOR": 9.2
    },
    "stretchRate": 5.5,
    "anchorRate": 9.2,
-   "breadth": 0.831,
-   "competitiveRatio": 46.2,
+   "breadth": 0.793,
+   "competitiveRatio": 45.9,
    "winRate": 52.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 29.1,
    "anchorRate": 3.4,
    "breadth": 0.854,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 33.7,
    "winRate": 38
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 0,
    "anchorRate": 6.4,
    "breadth": 0.658,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42,
    "winRate": 58
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 19.8,
    "breadth": 0.818,
-   "competitiveRatio": 46,
+   "competitiveRatio": 46.7,
    "winRate": 66.3
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 41.7,
    "anchorRate": 0,
    "breadth": 0.653,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 38.7,
    "winRate": 22.2
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 7,
    "anchorRate": 8,
    "breadth": 0.851,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 45.5,
    "winRate": 44.5
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 32.7,
    "anchorRate": 0,
    "breadth": 0.811,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 43,
    "winRate": 41
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 8.1,
    "anchorRate": 4,
    "breadth": 0.767,
-   "competitiveRatio": 37.2,
+   "competitiveRatio": 35.8,
    "winRate": 48.5
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 6.8,
    "anchorRate": 8.1,
    "breadth": 0.793,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 31.8,
    "winRate": 45.9
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 28.6,
    "anchorRate": 6.1,
    "breadth": 0.91,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 42.9,
    "winRate": 28.9
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 30.9,
    "anchorRate": 0,
    "breadth": 0.792,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 27.5,
    "winRate": 30.2
   },
   {
@@ -699,7 +699,7 @@
    "stretchRate": 0,
    "anchorRate": 10.1,
    "breadth": 0.734,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 50.7,
    "winRate": 50.3
   }
  ]

--- a/public/data/conferences/new-england-women-and-men-athletics-conference.json
+++ b/public/data/conferences/new-england-women-and-men-athletics-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 805,
     "UP": 1375,
-    "EVEN": 699,
-    "DOWN": 1546,
+    "EVEN": 683,
+    "DOWN": 1562,
     "ANCHOR": 811
    },
    "bandPct": {
     "STRETCH": 15.4,
     "UP": 26.3,
-    "EVEN": 13.3,
-    "DOWN": 29.5,
+    "EVEN": 13,
+    "DOWN": 29.8,
     "ANCHOR": 15.5
    },
    "stretchRate": 15.4,
    "anchorRate": 15.5,
-   "breadth": 0.967,
-   "competitiveRatio": 31.6,
+   "breadth": 0.966,
+   "competitiveRatio": 30.8,
    "winRate": 50.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 25.1,
    "anchorRate": 25.1,
    "breadth": 0.966,
-   "competitiveRatio": 22.5,
+   "competitiveRatio": 21.9,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 189,
     "UP": 867,
-    "EVEN": 493,
-    "DOWN": 1038,
+    "EVEN": 477,
+    "DOWN": 1054,
     "ANCHOR": 195
    },
    "bandPct": {
     "STRETCH": 6.8,
     "UP": 31.2,
-    "EVEN": 17.7,
-    "DOWN": 37.3,
+    "EVEN": 17.1,
+    "DOWN": 37.9,
     "ANCHOR": 7
    },
    "stretchRate": 6.8,
    "anchorRate": 7,
-   "breadth": 0.874,
-   "competitiveRatio": 39.6,
+   "breadth": 0.871,
+   "competitiveRatio": 38.7,
    "winRate": 50.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 40.2,
    "breadth": 0.738,
-   "competitiveRatio": 39.6,
+   "competitiveRatio": 39.4,
    "winRate": 70.5
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 33.9,
    "breadth": 0.792,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42.6,
    "winRate": 61.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 35.5,
    "breadth": 0.753,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 29.2,
    "winRate": 72.5
   },
   {
@@ -199,21 +199,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 33,
-    "EVEN": 76,
-    "DOWN": 132,
+    "EVEN": 66,
+    "DOWN": 142,
     "ANCHOR": 102
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 9.6,
-    "EVEN": 22.2,
-    "DOWN": 38.5,
+    "EVEN": 19.2,
+    "DOWN": 41.4,
     "ANCHOR": 29.7
    },
    "stretchRate": 0,
    "anchorRate": 29.7,
-   "breadth": 0.8,
-   "competitiveRatio": 28.9,
+   "breadth": 0.788,
+   "competitiveRatio": 27.7,
    "winRate": 77.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 13,
    "anchorRate": 7.1,
    "breadth": 0.917,
-   "competitiveRatio": 33.7,
+   "competitiveRatio": 33.1,
    "winRate": 44.6
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 18.9,
    "breadth": 0.806,
-   "competitiveRatio": 36.9,
+   "competitiveRatio": 35.8,
    "winRate": 69.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 19.9,
    "anchorRate": 1.9,
    "breadth": 0.877,
-   "competitiveRatio": 27.9,
+   "competitiveRatio": 26.6,
    "winRate": 42.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 19.7,
    "anchorRate": 12,
    "breadth": 0.948,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 38.6,
    "winRate": 54.8
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 24.5,
    "anchorRate": 0,
    "breadth": 0.785,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.2,
    "winRate": 28.9
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 12.2,
    "anchorRate": 11.9,
    "breadth": 0.9,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 22.4,
    "winRate": 46.6
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 18.4,
    "anchorRate": 20.5,
    "breadth": 0.987,
-   "competitiveRatio": 37.2,
+   "competitiveRatio": 36.5,
    "winRate": 55.3
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 31.3,
    "anchorRate": 0,
    "breadth": 0.833,
-   "competitiveRatio": 22.3,
+   "competitiveRatio": 22.6,
    "winRate": 29.2
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 23.8,
    "anchorRate": 8.3,
    "breadth": 0.932,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 43.7,
    "winRate": 44.8
   },
   {
@@ -496,21 +496,21 @@
    "bands": {
     "STRETCH": 90,
     "UP": 130,
-    "EVEN": 42,
-    "DOWN": 6,
+    "EVEN": 36,
+    "DOWN": 12,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 33.6,
     "UP": 48.5,
-    "EVEN": 15.7,
-    "DOWN": 2.2,
+    "EVEN": 13.4,
+    "DOWN": 4.5,
     "ANCHOR": 0
    },
    "stretchRate": 33.6,
    "anchorRate": 0,
-   "breadth": 0.679,
-   "competitiveRatio": 16.4,
+   "breadth": 0.7,
+   "competitiveRatio": 16,
    "winRate": 21.3
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 29.1,
    "anchorRate": 0,
    "breadth": 0.674,
-   "competitiveRatio": 33.1,
+   "competitiveRatio": 31.5,
    "winRate": 37.8
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 57,
    "anchorRate": 0,
    "breadth": 0.538,
-   "competitiveRatio": 14,
+   "competitiveRatio": 14.4,
    "winRate": 12.4
   }
  ]

--- a/public/data/conferences/new-jersey-athletic-conference.json
+++ b/public/data/conferences/new-jersey-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.7,
    "anchorRate": 18.4,
    "breadth": 0.911,
-   "competitiveRatio": 23.2,
+   "competitiveRatio": 22.4,
    "winRate": 57.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.6,
    "anchorRate": 17.6,
    "breadth": 0.994,
-   "competitiveRatio": 7.4,
+   "competitiveRatio": 6.5,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 2.6,
    "anchorRate": 18.7,
    "breadth": 0.819,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 28.5,
    "winRate": 60.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 25.9,
    "breadth": 0.646,
-   "competitiveRatio": 23.8,
+   "competitiveRatio": 22.9,
    "winRate": 77.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 27,
    "breadth": 0.822,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 43.6,
    "winRate": 68.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 15.9,
    "breadth": 0.806,
-   "competitiveRatio": 13.6,
+   "competitiveRatio": 12.8,
    "winRate": 58.1
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 9.5,
    "anchorRate": 30,
    "breadth": 0.772,
-   "competitiveRatio": 18.6,
+   "competitiveRatio": 17.7,
    "winRate": 59.1
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 11,
    "anchorRate": 0,
    "breadth": 0.753,
-   "competitiveRatio": 14.5,
+   "competitiveRatio": 13.3,
    "winRate": 24.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 29.5,
    "anchorRate": 0,
    "breadth": 0.616,
-   "competitiveRatio": 19.2,
+   "competitiveRatio": 18.6,
    "winRate": 25
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 17.3,
    "anchorRate": 9.1,
    "breadth": 0.952,
-   "competitiveRatio": 11.8,
+   "competitiveRatio": 10.9,
    "winRate": 58.2
   }
  ]

--- a/public/data/conferences/north-atlantic-conference.json
+++ b/public/data/conferences/north-atlantic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.6,
    "anchorRate": 6.8,
    "breadth": 0.897,
-   "competitiveRatio": 19.4,
+   "competitiveRatio": 19.1,
    "winRate": 42.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 10.1,
    "anchorRate": 10.1,
    "breadth": 0.92,
-   "competitiveRatio": 17.9,
+   "competitiveRatio": 17.7,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 11.3,
    "anchorRate": 2.3,
    "breadth": 0.845,
-   "competitiveRatio": 21.5,
+   "competitiveRatio": 21.1,
    "winRate": 31.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.4,
    "anchorRate": 9.1,
    "breadth": 0.585,
-   "competitiveRatio": 25.9,
+   "competitiveRatio": 25.1,
    "winRate": 74.3
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 20.3,
    "breadth": 0.79,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 24,
    "winRate": 53.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.651,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 27.2,
    "winRate": 44.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.52,
-   "competitiveRatio": 23,
+   "competitiveRatio": 22.5,
    "winRate": 31
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 26,
    "breadth": 0.356,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 23.8,
    "winRate": 68.6
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 36.4,
    "anchorRate": 0,
    "breadth": 0.674,
-   "competitiveRatio": 9.5,
+   "competitiveRatio": 7.9,
    "winRate": 23.5
   },
   {

--- a/public/data/conferences/north-coast-atlantic-conference.json
+++ b/public/data/conferences/north-coast-atlantic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 848,
     "UP": 1248,
-    "EVEN": 464,
-    "DOWN": 1590,
+    "EVEN": 428,
+    "DOWN": 1626,
     "ANCHOR": 955
    },
    "bandPct": {
     "STRETCH": 16.6,
     "UP": 24.4,
-    "EVEN": 9.1,
-    "DOWN": 31.1,
+    "EVEN": 8.4,
+    "DOWN": 31.9,
     "ANCHOR": 18.7
    },
    "stretchRate": 16.6,
    "anchorRate": 18.7,
-   "breadth": 0.955,
-   "competitiveRatio": 31.6,
+   "breadth": 0.95,
+   "competitiveRatio": 31.2,
    "winRate": 53.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 27.8,
    "anchorRate": 27.8,
    "breadth": 0.923,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.4,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 335,
     "UP": 873,
-    "EVEN": 392,
-    "DOWN": 1215,
+    "EVEN": 356,
+    "DOWN": 1251,
     "ANCHOR": 442
    },
    "bandPct": {
     "STRETCH": 10.3,
     "UP": 26.8,
-    "EVEN": 12,
-    "DOWN": 37.3,
+    "EVEN": 10.9,
+    "DOWN": 38.4,
     "ANCHOR": 13.6
    },
    "stretchRate": 10.3,
    "anchorRate": 13.6,
-   "breadth": 0.92,
-   "competitiveRatio": 36.3,
+   "breadth": 0.912,
+   "competitiveRatio": 35.7,
    "winRate": 55.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 45.4,
    "breadth": 0.717,
-   "competitiveRatio": 36.3,
+   "competitiveRatio": 34.9,
    "winRate": 80.1
   },
   {
@@ -145,21 +145,21 @@
    "bands": {
     "STRETCH": 59,
     "UP": 107,
-    "EVEN": 40,
-    "DOWN": 147,
+    "EVEN": 34,
+    "DOWN": 153,
     "ANCHOR": 69
    },
    "bandPct": {
     "STRETCH": 14,
     "UP": 25.4,
-    "EVEN": 9.5,
-    "DOWN": 34.8,
+    "EVEN": 8.1,
+    "DOWN": 36.3,
     "ANCHOR": 16.4
    },
    "stretchRate": 14,
    "anchorRate": 16.4,
-   "breadth": 0.938,
-   "competitiveRatio": 41.7,
+   "breadth": 0.926,
+   "competitiveRatio": 40.8,
    "winRate": 55.2
   },
   {
@@ -172,21 +172,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 100,
-    "EVEN": 12,
-    "DOWN": 200,
+    "EVEN": 6,
+    "DOWN": 206,
     "ANCHOR": 96
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 24.5,
-    "EVEN": 2.9,
-    "DOWN": 49,
+    "EVEN": 1.5,
+    "DOWN": 50.5,
     "ANCHOR": 23.5
    },
    "stretchRate": 0,
    "anchorRate": 23.5,
-   "breadth": 0.707,
-   "competitiveRatio": 28.9,
+   "breadth": 0.679,
+   "competitiveRatio": 28.4,
    "winRate": 65.7
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 13.3,
    "anchorRate": 23.6,
    "breadth": 0.869,
-   "competitiveRatio": 42.6,
+   "competitiveRatio": 40.6,
    "winRate": 57.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 36.4,
    "breadth": 0.759,
-   "competitiveRatio": 31.8,
+   "competitiveRatio": 32.3,
    "winRate": 72.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 44.5,
    "breadth": 0.692,
-   "competitiveRatio": 27,
+   "competitiveRatio": 27.2,
    "winRate": 73
   },
   {
@@ -280,21 +280,21 @@
    "bands": {
     "STRETCH": 68,
     "UP": 127,
-    "EVEN": 23,
-    "DOWN": 136,
+    "EVEN": 17,
+    "DOWN": 142,
     "ANCHOR": 16
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 34.3,
-    "EVEN": 6.2,
-    "DOWN": 36.8,
+    "EVEN": 4.6,
+    "DOWN": 38.4,
     "ANCHOR": 4.3
    },
    "stretchRate": 18.4,
    "anchorRate": 4.3,
-   "breadth": 0.842,
-   "competitiveRatio": 25.9,
+   "breadth": 0.822,
+   "competitiveRatio": 26.5,
    "winRate": 47.3
   },
   {
@@ -307,21 +307,21 @@
    "bands": {
     "STRETCH": 30,
     "UP": 112,
-    "EVEN": 42,
-    "DOWN": 132,
+    "EVEN": 36,
+    "DOWN": 138,
     "ANCHOR": 45
    },
    "bandPct": {
     "STRETCH": 8.3,
     "UP": 31,
-    "EVEN": 11.6,
-    "DOWN": 36.6,
+    "EVEN": 10,
+    "DOWN": 38.2,
     "ANCHOR": 12.5
    },
    "stretchRate": 8.3,
    "anchorRate": 12.5,
-   "breadth": 0.899,
-   "competitiveRatio": 39.7,
+   "breadth": 0.887,
+   "competitiveRatio": 38.6,
    "winRate": 47.4
   },
   {
@@ -334,21 +334,21 @@
    "bands": {
     "STRETCH": 51,
     "UP": 136,
-    "EVEN": 54,
-    "DOWN": 41,
+    "EVEN": 42,
+    "DOWN": 53,
     "ANCHOR": 27
    },
    "bandPct": {
     "STRETCH": 16.5,
     "UP": 44,
-    "EVEN": 17.5,
-    "DOWN": 13.3,
+    "EVEN": 13.6,
+    "DOWN": 17.2,
     "ANCHOR": 8.7
    },
    "stretchRate": 16.5,
    "anchorRate": 8.7,
-   "breadth": 0.897,
-   "competitiveRatio": 26.2,
+   "breadth": 0.898,
+   "competitiveRatio": 26.9,
    "winRate": 34
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 13.5,
    "anchorRate": 7.9,
    "breadth": 0.814,
-   "competitiveRatio": 26.1,
+   "competitiveRatio": 25.7,
    "winRate": 45.2
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 22.1,
    "anchorRate": 6.4,
    "breadth": 0.938,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 38.3,
    "winRate": 52
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 28.4,
    "anchorRate": 4.4,
    "breadth": 0.899,
-   "competitiveRatio": 34.4,
+   "competitiveRatio": 34.1,
    "winRate": 36.2
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 13.9,
    "anchorRate": 10,
    "breadth": 0.952,
-   "competitiveRatio": 20.5,
+   "competitiveRatio": 19.3,
    "winRate": 45.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 83.3,
    "anchorRate": 0,
    "breadth": 0.332,
-   "competitiveRatio": 21.4,
+   "competitiveRatio": 21,
    "winRate": 10.7
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 76.8,
    "anchorRate": 0,
    "breadth": 0.336,
-   "competitiveRatio": 17.7,
+   "competitiveRatio": 19.7,
    "winRate": 34
   }
  ]

--- a/public/data/conferences/northeast-10-conference.json
+++ b/public/data/conferences/northeast-10-conference.json
@@ -32,7 +32,7 @@
    "stretchRate": 7.7,
    "anchorRate": 4.3,
    "breadth": 0.85,
-   "competitiveRatio": 39,
+   "competitiveRatio": 38.4,
    "winRate": 48.5
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 1.5,
    "anchorRate": 1.5,
    "breadth": 0.738,
-   "competitiveRatio": 42.3,
+   "competitiveRatio": 41.9,
    "winRate": 50
   },
   "nonConference": {
@@ -76,7 +76,7 @@
    "stretchRate": 16.3,
    "anchorRate": 8.1,
    "breadth": 0.921,
-   "competitiveRatio": 34.3,
+   "competitiveRatio": 33.6,
    "winRate": 46.3
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 4.9,
    "anchorRate": 14.8,
    "breadth": 0.908,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 46.2,
    "winRate": 50
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 3.3,
    "anchorRate": 2.5,
    "breadth": 0.548,
-   "competitiveRatio": 33.7,
+   "competitiveRatio": 34,
    "winRate": 62.1
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 5.2,
    "anchorRate": 5.2,
    "breadth": 0.686,
-   "competitiveRatio": 45,
+   "competitiveRatio": 44.1,
    "winRate": 63
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 9.3,
    "anchorRate": 5.6,
    "breadth": 0.882,
-   "competitiveRatio": 51.2,
+   "competitiveRatio": 50.3,
    "winRate": 49.4
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 14.5,
    "anchorRate": 0,
    "breadth": 0.665,
-   "competitiveRatio": 52.6,
+   "competitiveRatio": 51.9,
    "winRate": 38.1
   },
   {
@@ -268,7 +268,7 @@
    "stretchRate": 0,
    "anchorRate": 8,
    "breadth": 0.559,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 35.5,
    "winRate": 63.9
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 9.7,
    "anchorRate": 2.1,
    "breadth": 0.74,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 43.4,
    "winRate": 33.3
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 4.2,
    "anchorRate": 0,
    "breadth": 0.714,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 47.9,
    "winRate": 44.9
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 0,
    "anchorRate": 1.5,
    "breadth": 0.713,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 23.6,
    "winRate": 34.8
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 26.1,
    "anchorRate": 0,
    "breadth": 0.804,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 31.1,
    "winRate": 39.3
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 5.2,
    "anchorRate": 13.5,
    "breadth": 0.801,
-   "competitiveRatio": 33.9,
+   "competitiveRatio": 33.1,
    "winRate": 62.3
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 2.7,
    "anchorRate": 0,
    "breadth": 0.735,
-   "competitiveRatio": 21.5,
+   "competitiveRatio": 21.1,
    "winRate": 42.9
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 23.1,
    "anchorRate": 0,
    "breadth": 0.485,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 24,
    "winRate": 22.6
   }
  ]

--- a/public/data/conferences/northeast-conference.json
+++ b/public/data/conferences/northeast-conference.json
@@ -32,7 +32,7 @@
    "stretchRate": 6.5,
    "anchorRate": 4.8,
    "breadth": 0.852,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 43.5,
    "winRate": 44.5
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.681,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 47.5,
    "winRate": 50
   },
   "nonConference": {
@@ -76,7 +76,7 @@
    "stretchRate": 9.9,
    "anchorRate": 7.3,
    "breadth": 0.88,
-   "competitiveRatio": 42.3,
+   "competitiveRatio": 41.4,
    "winRate": 41.7
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 9.4,
    "anchorRate": 6.8,
    "breadth": 0.861,
-   "competitiveRatio": 51.6,
+   "competitiveRatio": 46.2,
    "winRate": 49.6
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 4.9,
    "anchorRate": 5.9,
    "breadth": 0.755,
-   "competitiveRatio": 44.4,
+   "competitiveRatio": 44.7,
    "winRate": 61.6
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 2,
    "anchorRate": 6.7,
    "breadth": 0.83,
-   "competitiveRatio": 56.1,
+   "competitiveRatio": 55.5,
    "winRate": 45.1
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 6.6,
    "anchorRate": 4.8,
    "breadth": 0.856,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 46.3,
    "winRate": 34.9
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 4.7,
    "anchorRate": 12.3,
    "breadth": 0.813,
-   "competitiveRatio": 39.9,
+   "competitiveRatio": 38.7,
    "winRate": 39
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 2.3,
    "anchorRate": 0,
    "breadth": 0.708,
-   "competitiveRatio": 50.2,
+   "competitiveRatio": 49.2,
    "winRate": 54
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 5,
    "anchorRate": 0,
    "breadth": 0.741,
-   "competitiveRatio": 42.7,
+   "competitiveRatio": 42.3,
    "winRate": 43.2
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 9,
    "anchorRate": 0,
    "breadth": 0.63,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 40.1,
    "winRate": 46.2
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 11.2,
    "anchorRate": 5.8,
    "breadth": 0.891,
-   "competitiveRatio": 51,
+   "competitiveRatio": 50.3,
    "winRate": 42.9
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 6.3,
    "anchorRate": 0.7,
    "breadth": 0.792,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 47,
    "winRate": 49
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 6.4,
    "anchorRate": 10.7,
    "breadth": 0.786,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.6,
    "winRate": 52.7
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 8.5,
    "anchorRate": 17.8,
    "breadth": 0.938,
-   "competitiveRatio": 47,
+   "competitiveRatio": 45.9,
    "winRate": 52.3
   },
   {
@@ -538,7 +538,7 @@
    "stretchRate": 5.6,
    "anchorRate": 2.2,
    "breadth": 0.782,
-   "competitiveRatio": 40.4,
+   "competitiveRatio": 39.6,
    "winRate": 38.4
   }
  ]

--- a/public/data/conferences/northern-athletic-collegiate-conference.json
+++ b/public/data/conferences/northern-athletic-collegiate-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 739,
     "UP": 2019,
-    "EVEN": 515,
-    "DOWN": 1166,
+    "EVEN": 503,
+    "DOWN": 1178,
     "ANCHOR": 316
    },
    "bandPct": {
     "STRETCH": 15.5,
     "UP": 42.5,
-    "EVEN": 10.8,
-    "DOWN": 24.5,
+    "EVEN": 10.6,
+    "DOWN": 24.8,
     "ANCHOR": 6.6
    },
    "stretchRate": 15.5,
    "anchorRate": 6.6,
-   "breadth": 0.881,
-   "competitiveRatio": 27.3,
+   "breadth": 0.88,
+   "competitiveRatio": 27.1,
    "winRate": 40.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 12.3,
    "anchorRate": 12.3,
    "breadth": 0.912,
-   "competitiveRatio": 22.2,
+   "competitiveRatio": 22,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 467,
     "UP": 1287,
-    "EVEN": 309,
-    "DOWN": 434,
+    "EVEN": 297,
+    "DOWN": 446,
     "ANCHOR": 44
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 50.6,
-    "EVEN": 12.2,
-    "DOWN": 17.1,
+    "EVEN": 11.7,
+    "DOWN": 17.6,
     "ANCHOR": 1.7
    },
    "stretchRate": 18.4,
    "anchorRate": 1.7,
-   "breadth": 0.798,
-   "competitiveRatio": 31.8,
+   "breadth": 0.797,
+   "competitiveRatio": 31.6,
    "winRate": 32.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -118,21 +118,21 @@
    "bands": {
     "STRETCH": 24,
     "UP": 108,
-    "EVEN": 115,
-    "DOWN": 135,
+    "EVEN": 103,
+    "DOWN": 147,
     "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 5.6,
     "UP": 25.1,
-    "EVEN": 26.7,
-    "DOWN": 31.4,
+    "EVEN": 24,
+    "DOWN": 34.2,
     "ANCHOR": 11.2
    },
    "stretchRate": 5.6,
    "anchorRate": 11.2,
-   "breadth": 0.913,
-   "competitiveRatio": 28.2,
+   "breadth": 0.908,
+   "competitiveRatio": 27.5,
    "winRate": 64.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 25.2,
    "anchorRate": 0,
    "breadth": 0.708,
-   "competitiveRatio": 25.5,
+   "competitiveRatio": 24.7,
    "winRate": 45.2
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 5.5,
    "anchorRate": 17.8,
    "breadth": 0.911,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36.4,
    "winRate": 60
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 19.9,
    "anchorRate": 0,
    "breadth": 0.703,
-   "competitiveRatio": 28.2,
+   "competitiveRatio": 27.6,
    "winRate": 28.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 1.8,
    "anchorRate": 13.8,
    "breadth": 0.806,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 29.9,
    "winRate": 41.3
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 1.8,
    "anchorRate": 12.7,
    "breadth": 0.846,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 39.2,
    "winRate": 56.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 1.8,
    "anchorRate": 17.6,
    "breadth": 0.828,
-   "competitiveRatio": 39,
+   "competitiveRatio": 38.7,
    "winRate": 57.8
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 4,
    "anchorRate": 6,
    "breadth": 0.815,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 21.9,
    "winRate": 40.2
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 9.4,
    "anchorRate": 0,
    "breadth": 0.665,
-   "competitiveRatio": 17.3,
+   "competitiveRatio": 16.9,
    "winRate": 33.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.661,
-   "competitiveRatio": 19,
+   "competitiveRatio": 19.4,
    "winRate": 16.5
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 48.3,
    "anchorRate": 0,
    "breadth": 0.563,
-   "competitiveRatio": 17.8,
+   "competitiveRatio": 17.4,
    "winRate": 11.6
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 13,
    "anchorRate": 0,
    "breadth": 0.561,
-   "competitiveRatio": 23.6,
+   "competitiveRatio": 23.1,
    "winRate": 39.1
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 65.2,
    "anchorRate": 0,
    "breadth": 0.402,
-   "competitiveRatio": 23.1,
+   "competitiveRatio": 23.5,
    "winRate": 20.8
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 43.8,
    "anchorRate": 0,
    "breadth": 0.579,
-   "competitiveRatio": 13,
+   "competitiveRatio": 13.6,
    "winRate": 7.9
   },
   {

--- a/public/data/conferences/northern-sun-intercollegiate-conference.json
+++ b/public/data/conferences/northern-sun-intercollegiate-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 400,
     "UP": 1167,
-    "EVEN": 471,
-    "DOWN": 967,
+    "EVEN": 432,
+    "DOWN": 1006,
     "ANCHOR": 202
    },
    "bandPct": {
     "STRETCH": 12.5,
     "UP": 36.4,
-    "EVEN": 14.7,
-    "DOWN": 30.2,
+    "EVEN": 13.5,
+    "DOWN": 31.4,
     "ANCHOR": 6.3
    },
    "stretchRate": 12.5,
    "anchorRate": 6.3,
-   "breadth": 0.898,
+   "breadth": 0.892,
    "competitiveRatio": 33.2,
    "winRate": 47.1
   },
@@ -39,21 +39,21 @@
    "bands": {
     "STRETCH": 141,
     "UP": 680,
-    "EVEN": 290,
-    "DOWN": 680,
+    "EVEN": 251,
+    "DOWN": 719,
     "ANCHOR": 141
    },
    "bandPct": {
     "STRETCH": 7.3,
     "UP": 35.2,
-    "EVEN": 15,
-    "DOWN": 35.2,
+    "EVEN": 13,
+    "DOWN": 37.2,
     "ANCHOR": 7.3
    },
    "stretchRate": 7.3,
    "anchorRate": 7.3,
-   "breadth": 0.871,
-   "competitiveRatio": 32.5,
+   "breadth": 0.859,
+   "competitiveRatio": 32.6,
    "winRate": 50
   },
   "nonConference": {
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 17.4,
    "anchorRate": 1.6,
    "breadth": 0.845,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 31.6,
    "winRate": 41
   },
   {
@@ -172,20 +172,20 @@
    "bands": {
     "STRETCH": 87,
     "UP": 118,
-    "EVEN": 81,
-    "DOWN": 35,
+    "EVEN": 42,
+    "DOWN": 74,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 27.1,
     "UP": 36.8,
-    "EVEN": 25.2,
-    "DOWN": 10.9,
+    "EVEN": 13.1,
+    "DOWN": 23.1,
     "ANCHOR": 0
    },
    "stretchRate": 27.1,
    "anchorRate": 0,
-   "breadth": 0.814,
+   "breadth": 0.824,
    "competitiveRatio": 31.2,
    "winRate": 45.2
   },
@@ -213,7 +213,7 @@
    "stretchRate": 9.4,
    "anchorRate": 0,
    "breadth": 0.798,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 37.4,
    "winRate": 39.4
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 15.3,
    "anchorRate": 0,
    "breadth": 0.757,
-   "competitiveRatio": 34.9,
+   "competitiveRatio": 34.2,
    "winRate": 44.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.469,
-   "competitiveRatio": 38.9,
+   "competitiveRatio": 41.6,
    "winRate": 58.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 16.8,
    "anchorRate": 2.2,
    "breadth": 0.849,
-   "competitiveRatio": 31.6,
+   "competitiveRatio": 31.2,
    "winRate": 50.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 19.7,
    "anchorRate": 9.6,
    "breadth": 0.804,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 39.8,
    "winRate": 45.8
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 7,
    "breadth": 0.454,
-   "competitiveRatio": 31.2,
+   "competitiveRatio": 30.7,
    "winRate": 29.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 16.7,
    "anchorRate": 0,
    "breadth": 0.844,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25,
    "winRate": 54.2
   }
  ]

--- a/public/data/conferences/northwest-conference.json
+++ b/public/data/conferences/northwest-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.1,
    "anchorRate": 4.9,
    "breadth": 0.877,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 33.2,
    "winRate": 45.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 6.3,
    "anchorRate": 6.3,
    "breadth": 0.841,
-   "competitiveRatio": 33.4,
+   "competitiveRatio": 32.8,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 20.8,
    "anchorRate": 2.7,
    "breadth": 0.889,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 33.9,
    "winRate": 38.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 5.3,
    "anchorRate": 21.2,
    "breadth": 0.873,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 37.5,
    "winRate": 56.7
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 16,
    "anchorRate": 0,
    "breadth": 0.667,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 36.5,
    "winRate": 40.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 1.6,
    "breadth": 0.642,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 30.4,
    "winRate": 58.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.7,
    "anchorRate": 8,
    "breadth": 0.771,
-   "competitiveRatio": 35.3,
+   "competitiveRatio": 33.9,
    "winRate": 50.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 21.8,
    "anchorRate": 0,
    "breadth": 0.85,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 36.8,
    "winRate": 51.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 9.1,
    "anchorRate": 1.8,
    "breadth": 0.845,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.1,
    "winRate": 51.8
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 28,
    "anchorRate": 0,
    "breadth": 0.85,
-   "competitiveRatio": 38.4,
+   "competitiveRatio": 37.2,
    "winRate": 32.1
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 1.9,
    "anchorRate": 0,
    "breadth": 0.624,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 31.6,
    "winRate": 55.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 2,
    "anchorRate": 0,
    "breadth": 0.668,
-   "competitiveRatio": 36.2,
+   "competitiveRatio": 35.5,
    "winRate": 53.1
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 44.4,
    "anchorRate": 0,
    "breadth": 0.592,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 24.7,
    "winRate": 19.4
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 23,
    "anchorRate": 0,
    "breadth": 0.636,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 26.1,
    "winRate": 18.8
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 16.1,
    "anchorRate": 0,
    "breadth": 0.473,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 38.7,
    "winRate": 25.7
   }
  ]

--- a/public/data/conferences/ohio-athletic-conference.json
+++ b/public/data/conferences/ohio-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.3,
    "anchorRate": 6.4,
    "breadth": 0.9,
-   "competitiveRatio": 29.3,
+   "competitiveRatio": 29.2,
    "winRate": 49
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 8.1,
    "anchorRate": 8.1,
    "breadth": 0.916,
-   "competitiveRatio": 22.2,
+   "competitiveRatio": 22.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 11.3,
    "anchorRate": 5.7,
    "breadth": 0.875,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 32.1,
    "winRate": 48.5
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.4,
    "anchorRate": 13.4,
    "breadth": 0.638,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 24.9,
    "winRate": 72.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 2.7,
    "anchorRate": 8.4,
    "breadth": 0.781,
-   "competitiveRatio": 44.7,
+   "competitiveRatio": 44.2,
    "winRate": 59.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 11.7,
    "anchorRate": 5.9,
    "breadth": 0.915,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.9,
    "winRate": 46.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 17.3,
    "anchorRate": 0,
    "breadth": 0.792,
-   "competitiveRatio": 21.2,
+   "competitiveRatio": 20.9,
    "winRate": 53.3
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 26.3,
    "anchorRate": 0,
    "breadth": 0.817,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.8,
    "winRate": 27
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 18.6,
    "anchorRate": 0,
    "breadth": 0.845,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 26.6,
    "winRate": 36.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 14.4,
    "anchorRate": 2.4,
    "breadth": 0.667,
-   "competitiveRatio": 21.7,
+   "competitiveRatio": 22.1,
    "winRate": 28.8
   },
   {

--- a/public/data/conferences/ohio-valley-conference.json
+++ b/public/data/conferences/ohio-valley-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.4,
    "anchorRate": 8.9,
    "breadth": 0.911,
-   "competitiveRatio": 40,
+   "competitiveRatio": 38.8,
    "winRate": 43.7
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 3.3,
    "anchorRate": 3.3,
    "breadth": 0.789,
-   "competitiveRatio": 42,
+   "competitiveRatio": 41.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 13.4,
    "anchorRate": 11.3,
    "breadth": 0.94,
-   "competitiveRatio": 39.2,
+   "competitiveRatio": 37.6,
    "winRate": 41
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.7,
    "anchorRate": 16,
    "breadth": 0.772,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49,
    "winRate": 54.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 5,
    "anchorRate": 3.4,
    "breadth": 0.77,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 37.8,
    "winRate": 49.8
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 3.9,
    "breadth": 0.754,
-   "competitiveRatio": 42.8,
+   "competitiveRatio": 42.2,
    "winRate": 35.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 49.8,
    "anchorRate": 0,
    "breadth": 0.534,
-   "competitiveRatio": 31.8,
+   "competitiveRatio": 31.1,
    "winRate": 17.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1,
    "anchorRate": 28.6,
    "breadth": 0.579,
-   "competitiveRatio": 38.4,
+   "competitiveRatio": 37,
    "winRate": 73.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 13.4,
    "anchorRate": 6,
    "breadth": 0.582,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 31.3,
    "winRate": 31.3
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2.4,
    "anchorRate": 2.4,
    "breadth": 0.789,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41,
    "winRate": 38.6
   }
  ]

--- a/public/data/conferences/old-dominion-athletic-conference.json
+++ b/public/data/conferences/old-dominion-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 11.2,
    "anchorRate": 10.9,
    "breadth": 0.926,
-   "competitiveRatio": 28.8,
+   "competitiveRatio": 28.4,
    "winRate": 50.7
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 12,
    "anchorRate": 12,
    "breadth": 0.946,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 24.9,
    "winRate": 50
   },
   "nonConference": {
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 16.9,
    "anchorRate": 10.6,
    "breadth": 0.843,
-   "competitiveRatio": 37.7,
+   "competitiveRatio": 38.2,
    "winRate": 57.7
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 1.3,
    "anchorRate": 6.8,
    "breadth": 0.819,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 43.4,
    "winRate": 51.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 53.2,
    "breadth": 0.688,
-   "competitiveRatio": 21.7,
+   "competitiveRatio": 20.9,
    "winRate": 82.4
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 9.1,
    "anchorRate": 11.3,
    "breadth": 0.915,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 27.4,
    "winRate": 47.2
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 14,
    "anchorRate": 5,
    "breadth": 0.861,
-   "competitiveRatio": 35.3,
+   "competitiveRatio": 34.4,
    "winRate": 50.1
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 8.7,
    "anchorRate": 10.5,
    "breadth": 0.921,
-   "competitiveRatio": 24.7,
+   "competitiveRatio": 23.8,
    "winRate": 60.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 12.2,
    "breadth": 0.571,
-   "competitiveRatio": 22,
+   "competitiveRatio": 21.1,
    "winRate": 71.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 3.7,
    "anchorRate": 9.5,
    "breadth": 0.873,
-   "competitiveRatio": 36.6,
+   "competitiveRatio": 36.9,
    "winRate": 60
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 0,
    "anchorRate": 20.6,
    "breadth": 0.783,
-   "competitiveRatio": 38.9,
+   "competitiveRatio": 38,
    "winRate": 62.7
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 4.8,
    "anchorRate": 10.3,
    "breadth": 0.884,
-   "competitiveRatio": 37.4,
+   "competitiveRatio": 37.1,
    "winRate": 61.6
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 4,
    "anchorRate": 0,
    "breadth": 0.683,
-   "competitiveRatio": 35.1,
+   "competitiveRatio": 34.8,
    "winRate": 42.1
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 5,
    "anchorRate": 13.7,
    "breadth": 0.916,
-   "competitiveRatio": 26.8,
+   "competitiveRatio": 27.4,
    "winRate": 53.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 8.1,
    "anchorRate": 4.1,
    "breadth": 0.768,
-   "competitiveRatio": 27.2,
+   "competitiveRatio": 27.6,
    "winRate": 37.2
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 51.2,
    "anchorRate": 0,
    "breadth": 0.652,
-   "competitiveRatio": 24.2,
+   "competitiveRatio": 23.2,
    "winRate": 38.8
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 2.1,
    "anchorRate": 10.3,
    "breadth": 0.857,
-   "competitiveRatio": 24.9,
+   "competitiveRatio": 24.2,
    "winRate": 45.7
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 4.3,
    "anchorRate": 10.5,
    "breadth": 0.817,
-   "competitiveRatio": 26.8,
+   "competitiveRatio": 25.7,
    "winRate": 52.5
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 6.3,
    "anchorRate": 10.3,
    "breadth": 0.901,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 25.5,
    "winRate": 46.9
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 10.3,
    "anchorRate": 16.1,
    "breadth": 0.793,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 25.5,
    "winRate": 52.9
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 9.5,
    "anchorRate": 4.3,
    "breadth": 0.687,
-   "competitiveRatio": 16,
+   "competitiveRatio": 15.6,
    "winRate": 11.6
   },
   {

--- a/public/data/conferences/orange-empire-conference.json
+++ b/public/data/conferences/orange-empire-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 14.5,
    "anchorRate": 11.9,
    "breadth": 0.904,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.7,
    "winRate": 57.5
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 11.8,
    "anchorRate": 7.8,
    "breadth": 0.886,
-   "competitiveRatio": 28,
+   "competitiveRatio": 27.3,
    "winRate": 61.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 5.9,
    "anchorRate": 15.1,
    "breadth": 0.895,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 34.4,
    "winRate": 69.8
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 17.3,
    "anchorRate": 0,
    "breadth": 0.794,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 24.2,
    "winRate": 41.9
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 10.4,
    "breadth": 0.762,
-   "competitiveRatio": 24.6,
+   "competitiveRatio": 23.7,
    "winRate": 74.3
   },
   {

--- a/public/data/conferences/pacific-coast-athletic-conference.json
+++ b/public/data/conferences/pacific-coast-athletic-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 3,
    "anchorRate": 16.7,
    "breadth": 0.887,
-   "competitiveRatio": 22,
+   "competitiveRatio": 21.4,
    "winRate": 52.2
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 6.8,
    "anchorRate": 6.8,
    "breadth": 0.858,
-   "competitiveRatio": 19.8,
+   "competitiveRatio": 18.5,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 2,
    "anchorRate": 19.4,
    "breadth": 0.836,
-   "competitiveRatio": 22.7,
+   "competitiveRatio": 22.1,
    "winRate": 52.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 11.5,
    "breadth": 0.79,
-   "competitiveRatio": 22,
+   "competitiveRatio": 21.6,
    "winRate": 64.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 13.5,
    "breadth": 0.818,
-   "competitiveRatio": 26.6,
+   "competitiveRatio": 25.3,
    "winRate": 44.9
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 23.7,
    "anchorRate": 0,
    "breadth": 0.474,
-   "competitiveRatio": 13.4,
+   "competitiveRatio": 11.3,
    "winRate": 10.3
   }
  ]

--- a/public/data/conferences/pacific-west-conference.json
+++ b/public/data/conferences/pacific-west-conference.json
@@ -32,7 +32,7 @@
    "stretchRate": 11.2,
    "anchorRate": 11.5,
    "breadth": 0.923,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 39.3,
    "winRate": 50.8
   },
   "inConference": {
@@ -54,7 +54,7 @@
    "stretchRate": 8.7,
    "anchorRate": 8.7,
    "breadth": 0.889,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 41.1,
    "winRate": 50
   },
   "nonConference": {
@@ -76,7 +76,7 @@
    "stretchRate": 16.3,
    "anchorRate": 17,
    "breadth": 0.963,
-   "competitiveRatio": 36.6,
+   "competitiveRatio": 35.7,
    "winRate": 52.3
   }
  },
@@ -85,21 +85,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -133,7 +133,7 @@
    "stretchRate": 0,
    "anchorRate": 15.5,
    "breadth": 0.671,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 37.1,
    "winRate": 48
   },
   {
@@ -160,7 +160,7 @@
    "stretchRate": 0,
    "anchorRate": 18.2,
    "breadth": 0.728,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 42.9,
    "winRate": 74
   },
   {
@@ -187,7 +187,7 @@
    "stretchRate": 0,
    "anchorRate": 19.7,
    "breadth": 0.562,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 37.6,
    "winRate": 78.4
   },
   {
@@ -214,7 +214,7 @@
    "stretchRate": 2.9,
    "anchorRate": 10.7,
    "breadth": 0.876,
-   "competitiveRatio": 47.9,
+   "competitiveRatio": 47.3,
    "winRate": 67.1
   },
   {
@@ -241,7 +241,7 @@
    "stretchRate": 0,
    "anchorRate": 17.5,
    "breadth": 0.783,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 43.8,
    "winRate": 63.9
   },
   {
@@ -268,7 +268,7 @@
    "stretchRate": 7.8,
    "anchorRate": 2.6,
    "breadth": 0.748,
-   "competitiveRatio": 30.9,
+   "competitiveRatio": 29.8,
    "winRate": 23.3
   },
   {
@@ -295,7 +295,7 @@
    "stretchRate": 14.1,
    "anchorRate": 5,
    "breadth": 0.836,
-   "competitiveRatio": 43.7,
+   "competitiveRatio": 43.4,
    "winRate": 41.6
   },
   {
@@ -322,7 +322,7 @@
    "stretchRate": 5.2,
    "anchorRate": 14.9,
    "breadth": 0.915,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 42.6,
    "winRate": 54.7
   },
   {
@@ -349,7 +349,7 @@
    "stretchRate": 3.8,
    "anchorRate": 16.5,
    "breadth": 0.88,
-   "competitiveRatio": 28.6,
+   "competitiveRatio": 28.3,
    "winRate": 39.4
   },
   {
@@ -376,7 +376,7 @@
    "stretchRate": 0,
    "anchorRate": 31.7,
    "breadth": 0.672,
-   "competitiveRatio": 55.9,
+   "competitiveRatio": 55.6,
    "winRate": 62.2
   },
   {
@@ -403,7 +403,7 @@
    "stretchRate": 5.8,
    "anchorRate": 20.3,
    "breadth": 0.926,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 30.5,
    "winRate": 59.8
   },
   {
@@ -430,7 +430,7 @@
    "stretchRate": 0,
    "anchorRate": 17.5,
    "breadth": 0.76,
-   "competitiveRatio": 48.5,
+   "competitiveRatio": 46.9,
    "winRate": 42.5
   },
   {
@@ -457,7 +457,7 @@
    "stretchRate": 34.7,
    "anchorRate": 10.3,
    "breadth": 0.885,
-   "competitiveRatio": 47.4,
+   "competitiveRatio": 47.1,
    "winRate": 49.8
   },
   {
@@ -484,7 +484,7 @@
    "stretchRate": 16.9,
    "anchorRate": 6.2,
    "breadth": 0.817,
-   "competitiveRatio": 27.9,
+   "competitiveRatio": 26.9,
    "winRate": 46.2
   },
   {
@@ -511,7 +511,7 @@
    "stretchRate": 69,
    "anchorRate": 0,
    "breadth": 0.461,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 37.2,
    "winRate": 54.1
   },
   {
@@ -538,7 +538,7 @@
    "stretchRate": 2.1,
    "anchorRate": 0,
    "breadth": 0.673,
-   "competitiveRatio": 54.2,
+   "competitiveRatio": 55.6,
    "winRate": 52.1
   },
   {
@@ -565,7 +565,7 @@
    "stretchRate": 1.1,
    "anchorRate": 4.3,
    "breadth": 0.76,
-   "competitiveRatio": 51.1,
+   "competitiveRatio": 50,
    "winRate": 56
   },
   {
@@ -592,7 +592,7 @@
    "stretchRate": 0,
    "anchorRate": 19.5,
    "breadth": 0.648,
-   "competitiveRatio": 38.5,
+   "competitiveRatio": 36.6,
    "winRate": 49.2
   },
   {
@@ -619,7 +619,7 @@
    "stretchRate": 8.7,
    "anchorRate": 8.7,
    "breadth": 0.821,
-   "competitiveRatio": 43,
+   "competitiveRatio": 41.7,
    "winRate": 59.5
   },
   {
@@ -646,7 +646,7 @@
    "stretchRate": 0,
    "anchorRate": 1.3,
    "breadth": 0.635,
-   "competitiveRatio": 53.3,
+   "competitiveRatio": 51.7,
    "winRate": 50.4
   },
   {
@@ -673,7 +673,7 @@
    "stretchRate": 19.6,
    "anchorRate": 2.6,
    "breadth": 0.792,
-   "competitiveRatio": 28.8,
+   "competitiveRatio": 28.4,
    "winRate": 20
   },
   {
@@ -700,7 +700,7 @@
    "stretchRate": 2.6,
    "anchorRate": 13.7,
    "breadth": 0.835,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 34.4,
    "winRate": 60.4
   },
   {
@@ -727,7 +727,7 @@
    "stretchRate": 40,
    "anchorRate": 0,
    "breadth": 0.784,
-   "competitiveRatio": 25.8,
+   "competitiveRatio": 24.9,
    "winRate": 16.9
   },
   {

--- a/public/data/conferences/patriot-league.json
+++ b/public/data/conferences/patriot-league.json
@@ -31,7 +31,7 @@
    "stretchRate": 7.7,
    "anchorRate": 6.7,
    "breadth": 0.852,
-   "competitiveRatio": 43,
+   "competitiveRatio": 42.5,
    "winRate": 49.8
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 7.7,
    "anchorRate": 7.7,
    "breadth": 0.809,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 38.2,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 7.7,
    "anchorRate": 6.3,
    "breadth": 0.865,
-   "competitiveRatio": 45,
+   "competitiveRatio": 44.6,
    "winRate": 49.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 5.8,
    "anchorRate": 16.6,
    "breadth": 0.832,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 44.8,
    "winRate": 57
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0.6,
    "anchorRate": 8,
    "breadth": 0.589,
-   "competitiveRatio": 40.4,
+   "competitiveRatio": 40.8,
    "winRate": 66.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 12.3,
    "anchorRate": 0,
    "breadth": 0.739,
-   "competitiveRatio": 46.9,
+   "competitiveRatio": 46.6,
    "winRate": 65.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 8.3,
    "breadth": 0.771,
-   "competitiveRatio": 47.6,
+   "competitiveRatio": 46.4,
    "winRate": 44.2
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 13.5,
    "breadth": 0.724,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 27.7,
    "winRate": 66
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 7,
    "anchorRate": 7,
    "breadth": 0.867,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 43,
    "winRate": 46.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 3.5,
    "anchorRate": 3.8,
    "breadth": 0.733,
-   "competitiveRatio": 43.4,
+   "competitiveRatio": 42.3,
    "winRate": 53.1
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 3.6,
    "anchorRate": 3.9,
    "breadth": 0.739,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 49.7,
    "winRate": 53.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 12.5,
    "breadth": 0.706,
-   "competitiveRatio": 48.9,
+   "competitiveRatio": 48.6,
    "winRate": 55.4
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 12.4,
    "breadth": 0.823,
-   "competitiveRatio": 42.4,
+   "competitiveRatio": 41.8,
    "winRate": 57
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 17.8,
    "anchorRate": 3.6,
    "breadth": 0.769,
-   "competitiveRatio": 41.7,
+   "competitiveRatio": 42.1,
    "winRate": 32
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 5.1,
    "anchorRate": 1.7,
    "breadth": 0.67,
-   "competitiveRatio": 39.5,
+   "competitiveRatio": 38.4,
    "winRate": 39.2
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 3.2,
    "anchorRate": 1.4,
    "breadth": 0.703,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 47.7,
    "winRate": 46.2
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 21.2,
    "anchorRate": 2.2,
    "breadth": 0.873,
-   "competitiveRatio": 49.3,
+   "competitiveRatio": 48.9,
    "winRate": 39.8
   },
   {

--- a/public/data/conferences/peach-belt-conference.json
+++ b/public/data/conferences/peach-belt-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 4,
    "anchorRate": 9.4,
    "breadth": 0.839,
-   "competitiveRatio": 46.3,
+   "competitiveRatio": 44.9,
    "winRate": 58.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 9.1,
    "anchorRate": 9.1,
    "breadth": 0.836,
-   "competitiveRatio": 45.7,
+   "competitiveRatio": 45.1,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 1.1,
    "anchorRate": 9.6,
    "breadth": 0.802,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 44.8,
    "winRate": 62.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 7.2,
    "breadth": 0.624,
-   "competitiveRatio": 43.5,
+   "competitiveRatio": 43.1,
    "winRate": 73.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 9.7,
    "breadth": 0.744,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 40.6,
    "winRate": 68.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 23.1,
    "breadth": 0.49,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 44.6,
    "winRate": 78.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 5.5,
    "breadth": 0.594,
-   "competitiveRatio": 55.9,
+   "competitiveRatio": 51.5,
    "winRate": 63.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 7.6,
    "breadth": 0.732,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 42.4,
    "winRate": 55.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 7.6,
    "breadth": 0.609,
-   "competitiveRatio": 43.7,
+   "competitiveRatio": 41.3,
    "winRate": 68
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 6.8,
    "breadth": 0.684,
-   "competitiveRatio": 56.4,
+   "competitiveRatio": 57.3,
    "winRate": 57.1
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 15.6,
    "breadth": 0.713,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 53.3,
    "winRate": 60.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 9.3,
    "anchorRate": 5.3,
    "breadth": 0.867,
-   "competitiveRatio": 57.1,
+   "competitiveRatio": 55.9,
    "winRate": 55.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 8.9,
    "breadth": 0.743,
-   "competitiveRatio": 37.1,
+   "competitiveRatio": 35.9,
    "winRate": 39
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 6.8,
    "anchorRate": 5.8,
    "breadth": 0.825,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 48.4,
    "winRate": 38.3
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 14.6,
    "breadth": 0.807,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42.3,
    "winRate": 53.5
   },
   {

--- a/public/data/conferences/pennsylvania-state-athletic-conference.json
+++ b/public/data/conferences/pennsylvania-state-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.7,
    "anchorRate": 8.1,
    "breadth": 0.914,
-   "competitiveRatio": 31.8,
+   "competitiveRatio": 31.2,
    "winRate": 46.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 14,
    "anchorRate": 14,
    "breadth": 0.967,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.8,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 11.9,
    "anchorRate": 4.1,
    "breadth": 0.855,
-   "competitiveRatio": 35.6,
+   "competitiveRatio": 34.9,
    "winRate": 43.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 20.8,
    "breadth": 0.845,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 34.4,
    "winRate": 65.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 29.1,
    "breadth": 0.848,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 29.9,
    "winRate": 68.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 9.4,
    "breadth": 0.747,
-   "competitiveRatio": 33.9,
+   "competitiveRatio": 32.5,
    "winRate": 53
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 4.8,
    "anchorRate": 14.5,
    "breadth": 0.838,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 48.2,
    "winRate": 60.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 11.1,
    "anchorRate": 1.8,
    "breadth": 0.822,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 33.7,
    "winRate": 39.7
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 13,
    "breadth": 0.709,
-   "competitiveRatio": 27.6,
+   "competitiveRatio": 26.6,
    "winRate": 56.7
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2,
    "anchorRate": 14.7,
    "breadth": 0.833,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 33,
    "winRate": 61.9
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 5,
    "anchorRate": 2,
    "breadth": 0.803,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 33.4,
    "winRate": 50
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 9.8,
    "anchorRate": 0,
    "breadth": 0.631,
-   "competitiveRatio": 20.5,
+   "competitiveRatio": 19.9,
    "winRate": 27.9
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 11.2,
    "anchorRate": 4.5,
    "breadth": 0.686,
-   "competitiveRatio": 37.7,
+   "competitiveRatio": 36.2,
    "winRate": 54.5
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 41.7,
    "anchorRate": 0,
    "breadth": 0.709,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.9,
    "winRate": 21.1
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 38.1,
    "anchorRate": 0,
    "breadth": 0.7,
-   "competitiveRatio": 44.9,
+   "competitiveRatio": 44.5,
    "winRate": 41.9
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 18.8,
    "anchorRate": 6.5,
    "breadth": 0.829,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 21.5,
    "winRate": 36.9
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 0,
    "anchorRate": 4.9,
    "breadth": 0.53,
-   "competitiveRatio": 50,
+   "competitiveRatio": 48.8,
    "winRate": 47.5
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 48.7,
    "anchorRate": 0,
    "breadth": 0.646,
-   "competitiveRatio": 15.4,
+   "competitiveRatio": 14.9,
    "winRate": 28.2
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 28,
    "anchorRate": 0,
    "breadth": 0.628,
-   "competitiveRatio": 22.1,
+   "competitiveRatio": 21.5,
    "winRate": 19.8
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 50,
    "anchorRate": 0,
    "breadth": 0.703,
-   "competitiveRatio": 19.3,
+   "competitiveRatio": 18.7,
    "winRate": 16.5
   }
  ]

--- a/public/data/conferences/presidents-athletic-conference.json
+++ b/public/data/conferences/presidents-athletic-conference.json
@@ -18,20 +18,20 @@
     "STRETCH": 431,
     "UP": 1547,
     "EVEN": 631,
-    "DOWN": 1858,
-    "ANCHOR": 360
+    "DOWN": 1852,
+    "ANCHOR": 366
    },
    "bandPct": {
     "STRETCH": 8.9,
     "UP": 32,
     "EVEN": 13.1,
-    "DOWN": 38.5,
-    "ANCHOR": 7.5
+    "DOWN": 38.4,
+    "ANCHOR": 7.6
    },
    "stretchRate": 8.9,
-   "anchorRate": 7.5,
-   "breadth": 0.875,
-   "competitiveRatio": 23.5,
+   "anchorRate": 7.6,
+   "breadth": 0.876,
+   "competitiveRatio": 23,
    "winRate": 49.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 10.3,
    "anchorRate": 10.3,
    "breadth": 0.895,
-   "competitiveRatio": 21.8,
+   "competitiveRatio": 21.4,
    "winRate": 50
   },
   "nonConference": {
@@ -62,20 +62,20 @@
     "STRETCH": 166,
     "UP": 659,
     "EVEN": 355,
-    "DOWN": 970,
-    "ANCHOR": 95
+    "DOWN": 964,
+    "ANCHOR": 101
    },
    "bandPct": {
     "STRETCH": 7.4,
     "UP": 29.4,
     "EVEN": 15.8,
-    "DOWN": 43.2,
-    "ANCHOR": 4.2
+    "DOWN": 42.9,
+    "ANCHOR": 4.5
    },
    "stretchRate": 7.4,
-   "anchorRate": 4.2,
-   "breadth": 0.833,
-   "competitiveRatio": 25.5,
+   "anchorRate": 4.5,
+   "breadth": 0.837,
+   "competitiveRatio": 25,
    "winRate": 48.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 12.3,
    "anchorRate": 40.4,
    "breadth": 0.846,
-   "competitiveRatio": 22.2,
+   "competitiveRatio": 22,
    "winRate": 71.9
   },
   {
@@ -146,20 +146,20 @@
     "STRETCH": 24,
     "UP": 48,
     "EVEN": 24,
-    "DOWN": 216,
-    "ANCHOR": 87
+    "DOWN": 210,
+    "ANCHOR": 93
    },
    "bandPct": {
     "STRETCH": 6,
     "UP": 12,
     "EVEN": 6,
-    "DOWN": 54.1,
-    "ANCHOR": 21.8
+    "DOWN": 52.6,
+    "ANCHOR": 23.3
    },
    "stretchRate": 6,
-   "anchorRate": 21.8,
-   "breadth": 0.781,
-   "competitiveRatio": 23.3,
+   "anchorRate": 23.3,
+   "breadth": 0.789,
+   "competitiveRatio": 23.6,
    "winRate": 62.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.8,
    "anchorRate": 6.8,
    "breadth": 0.813,
-   "competitiveRatio": 27.3,
+   "competitiveRatio": 26.7,
    "winRate": 51
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 6.3,
    "anchorRate": 0,
    "breadth": 0.636,
-   "competitiveRatio": 25.6,
+   "competitiveRatio": 25.3,
    "winRate": 62.8
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.497,
-   "competitiveRatio": 19.9,
+   "competitiveRatio": 19.3,
    "winRate": 59.9
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 14.4,
    "anchorRate": 0,
    "breadth": 0.77,
-   "competitiveRatio": 26,
+   "competitiveRatio": 25.3,
    "winRate": 36.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 16.1,
    "anchorRate": 0,
    "breadth": 0.805,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.3,
    "winRate": 38.6
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 6.3,
    "breadth": 0.78,
-   "competitiveRatio": 33.3,
+   "competitiveRatio": 32.5,
    "winRate": 50.4
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 6.8,
    "anchorRate": 0,
    "breadth": 0.758,
-   "competitiveRatio": 16.8,
+   "competitiveRatio": 16.4,
    "winRate": 26
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 46.6,
    "anchorRate": 0,
    "breadth": 0.429,
-   "competitiveRatio": 8.6,
+   "competitiveRatio": 8.2,
    "winRate": 7.3
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 7.8,
    "anchorRate": 0,
    "breadth": 0.796,
-   "competitiveRatio": 31.5,
+   "competitiveRatio": 29.7,
    "winRate": 44.8
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 12.6,
    "anchorRate": 0,
    "breadth": 0.721,
-   "competitiveRatio": 28.6,
+   "competitiveRatio": 28.1,
    "winRate": 53.2
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 7.8,
    "anchorRate": 0,
    "breadth": 0.627,
-   "competitiveRatio": 21.7,
+   "competitiveRatio": 21.3,
    "winRate": 27.8
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 21.1,
    "anchorRate": 0,
    "breadth": 0.429,
-   "competitiveRatio": 12.1,
+   "competitiveRatio": 10.9,
    "winRate": 10.9
   }
  ]

--- a/public/data/conferences/red-river-athletic-conference.json
+++ b/public/data/conferences/red-river-athletic-conference.json
@@ -18,20 +18,20 @@
     "STRETCH": 218,
     "UP": 950,
     "EVEN": 623,
-    "DOWN": 1322,
-    "ANCHOR": 376
+    "DOWN": 1316,
+    "ANCHOR": 382
    },
    "bandPct": {
     "STRETCH": 6.2,
     "UP": 27.2,
     "EVEN": 17.9,
-    "DOWN": 37.9,
-    "ANCHOR": 10.8
+    "DOWN": 37.7,
+    "ANCHOR": 10.9
    },
    "stretchRate": 6.2,
-   "anchorRate": 10.8,
-   "breadth": 0.897,
-   "competitiveRatio": 35.7,
+   "anchorRate": 10.9,
+   "breadth": 0.898,
+   "competitiveRatio": 35.3,
    "winRate": 56.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 3.1,
    "anchorRate": 3.1,
    "breadth": 0.793,
-   "competitiveRatio": 33.6,
+   "competitiveRatio": 33.3,
    "winRate": 50
   },
   "nonConference": {
@@ -62,20 +62,20 @@
     "STRETCH": 195,
     "UP": 681,
     "EVEN": 475,
-    "DOWN": 1053,
-    "ANCHOR": 353
+    "DOWN": 1047,
+    "ANCHOR": 359
    },
    "bandPct": {
     "STRETCH": 7.1,
     "UP": 24.7,
     "EVEN": 17.2,
-    "DOWN": 38.2,
-    "ANCHOR": 12.8
+    "DOWN": 38,
+    "ANCHOR": 13
    },
    "stretchRate": 7.1,
-   "anchorRate": 12.8,
-   "breadth": 0.911,
-   "competitiveRatio": 36.2,
+   "anchorRate": 13,
+   "breadth": 0.913,
+   "competitiveRatio": 35.9,
    "winRate": 57.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 16.1,
    "breadth": 0.711,
-   "competitiveRatio": 50.8,
+   "competitiveRatio": 51.1,
    "winRate": 58.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 7.7,
    "anchorRate": 20.2,
    "breadth": 0.954,
-   "competitiveRatio": 37.2,
+   "competitiveRatio": 36.7,
    "winRate": 65.8
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 18,
    "anchorRate": 3.3,
    "breadth": 0.899,
-   "competitiveRatio": 43.4,
+   "competitiveRatio": 41.5,
    "winRate": 43.4
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 15,
    "anchorRate": 0,
    "breadth": 0.741,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 28.3,
    "winRate": 41.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.705,
-   "competitiveRatio": 39.2,
+   "competitiveRatio": 38.3,
    "winRate": 61.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 5,
    "anchorRate": 19.4,
    "breadth": 0.925,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 39.4,
    "winRate": 70.6
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 19.2,
    "breadth": 0.818,
-   "competitiveRatio": 24.2,
+   "competitiveRatio": 23.9,
    "winRate": 62.5
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 2.7,
    "anchorRate": 12.5,
    "breadth": 0.864,
-   "competitiveRatio": 26.6,
+   "competitiveRatio": 27.3,
    "winRate": 56.9
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 3.2,
    "anchorRate": 15.9,
    "breadth": 0.887,
-   "competitiveRatio": 31.2,
+   "competitiveRatio": 30.7,
    "winRate": 48.8
   },
   {
@@ -362,20 +362,20 @@
     "STRETCH": 0,
     "UP": 51,
     "EVEN": 49,
-    "DOWN": 155,
-    "ANCHOR": 18
+    "DOWN": 149,
+    "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 18.7,
     "EVEN": 17.9,
-    "DOWN": 56.8,
-    "ANCHOR": 6.6
+    "DOWN": 54.6,
+    "ANCHOR": 8.8
    },
    "stretchRate": 0,
-   "anchorRate": 6.6,
-   "breadth": 0.697,
-   "competitiveRatio": 33.8,
+   "anchorRate": 8.8,
+   "breadth": 0.724,
+   "competitiveRatio": 33.5,
    "winRate": 64.1
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 21.6,
    "anchorRate": 0,
    "breadth": 0.683,
-   "competitiveRatio": 29.5,
+   "competitiveRatio": 30.1,
    "winRate": 37.7
   }
  ]

--- a/public/data/conferences/region-1.json
+++ b/public/data/conferences/region-1.json
@@ -30,7 +30,7 @@
    "stretchRate": 34.1,
    "anchorRate": 18.3,
    "breadth": 0.873,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.2,
    "winRate": 39.8
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 44.4,
    "anchorRate": 4,
    "breadth": 0.749,
-   "competitiveRatio": 17.2,
+   "competitiveRatio": 16.6,
    "winRate": 23.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -158,7 +158,7 @@
    "stretchRate": 76.1,
    "anchorRate": 0,
    "breadth": 0.341,
-   "competitiveRatio": 32.2,
+   "competitiveRatio": 31,
    "winRate": 18.2
   },
   {

--- a/public/data/conferences/region-10.json
+++ b/public/data/conferences/region-10.json
@@ -30,7 +30,7 @@
    "stretchRate": 44.5,
    "anchorRate": 6.8,
    "breadth": 0.815,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.1,
    "winRate": 27
   },
   "inConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 44.5,
    "anchorRate": 6.8,
    "breadth": 0.815,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.1,
    "winRate": 27
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 28,
    "anchorRate": 11.2,
    "breadth": 0.933,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 30,
    "winRate": 35.5
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 69.5,
    "anchorRate": 0,
    "breadth": 0.382,
-   "competitiveRatio": 18.4,
+   "competitiveRatio": 17.7,
    "winRate": 14.2
   }
  ]

--- a/public/data/conferences/region-14.json
+++ b/public/data/conferences/region-14.json
@@ -31,7 +31,7 @@
    "stretchRate": 35.2,
    "anchorRate": 9.8,
    "breadth": 0.906,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 32.5,
    "winRate": 45.6
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 34.1,
    "anchorRate": 6.9,
    "breadth": 0.891,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 34.4,
    "winRate": 45.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 23,
    "breadth": 0.751,
-   "competitiveRatio": 43.1,
+   "competitiveRatio": 41.9,
    "winRate": 67
   },
   {

--- a/public/data/conferences/region-17.json
+++ b/public/data/conferences/region-17.json
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 51.2,
    "anchorRate": 0,
    "breadth": 0.759,
-   "competitiveRatio": 12.4,
+   "competitiveRatio": 11.6,
    "winRate": 17.4
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.421,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 30,
    "winRate": 32.2
   }
  ]

--- a/public/data/conferences/region-19.json
+++ b/public/data/conferences/region-19.json
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {

--- a/public/data/conferences/region-22.json
+++ b/public/data/conferences/region-22.json
@@ -31,7 +31,7 @@
    "stretchRate": 14.7,
    "anchorRate": 30,
    "breadth": 0.935,
-   "competitiveRatio": 21.3,
+   "competitiveRatio": 21.2,
    "winRate": 53.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 28.6,
    "anchorRate": 28.6,
    "breadth": 0.855,
-   "competitiveRatio": 13.9,
+   "competitiveRatio": 13.5,
    "winRate": 50
   },
   "nonConference": {
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 8.7,
    "anchorRate": 46,
    "breadth": 0.855,
-   "competitiveRatio": 25.4,
+   "competitiveRatio": 25.2,
    "winRate": 65.6
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 4.9,
    "anchorRate": 25.3,
    "breadth": 0.805,
-   "competitiveRatio": 21.3,
+   "competitiveRatio": 21,
    "winRate": 63.1
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.9,
    "anchorRate": 45.1,
    "breadth": 0.669,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 22.2,
    "winRate": 66
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 45.5,
    "anchorRate": 0,
    "breadth": 0.428,
-   "competitiveRatio": 6.2,
+   "competitiveRatio": 5.5,
    "winRate": 6.2
   }
  ]

--- a/public/data/conferences/region-23.json
+++ b/public/data/conferences/region-23.json
@@ -31,7 +31,7 @@
    "stretchRate": 19.2,
    "anchorRate": 9.7,
    "breadth": 0.934,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 24.1,
    "winRate": 50.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 12.1,
    "anchorRate": 12.1,
    "breadth": 0.904,
-   "competitiveRatio": 25.3,
+   "competitiveRatio": 24.6,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 26.3,
    "anchorRate": 7.4,
    "breadth": 0.937,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.6,
    "winRate": 50.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -159,7 +159,7 @@
    "stretchRate": 16.2,
    "anchorRate": 7.3,
    "breadth": 0.741,
-   "competitiveRatio": 30,
+   "competitiveRatio": 27.7,
    "winRate": 49
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 34.1,
    "anchorRate": 7.3,
    "breadth": 0.935,
-   "competitiveRatio": 26.1,
+   "competitiveRatio": 24,
    "winRate": 42.9
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 21.7,
    "anchorRate": 7.5,
    "breadth": 0.809,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.5,
    "winRate": 41.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 15,
    "breadth": 0.443,
-   "competitiveRatio": 20.1,
+   "competitiveRatio": 19,
    "winRate": 90.8
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 6.5,
    "anchorRate": 0,
    "breadth": 0.689,
-   "competitiveRatio": 23.4,
+   "competitiveRatio": 23.6,
    "winRate": 50.3
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 18.5,
    "anchorRate": 0,
    "breadth": 0.761,
-   "competitiveRatio": 25.2,
+   "competitiveRatio": 24.1,
    "winRate": 47.2
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 15.4,
    "anchorRate": 0,
    "breadth": 0.794,
-   "competitiveRatio": 18.1,
+   "competitiveRatio": 18.5,
    "winRate": 54.1
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 9.9,
    "anchorRate": 13.7,
    "breadth": 0.958,
-   "competitiveRatio": 29.7,
+   "competitiveRatio": 30.8,
    "winRate": 46.4
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 24.9,
    "anchorRate": 4.8,
    "breadth": 0.929,
-   "competitiveRatio": 32,
+   "competitiveRatio": 31.6,
    "winRate": 58.1
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 2.6,
    "anchorRate": 15.4,
    "breadth": 0.818,
-   "competitiveRatio": 16.2,
+   "competitiveRatio": 18,
    "winRate": 43.4
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 30.7,
    "anchorRate": 0,
    "breadth": 0.459,
-   "competitiveRatio": 20,
+   "competitiveRatio": 21.5,
    "winRate": 38.5
   },
   {

--- a/public/data/conferences/region-4.json
+++ b/public/data/conferences/region-4.json
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {

--- a/public/data/conferences/region-5.json
+++ b/public/data/conferences/region-5.json
@@ -30,7 +30,7 @@
    "stretchRate": 11.9,
    "anchorRate": 11.2,
    "breadth": 0.928,
-   "competitiveRatio": 34.5,
+   "competitiveRatio": 33.9,
    "winRate": 42.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.6,
-   "competitiveRatio": 41.4,
+   "competitiveRatio": 37.9,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 12.6,
    "anchorRate": 11.8,
    "breadth": 0.925,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 33.7,
    "winRate": 42.2
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 18.4,
    "anchorRate": 13.5,
    "breadth": 0.947,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 43.3,
    "winRate": 54.7
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 9.9,
    "anchorRate": 9.9,
    "breadth": 0.932,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 27.1,
    "winRate": 32.7
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 11.2,
    "anchorRate": 1.3,
    "breadth": 0.702,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 31,
    "winRate": 33
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 5,
    "anchorRate": 21,
    "breadth": 0.938,
-   "competitiveRatio": 33,
+   "competitiveRatio": 32.5,
    "winRate": 49.5
   }
  ]

--- a/public/data/conferences/region-6.json
+++ b/public/data/conferences/region-6.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 93,
     "UP": 450,
-    "EVEN": 88,
-    "DOWN": 328,
+    "EVEN": 84,
+    "DOWN": 332,
     "ANCHOR": 118
    },
    "bandPct": {
     "STRETCH": 8.6,
     "UP": 41.8,
-    "EVEN": 8.2,
-    "DOWN": 30.5,
+    "EVEN": 7.8,
+    "DOWN": 30.8,
     "ANCHOR": 11
    },
    "stretchRate": 8.6,
    "anchorRate": 11,
-   "breadth": 0.861,
-   "competitiveRatio": 41.5,
+   "breadth": 0.858,
+   "competitiveRatio": 40.1,
    "winRate": 55.1
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 8,
    "anchorRate": 8,
    "breadth": 0.704,
-   "competitiveRatio": 46,
+   "competitiveRatio": 45,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 77,
     "UP": 366,
-    "EVEN": 88,
-    "DOWN": 244,
+    "EVEN": 84,
+    "DOWN": 248,
     "ANCHOR": 102
    },
    "bandPct": {
     "STRETCH": 8.8,
     "UP": 41.7,
-    "EVEN": 10,
-    "DOWN": 27.8,
+    "EVEN": 9.6,
+    "DOWN": 28.3,
     "ANCHOR": 11.6
    },
    "stretchRate": 8.8,
    "anchorRate": 11.6,
-   "breadth": 0.879,
-   "competitiveRatio": 40.5,
+   "breadth": 0.876,
+   "competitiveRatio": 39,
    "winRate": 56.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 12.6,
    "breadth": 0.725,
-   "competitiveRatio": 53.2,
+   "competitiveRatio": 50.2,
    "winRate": 62.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 7.4,
    "anchorRate": 18.6,
    "breadth": 0.831,
-   "competitiveRatio": 36.3,
+   "competitiveRatio": 34.4,
    "winRate": 67.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 14.6,
    "breadth": 0.741,
-   "competitiveRatio": 47.6,
+   "competitiveRatio": 47,
    "winRate": 40
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 7.3,
    "anchorRate": 10.3,
    "breadth": 0.833,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 40.6,
    "winRate": 56.4
   },
   {
@@ -226,21 +226,21 @@
    "bands": {
     "STRETCH": 65,
     "UP": 55,
-    "EVEN": 18,
-    "DOWN": 15,
+    "EVEN": 14,
+    "DOWN": 19,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 42.5,
     "UP": 35.9,
-    "EVEN": 11.8,
-    "DOWN": 9.8,
+    "EVEN": 9.2,
+    "DOWN": 12.4,
     "ANCHOR": 0
    },
    "stretchRate": 42.5,
    "anchorRate": 0,
-   "breadth": 0.752,
-   "competitiveRatio": 32.5,
+   "breadth": 0.751,
+   "competitiveRatio": 31.8,
    "winRate": 46.4
   },
   {

--- a/public/data/conferences/river-states-conference.json
+++ b/public/data/conferences/river-states-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 21.6,
    "anchorRate": 10.1,
    "breadth": 0.942,
-   "competitiveRatio": 27.8,
+   "competitiveRatio": 27.3,
    "winRate": 41
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 20,
    "anchorRate": 20,
    "breadth": 0.961,
-   "competitiveRatio": 23.4,
+   "competitiveRatio": 23,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 22.5,
    "anchorRate": 4.4,
    "breadth": 0.899,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.9,
    "winRate": 35.8
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 32.5,
    "breadth": 0.816,
-   "competitiveRatio": 39.8,
+   "competitiveRatio": 40.1,
    "winRate": 64.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 27.7,
    "anchorRate": 0,
    "breadth": 0.753,
-   "competitiveRatio": 23.9,
+   "competitiveRatio": 23.1,
    "winRate": 27.3
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.5,
    "anchorRate": 26.5,
    "breadth": 0.792,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 38.1,
    "winRate": 51.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 41.5,
    "anchorRate": 1.7,
    "breadth": 0.719,
-   "competitiveRatio": 23.8,
+   "competitiveRatio": 22.6,
    "winRate": 28.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 16.4,
    "anchorRate": 2.7,
    "breadth": 0.873,
-   "competitiveRatio": 26.6,
+   "competitiveRatio": 25.7,
    "winRate": 43.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 70.2,
    "anchorRate": 0,
    "breadth": 0.463,
-   "competitiveRatio": 23.4,
+   "competitiveRatio": 22.9,
    "winRate": 23.9
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 8.2,
    "anchorRate": 0,
    "breadth": 0.76,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 28.8,
    "winRate": 47.6
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 28,
    "anchorRate": 4.3,
    "breadth": 0.881,
-   "competitiveRatio": 30.4,
+   "competitiveRatio": 29.8,
    "winRate": 29.8
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 7.1,
    "anchorRate": 0,
    "breadth": 0.657,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 21.2,
    "winRate": 51.8
   }
  ]

--- a/public/data/conferences/rocky-mountain-athletic-conference.json
+++ b/public/data/conferences/rocky-mountain-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 58.7,
    "anchorRate": 0,
    "breadth": 0.541,
-   "competitiveRatio": 18.5,
+   "competitiveRatio": 17.5,
    "winRate": 14.3
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 58.7,
    "anchorRate": 0,
    "breadth": 0.541,
-   "competitiveRatio": 18.5,
+   "competitiveRatio": 17.5,
    "winRate": 14.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 58.7,
    "anchorRate": 0,
    "breadth": 0.541,
-   "competitiveRatio": 18.5,
+   "competitiveRatio": 17.5,
    "winRate": 14.3
   }
  ]

--- a/public/data/conferences/skyline-conference.json
+++ b/public/data/conferences/skyline-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 310,
     "UP": 839,
-    "EVEN": 576,
-    "DOWN": 1061,
+    "EVEN": 564,
+    "DOWN": 1073,
     "ANCHOR": 255
    },
    "bandPct": {
     "STRETCH": 10.2,
     "UP": 27.6,
-    "EVEN": 18.9,
-    "DOWN": 34.9,
+    "EVEN": 18.5,
+    "DOWN": 35.3,
     "ANCHOR": 8.4
    },
    "stretchRate": 10.2,
    "anchorRate": 8.4,
-   "breadth": 0.919,
-   "competitiveRatio": 25.6,
+   "breadth": 0.917,
+   "competitiveRatio": 24.5,
    "winRate": 50.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 9.5,
    "anchorRate": 9.5,
    "breadth": 0.935,
-   "competitiveRatio": 27,
+   "competitiveRatio": 26.2,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 163,
     "UP": 400,
-    "EVEN": 194,
-    "DOWN": 622,
+    "EVEN": 182,
+    "DOWN": 634,
     "ANCHOR": 108
    },
    "bandPct": {
     "STRETCH": 11,
     "UP": 26.9,
-    "EVEN": 13,
-    "DOWN": 41.8,
+    "EVEN": 12.2,
+    "DOWN": 42.6,
     "ANCHOR": 7.3
    },
    "stretchRate": 11,
    "anchorRate": 7.3,
-   "breadth": 0.88,
-   "competitiveRatio": 24.1,
+   "breadth": 0.874,
+   "competitiveRatio": 22.8,
    "winRate": 51.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 5.6,
    "anchorRate": 18.2,
    "breadth": 0.794,
-   "competitiveRatio": 25.1,
+   "competitiveRatio": 23.5,
    "winRate": 73.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 12.5,
    "breadth": 0.743,
-   "competitiveRatio": 22.3,
+   "competitiveRatio": 21.6,
    "winRate": 66.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 13.2,
    "anchorRate": 19.8,
    "breadth": 0.912,
-   "competitiveRatio": 25.2,
+   "competitiveRatio": 24.4,
    "winRate": 53.5
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 13.7,
    "anchorRate": 9.3,
    "breadth": 0.95,
-   "competitiveRatio": 35.5,
+   "competitiveRatio": 34.7,
    "winRate": 46
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.3,
    "anchorRate": 15.9,
    "breadth": 0.713,
-   "competitiveRatio": 22.2,
+   "competitiveRatio": 21.8,
    "winRate": 69.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 5.2,
    "anchorRate": 12.9,
    "breadth": 0.852,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 20.5,
    "winRate": 50
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.662,
-   "competitiveRatio": 20.8,
+   "competitiveRatio": 19.8,
    "winRate": 32.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.673,
-   "competitiveRatio": 26,
+   "competitiveRatio": 25.5,
    "winRate": 52.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 9,
    "anchorRate": 11.6,
    "breadth": 0.93,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 34.2,
    "winRate": 59.3
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 22.3,
    "anchorRate": 0,
    "breadth": 0.495,
-   "competitiveRatio": 23.1,
+   "competitiveRatio": 21,
    "winRate": 21.8
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.644,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 24.4,
    "winRate": 51.7
   },
   {
@@ -442,21 +442,21 @@
    "bands": {
     "STRETCH": 35,
     "UP": 74,
-    "EVEN": 36,
-    "DOWN": 27,
+    "EVEN": 24,
+    "DOWN": 39,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 20.3,
     "UP": 43,
-    "EVEN": 20.9,
-    "DOWN": 15.7,
+    "EVEN": 14,
+    "DOWN": 22.7,
     "ANCHOR": 0
    },
    "stretchRate": 20.3,
    "anchorRate": 0,
-   "breadth": 0.811,
-   "competitiveRatio": 29.1,
+   "breadth": 0.807,
+   "competitiveRatio": 28.5,
    "winRate": 36.6
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.663,
-   "competitiveRatio": 30.3,
+   "competitiveRatio": 28.4,
    "winRate": 50.3
   }
  ]

--- a/public/data/conferences/sooner-athletic-conference.json
+++ b/public/data/conferences/sooner-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 7.9,
    "anchorRate": 2.8,
    "breadth": 0.846,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 34.5,
    "winRate": 49
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 7.9,
    "anchorRate": 2.8,
    "breadth": 0.846,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 34.5,
    "winRate": 49
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 9.7,
    "anchorRate": 5.2,
    "breadth": 0.886,
-   "competitiveRatio": 38.6,
+   "competitiveRatio": 37.9,
    "winRate": 49.3
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 5.9,
    "anchorRate": 0,
    "breadth": 0.769,
-   "competitiveRatio": 31.4,
+   "competitiveRatio": 30.6,
    "winRate": 48.6
   }
  ]

--- a/public/data/conferences/south-atlantic-conference.json
+++ b/public/data/conferences/south-atlantic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 13.2,
    "anchorRate": 14.2,
    "breadth": 0.949,
-   "competitiveRatio": 37.5,
+   "competitiveRatio": 36.8,
    "winRate": 51.2
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 14.9,
    "anchorRate": 14.9,
    "breadth": 0.953,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 33.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 11.2,
    "anchorRate": 13.3,
    "breadth": 0.941,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 40.9,
    "winRate": 52.7
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 21.8,
    "breadth": 0.783,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 43.3,
    "winRate": 65.4
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 11.6,
    "breadth": 0.778,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 36.2,
    "winRate": 48.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.9,
    "anchorRate": 15.1,
    "breadth": 0.857,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 46.9,
    "winRate": 51.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 16.4,
    "breadth": 0.82,
-   "competitiveRatio": 40.7,
+   "competitiveRatio": 38.6,
    "winRate": 68.2
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.9,
    "anchorRate": 8.1,
    "breadth": 0.726,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 36.4,
    "winRate": 68.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 8.6,
    "breadth": 0.695,
-   "competitiveRatio": 40,
+   "competitiveRatio": 39.4,
    "winRate": 64.1
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 23.9,
    "breadth": 0.601,
-   "competitiveRatio": 31.2,
+   "competitiveRatio": 30.6,
    "winRate": 76.4
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 0,
    "anchorRate": 20.6,
    "breadth": 0.829,
-   "competitiveRatio": 34,
+   "competitiveRatio": 34.3,
    "winRate": 65.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 2.9,
    "anchorRate": 14.3,
    "breadth": 0.859,
-   "competitiveRatio": 37.3,
+   "competitiveRatio": 34.6,
    "winRate": 43.6
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 14.9,
    "breadth": 0.667,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 33.7,
    "winRate": 55.4
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 28,
    "breadth": 0.516,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 42.7,
    "winRate": 73.4
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 2.1,
    "anchorRate": 11,
    "breadth": 0.846,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 35.1,
    "winRate": 56.7
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 10.1,
    "anchorRate": 4.9,
    "breadth": 0.667,
-   "competitiveRatio": 32.3,
+   "competitiveRatio": 30.2,
    "winRate": 45.8
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 0,
    "anchorRate": 33.6,
    "breadth": 0.843,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 36.5,
    "winRate": 55.2
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 0,
    "anchorRate": 18.7,
    "breadth": 0.816,
-   "competitiveRatio": 42.7,
+   "competitiveRatio": 41.9,
    "winRate": 43.1
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 0,
    "anchorRate": 19.4,
    "breadth": 0.849,
-   "competitiveRatio": 43,
+   "competitiveRatio": 43.7,
    "winRate": 47.5
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 75.3,
    "anchorRate": 0,
    "breadth": 0.444,
-   "competitiveRatio": 30.2,
+   "competitiveRatio": 30.6,
    "winRate": 16.6
   },
   {
@@ -672,7 +672,7 @@
    "stretchRate": 87.6,
    "anchorRate": 0,
    "breadth": 0.233,
-   "competitiveRatio": 25.3,
+   "competitiveRatio": 26.2,
    "winRate": 14.5
   },
   {
@@ -699,7 +699,7 @@
    "stretchRate": 28.4,
    "anchorRate": 0,
    "breadth": 0.707,
-   "competitiveRatio": 26.7,
+   "competitiveRatio": 26.2,
    "winRate": 21.2
   },
   {
@@ -726,7 +726,7 @@
    "stretchRate": 85.5,
    "anchorRate": 0,
    "breadth": 0.3,
-   "competitiveRatio": 16.7,
+   "competitiveRatio": 16.1,
    "winRate": 13
   }
  ]

--- a/public/data/conferences/south-coast-conference.json
+++ b/public/data/conferences/south-coast-conference.json
@@ -29,7 +29,7 @@
    "stretchRate": 26.4,
    "anchorRate": 0,
    "breadth": 0.479,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 22.7,
    "winRate": 17.3
   },
   "inConference": {
@@ -73,7 +73,7 @@
    "stretchRate": 26.4,
    "anchorRate": 0,
    "breadth": 0.479,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 22.7,
    "winRate": 17.3
   }
  },
@@ -82,21 +82,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -130,7 +130,7 @@
    "stretchRate": 26.4,
    "anchorRate": 0,
    "breadth": 0.479,
-   "competitiveRatio": 24.5,
+   "competitiveRatio": 22.7,
    "winRate": 17.3
   }
  ]

--- a/public/data/conferences/southeastern-conference.json
+++ b/public/data/conferences/southeastern-conference.json
@@ -17,20 +17,20 @@
     "STRETCH": 91,
     "UP": 3373,
     "EVEN": 2038,
-    "DOWN": 4974,
-    "ANCHOR": 1985
+    "DOWN": 4955,
+    "ANCHOR": 2004
    },
    "bandPct": {
     "STRETCH": 0.7,
     "UP": 27.1,
     "EVEN": 16.4,
-    "DOWN": 39.9,
-    "ANCHOR": 15.9
+    "DOWN": 39.8,
+    "ANCHOR": 16.1
    },
    "stretchRate": 0.7,
-   "anchorRate": 15.9,
-   "breadth": 0.836,
-   "competitiveRatio": 48.7,
+   "anchorRate": 16.1,
+   "breadth": 0.837,
+   "competitiveRatio": 45.4,
    "winRate": 60.3
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 1.3,
    "anchorRate": 1.3,
    "breadth": 0.719,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 50.3,
    "winRate": 50
   },
   "nonConference": {
@@ -61,20 +61,20 @@
     "STRETCH": 0,
     "UP": 541,
     "EVEN": 706,
-    "DOWN": 2142,
-    "ANCHOR": 1894
+    "DOWN": 2123,
+    "ANCHOR": 1913
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 10.2,
     "EVEN": 13.4,
-    "DOWN": 40.5,
-    "ANCHOR": 35.9
+    "DOWN": 40.2,
+    "ANCHOR": 36.2
    },
    "stretchRate": 0,
-   "anchorRate": 35.9,
+   "anchorRate": 36.2,
    "breadth": 0.768,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 38.7,
    "winRate": 74.3
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 24.7,
    "breadth": 0.676,
-   "competitiveRatio": 58.1,
+   "competitiveRatio": 54.9,
    "winRate": 69
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 7,
    "breadth": 0.732,
-   "competitiveRatio": 43.3,
+   "competitiveRatio": 38.9,
    "winRate": 76.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 30.8,
    "breadth": 0.739,
-   "competitiveRatio": 55,
+   "competitiveRatio": 51.5,
    "winRate": 58.8
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 16.1,
    "breadth": 0.626,
-   "competitiveRatio": 61.2,
+   "competitiveRatio": 57.5,
    "winRate": 59.2
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 24.1,
    "breadth": 0.731,
-   "competitiveRatio": 40.4,
+   "competitiveRatio": 37.8,
    "winRate": 70.7
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 24.5,
    "breadth": 0.569,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 41.1,
    "winRate": 77
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 16,
    "breadth": 0.735,
-   "competitiveRatio": 51.7,
+   "competitiveRatio": 48.1,
    "winRate": 62.3
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 2,
    "anchorRate": 12.4,
    "breadth": 0.68,
-   "competitiveRatio": 56.2,
+   "competitiveRatio": 52.6,
    "winRate": 54.4
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 14.6,
    "breadth": 0.73,
-   "competitiveRatio": 55.2,
+   "competitiveRatio": 50.9,
    "winRate": 60.1
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 17.9,
    "breadth": 0.84,
-   "competitiveRatio": 52.3,
+   "competitiveRatio": 48.2,
    "winRate": 59.4
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 16.1,
    "breadth": 0.787,
-   "competitiveRatio": 52.6,
+   "competitiveRatio": 50.6,
    "winRate": 57
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 0,
    "anchorRate": 15,
    "breadth": 0.841,
-   "competitiveRatio": 54.9,
+   "competitiveRatio": 51.4,
    "winRate": 62.5
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 15.8,
    "breadth": 0.736,
-   "competitiveRatio": 48.7,
+   "competitiveRatio": 46.8,
    "winRate": 62.4
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 22.2,
    "breadth": 0.844,
-   "competitiveRatio": 53.1,
+   "competitiveRatio": 47.8,
    "winRate": 54.2
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 15.1,
    "breadth": 0.758,
-   "competitiveRatio": 57.8,
+   "competitiveRatio": 55.8,
    "winRate": 55.8
   },
   {
@@ -523,20 +523,20 @@
     "STRETCH": 0,
     "UP": 131,
     "EVEN": 34,
-    "DOWN": 153,
-    "ANCHOR": 86
+    "DOWN": 147,
+    "ANCHOR": 92
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.4,
     "EVEN": 8.4,
-    "DOWN": 37.9,
-    "ANCHOR": 21.3
+    "DOWN": 36.4,
+    "ANCHOR": 22.8
    },
    "stretchRate": 0,
-   "anchorRate": 21.3,
-   "breadth": 0.789,
-   "competitiveRatio": 52.7,
+   "anchorRate": 22.8,
+   "breadth": 0.794,
+   "competitiveRatio": 50.7,
    "winRate": 56.9
   },
   {
@@ -550,20 +550,20 @@
     "STRETCH": 0,
     "UP": 44,
     "EVEN": 105,
-    "DOWN": 209,
-    "ANCHOR": 39
+    "DOWN": 206,
+    "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 11.1,
     "EVEN": 26.4,
-    "DOWN": 52.6,
-    "ANCHOR": 9.8
+    "DOWN": 51.9,
+    "ANCHOR": 10.6
    },
    "stretchRate": 0,
-   "anchorRate": 9.8,
-   "breadth": 0.722,
-   "competitiveRatio": 44.8,
+   "anchorRate": 10.6,
+   "breadth": 0.729,
+   "competitiveRatio": 41.3,
    "winRate": 66.5
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 22.4,
    "breadth": 0.851,
-   "competitiveRatio": 50.6,
+   "competitiveRatio": 41,
    "winRate": 60.8
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 0,
    "anchorRate": 23,
    "breadth": 0.718,
-   "competitiveRatio": 53.5,
+   "competitiveRatio": 52.5,
    "winRate": 66.3
   },
   {
@@ -644,7 +644,7 @@
    "stretchRate": 0,
    "anchorRate": 15.4,
    "breadth": 0.676,
-   "competitiveRatio": 41.6,
+   "competitiveRatio": 40.3,
    "winRate": 67.5
   },
   {
@@ -671,7 +671,7 @@
    "stretchRate": 0,
    "anchorRate": 7.6,
    "breadth": 0.756,
-   "competitiveRatio": 40,
+   "competitiveRatio": 38.2,
    "winRate": 61.2
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 0,
    "anchorRate": 7.5,
    "breadth": 0.797,
-   "competitiveRatio": 49.5,
+   "competitiveRatio": 44.6,
    "winRate": 60.6
   },
   {
@@ -725,7 +725,7 @@
    "stretchRate": 0,
    "anchorRate": 13.5,
    "breadth": 0.246,
-   "competitiveRatio": 43.4,
+   "competitiveRatio": 39.2,
    "winRate": 74
   },
   {
@@ -752,7 +752,7 @@
    "stretchRate": 0,
    "anchorRate": 21.5,
    "breadth": 0.841,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.1,
    "winRate": 46.7
   },
   {
@@ -779,7 +779,7 @@
    "stretchRate": 0,
    "anchorRate": 6.6,
    "breadth": 0.748,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 40.9,
    "winRate": 55.6
   },
   {
@@ -806,7 +806,7 @@
    "stretchRate": 2.9,
    "anchorRate": 11,
    "breadth": 0.854,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 42.2,
    "winRate": 49
   },
   {
@@ -820,20 +820,20 @@
     "STRETCH": 0,
     "UP": 103,
     "EVEN": 56,
-    "DOWN": 157,
-    "ANCHOR": 23
+    "DOWN": 147,
+    "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 30.4,
     "EVEN": 16.5,
-    "DOWN": 46.3,
-    "ANCHOR": 6.8
+    "DOWN": 43.4,
+    "ANCHOR": 9.7
    },
    "stretchRate": 0,
-   "anchorRate": 6.8,
-   "breadth": 0.745,
-   "competitiveRatio": 49,
+   "anchorRate": 9.7,
+   "breadth": 0.776,
+   "competitiveRatio": 44,
    "winRate": 56.6
   },
   {
@@ -860,7 +860,7 @@
    "stretchRate": 0,
    "anchorRate": 14.3,
    "breadth": 0.706,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 40.3,
    "winRate": 55.5
   },
   {
@@ -887,7 +887,7 @@
    "stretchRate": 21.5,
    "anchorRate": 3.9,
    "breadth": 0.797,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 27.5,
    "winRate": 38.5
   },
   {
@@ -914,7 +914,7 @@
    "stretchRate": 0,
    "anchorRate": 13.2,
    "breadth": 0.705,
-   "competitiveRatio": 40.2,
+   "competitiveRatio": 37.5,
    "winRate": 54.4
   },
   {

--- a/public/data/conferences/southern-athletic-association.json
+++ b/public/data/conferences/southern-athletic-association.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 774,
     "UP": 1314,
-    "EVEN": 482,
-    "DOWN": 1238,
+    "EVEN": 476,
+    "DOWN": 1244,
     "ANCHOR": 405
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 31.2,
-    "EVEN": 11.4,
-    "DOWN": 29.4,
+    "EVEN": 11.3,
+    "DOWN": 29.5,
     "ANCHOR": 9.6
    },
    "stretchRate": 18.4,
    "anchorRate": 9.6,
-   "breadth": 0.937,
-   "competitiveRatio": 34.8,
+   "breadth": 0.936,
+   "competitiveRatio": 34.7,
    "winRate": 48.4
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 15.5,
    "anchorRate": 15.5,
    "breadth": 0.965,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 34.6,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 557,
     "UP": 921,
-    "EVEN": 306,
-    "DOWN": 845,
+    "EVEN": 300,
+    "DOWN": 851,
     "ANCHOR": 188
    },
    "bandPct": {
     "STRETCH": 19.8,
     "UP": 32.7,
-    "EVEN": 10.9,
-    "DOWN": 30,
+    "EVEN": 10.6,
+    "DOWN": 30.2,
     "ANCHOR": 6.7
    },
    "stretchRate": 19.8,
    "anchorRate": 6.7,
-   "breadth": 0.913,
-   "competitiveRatio": 34.9,
+   "breadth": 0.911,
+   "competitiveRatio": 34.8,
    "winRate": 47.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 1.5,
    "anchorRate": 9.7,
    "breadth": 0.763,
-   "competitiveRatio": 48,
+   "competitiveRatio": 45.8,
    "winRate": 71.3
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 11,
    "anchorRate": 22.3,
    "breadth": 0.942,
-   "competitiveRatio": 28,
+   "competitiveRatio": 29.6,
    "winRate": 67.5
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 25.2,
    "anchorRate": 0,
    "breadth": 0.68,
-   "competitiveRatio": 26.5,
+   "competitiveRatio": 26.8,
    "winRate": 50.2
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 12.8,
    "anchorRate": 9.3,
    "breadth": 0.924,
-   "competitiveRatio": 48,
+   "competitiveRatio": 48.3,
    "winRate": 41.4
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 13.2,
    "breadth": 0.777,
-   "competitiveRatio": 47.9,
+   "competitiveRatio": 46.4,
    "winRate": 59.3
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 7.3,
    "anchorRate": 14.2,
    "breadth": 0.913,
-   "competitiveRatio": 33.9,
+   "competitiveRatio": 34.3,
    "winRate": 47.8
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 4.2,
    "anchorRate": 8,
    "breadth": 0.819,
-   "competitiveRatio": 36,
+   "competitiveRatio": 35.7,
    "winRate": 47.6
   },
   {
@@ -333,21 +333,21 @@
    "bands": {
     "STRETCH": 30,
     "UP": 43,
-    "EVEN": 32,
-    "DOWN": 122,
+    "EVEN": 26,
+    "DOWN": 128,
     "ANCHOR": 56
    },
    "bandPct": {
     "STRETCH": 10.6,
     "UP": 15.2,
-    "EVEN": 11.3,
-    "DOWN": 43.1,
+    "EVEN": 9.2,
+    "DOWN": 45.2,
     "ANCHOR": 19.8
    },
    "stretchRate": 10.6,
    "anchorRate": 19.8,
-   "breadth": 0.903,
-   "competitiveRatio": 38.5,
+   "breadth": 0.884,
+   "competitiveRatio": 38.9,
    "winRate": 53
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 6.4,
    "anchorRate": 24.8,
    "breadth": 0.807,
-   "competitiveRatio": 26.2,
+   "competitiveRatio": 25.9,
    "winRate": 59.2
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 81.2,
    "anchorRate": 0,
    "breadth": 0.337,
-   "competitiveRatio": 29,
+   "competitiveRatio": 30.1,
    "winRate": 25.3
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 30.1,
    "anchorRate": 0,
    "breadth": 0.828,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28,
    "winRate": 33.7
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 27.3,
    "anchorRate": 0,
    "breadth": 0.791,
-   "competitiveRatio": 23.9,
+   "competitiveRatio": 24.8,
    "winRate": 38.7
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 49.6,
    "anchorRate": 0,
    "breadth": 0.577,
-   "competitiveRatio": 11.5,
+   "competitiveRatio": 11.1,
    "winRate": 12.4
   }
  ]

--- a/public/data/conferences/southern-california-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/southern-california-intercollegiate-athletic-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 12,
    "anchorRate": 14.5,
    "breadth": 0.938,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41,
    "winRate": 53.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 20.2,
    "anchorRate": 20.2,
    "breadth": 0.937,
-   "competitiveRatio": 38.1,
+   "competitiveRatio": 37.3,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 6.6,
    "anchorRate": 10.8,
    "breadth": 0.896,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 43.4,
    "winRate": 56
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 23.1,
    "breadth": 0.683,
-   "competitiveRatio": 45.9,
+   "competitiveRatio": 44.5,
    "winRate": 80.3
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 2.5,
    "anchorRate": 17.5,
    "breadth": 0.857,
-   "competitiveRatio": 48.9,
+   "competitiveRatio": 47,
    "winRate": 48.3
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 39.5,
    "breadth": 0.658,
-   "competitiveRatio": 40.9,
+   "competitiveRatio": 39.2,
    "winRate": 79.7
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 23.3,
    "breadth": 0.8,
-   "competitiveRatio": 36.4,
+   "competitiveRatio": 35.6,
    "winRate": 66.7
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 1.7,
    "anchorRate": 20.7,
    "breadth": 0.827,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 49.4,
    "winRate": 62.8
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 5.4,
    "anchorRate": 8.9,
    "breadth": 0.776,
-   "competitiveRatio": 53.3,
+   "competitiveRatio": 51.5,
    "winRate": 48.2
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 9.1,
    "anchorRate": 5.7,
    "breadth": 0.864,
-   "competitiveRatio": 37.6,
+   "competitiveRatio": 36.7,
    "winRate": 54.7
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 1.9,
    "anchorRate": 5.7,
    "breadth": 0.733,
-   "competitiveRatio": 43.4,
+   "competitiveRatio": 40.6,
    "winRate": 41.8
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 14,
    "breadth": 0.809,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46,
    "winRate": 59.9
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 27.9,
    "anchorRate": 3.7,
    "breadth": 0.803,
-   "competitiveRatio": 40.4,
+   "competitiveRatio": 40.7,
    "winRate": 39.4
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 14.6,
    "anchorRate": 16,
    "breadth": 0.813,
-   "competitiveRatio": 37.4,
+   "competitiveRatio": 36.7,
    "winRate": 43.9
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 58.9,
    "anchorRate": 0,
    "breadth": 0.55,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 32.4,
    "winRate": 21.1
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 11.2,
    "anchorRate": 8.6,
    "breadth": 0.921,
-   "competitiveRatio": 40.9,
+   "competitiveRatio": 40.5,
    "winRate": 50.2
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 17,
    "anchorRate": 14.8,
    "breadth": 0.98,
-   "competitiveRatio": 30.3,
+   "competitiveRatio": 29.9,
    "winRate": 55.7
   },
   {

--- a/public/data/conferences/southern-collegiate-athletic-conference.json
+++ b/public/data/conferences/southern-collegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 12.2,
    "anchorRate": 13.1,
    "breadth": 0.928,
-   "competitiveRatio": 33.8,
+   "competitiveRatio": 32.8,
    "winRate": 48.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 15.6,
    "anchorRate": 15.6,
    "breadth": 0.906,
-   "competitiveRatio": 26,
+   "competitiveRatio": 24.9,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 11.1,
    "anchorRate": 12.4,
    "breadth": 0.928,
-   "competitiveRatio": 36.2,
+   "competitiveRatio": 35.2,
    "winRate": 48.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 3.4,
    "anchorRate": 18.4,
    "breadth": 0.84,
-   "competitiveRatio": 50.9,
+   "competitiveRatio": 49.3,
    "winRate": 56.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 1.5,
    "anchorRate": 22.3,
    "breadth": 0.815,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 44.6,
    "winRate": 58.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 14.7,
    "anchorRate": 7.3,
    "breadth": 0.901,
-   "competitiveRatio": 28.5,
+   "competitiveRatio": 26.6,
    "winRate": 54.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 32.2,
    "breadth": 0.791,
-   "competitiveRatio": 32.2,
+   "competitiveRatio": 31.1,
    "winRate": 75.1
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 12.3,
    "anchorRate": 9.8,
    "breadth": 0.799,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 45.5,
    "winRate": 49.4
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 30.2,
    "breadth": 0.769,
-   "competitiveRatio": 35,
+   "competitiveRatio": 34.1,
    "winRate": 63.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 14.1,
    "anchorRate": 0,
    "breadth": 0.762,
-   "competitiveRatio": 29.6,
+   "competitiveRatio": 28.2,
    "winRate": 33.7
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 8.6,
    "anchorRate": 14.1,
    "breadth": 0.905,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 38.8,
    "winRate": 40.9
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 24.4,
    "anchorRate": 4.3,
    "breadth": 0.75,
-   "competitiveRatio": 30.6,
+   "competitiveRatio": 28.7,
    "winRate": 51.2
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 45.5,
    "anchorRate": 0,
    "breadth": 0.603,
-   "competitiveRatio": 10,
+   "competitiveRatio": 8.5,
    "winRate": 9.5
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 16.4,
    "anchorRate": 0,
    "breadth": 0.822,
-   "competitiveRatio": 16.4,
+   "competitiveRatio": 15.2,
    "winRate": 32.7
   }
  ]

--- a/public/data/conferences/southern-conference.json
+++ b/public/data/conferences/southern-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 8.2,
    "anchorRate": 4.4,
    "breadth": 0.866,
-   "competitiveRatio": 48.4,
+   "competitiveRatio": 46.8,
    "winRate": 47.3
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.662,
-   "competitiveRatio": 51.1,
+   "competitiveRatio": 49.5,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 13.5,
    "anchorRate": 7.2,
    "breadth": 0.926,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 45.1,
    "winRate": 45.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 26.2,
    "anchorRate": 9.3,
    "breadth": 0.965,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 33.7,
    "winRate": 21.1
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 5.6,
    "anchorRate": 7,
    "breadth": 0.863,
-   "competitiveRatio": 54.9,
+   "competitiveRatio": 53.7,
    "winRate": 51.9
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 2.3,
    "anchorRate": 5.8,
    "breadth": 0.751,
-   "competitiveRatio": 53.7,
+   "competitiveRatio": 52.4,
    "winRate": 59.5
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 15.1,
    "anchorRate": 1.6,
    "breadth": 0.859,
-   "competitiveRatio": 51.2,
+   "competitiveRatio": 49.3,
    "winRate": 44.4
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 4.5,
    "anchorRate": 1.6,
    "breadth": 0.722,
-   "competitiveRatio": 56.5,
+   "competitiveRatio": 55.4,
    "winRate": 37.9
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 4,
    "anchorRate": 1.3,
    "breadth": 0.787,
-   "competitiveRatio": 48.8,
+   "competitiveRatio": 46.6,
    "winRate": 59.6
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.645,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 45.9,
    "winRate": 61.9
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 1.6,
    "anchorRate": 7.9,
    "breadth": 0.6,
-   "competitiveRatio": 49.3,
+   "competitiveRatio": 47.7,
    "winRate": 58.3
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 10.7,
    "anchorRate": 0,
    "breadth": 0.681,
-   "competitiveRatio": 46.7,
+   "competitiveRatio": 46.2,
    "winRate": 29.6
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 4.2,
    "anchorRate": 1.7,
    "breadth": 0.77,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 51.4,
    "winRate": 44.2
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 7.3,
    "anchorRate": 5.6,
    "breadth": 0.688,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 50.4,
    "winRate": 62.5
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 12.9,
    "anchorRate": 5.2,
    "breadth": 0.739,
-   "competitiveRatio": 49.1,
+   "competitiveRatio": 47.7,
    "winRate": 43.4
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 8.6,
    "anchorRate": 4,
    "breadth": 0.815,
-   "competitiveRatio": 42.2,
+   "competitiveRatio": 41.4,
    "winRate": 43.7
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 11.9,
    "breadth": 0.807,
-   "competitiveRatio": 44.2,
+   "competitiveRatio": 42.4,
    "winRate": 62.9
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 14,
    "anchorRate": 3.6,
    "breadth": 0.807,
-   "competitiveRatio": 39.8,
+   "competitiveRatio": 38.3,
    "winRate": 43.6
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 8.7,
    "anchorRate": 1.9,
    "breadth": 0.846,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 48.9,
    "winRate": 41.8
   }
  ]

--- a/public/data/conferences/southern-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/southern-intercollegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 20.2,
    "anchorRate": 12.4,
    "breadth": 0.927,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 24.2,
    "winRate": 41
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.1,
    "anchorRate": 17.1,
    "breadth": 0.94,
-   "competitiveRatio": 22.8,
+   "competitiveRatio": 22.4,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 24.9,
    "anchorRate": 5.3,
    "breadth": 0.857,
-   "competitiveRatio": 26.9,
+   "competitiveRatio": 26.8,
    "winRate": 27.4
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -159,7 +159,7 @@
    "stretchRate": 11.4,
    "anchorRate": 23.4,
    "breadth": 0.92,
-   "competitiveRatio": 35.9,
+   "competitiveRatio": 36.5,
    "winRate": 51
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 3.7,
    "anchorRate": 42.7,
    "breadth": 0.78,
-   "competitiveRatio": 24.7,
+   "competitiveRatio": 23.5,
    "winRate": 64.6
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 11.3,
    "anchorRate": 41.5,
    "breadth": 0.733,
-   "competitiveRatio": 23.7,
+   "competitiveRatio": 23.3,
    "winRate": 45.5
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 35.1,
    "anchorRate": 0,
    "breadth": 0.809,
-   "competitiveRatio": 17.3,
+   "competitiveRatio": 17.6,
    "winRate": 20.8
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 2.5,
    "anchorRate": 0,
    "breadth": 0.684,
-   "competitiveRatio": 27.8,
+   "competitiveRatio": 27,
    "winRate": 43.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 23,
    "anchorRate": 0,
    "breadth": 0.676,
-   "competitiveRatio": 24.4,
+   "competitiveRatio": 23.9,
    "winRate": 51.5
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 67.5,
    "anchorRate": 1.9,
    "breadth": 0.569,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.6,
    "winRate": 33
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 21.3,
    "anchorRate": 0,
    "breadth": 0.821,
-   "competitiveRatio": 23.3,
+   "competitiveRatio": 22.8,
    "winRate": 48
   },
   {

--- a/public/data/conferences/southern-states-athletic-conference.json
+++ b/public/data/conferences/southern-states-athletic-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 12,
    "anchorRate": 12.6,
    "breadth": 0.923,
-   "competitiveRatio": 36.5,
+   "competitiveRatio": 35.3,
    "winRate": 49.5
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 15.5,
    "anchorRate": 15.5,
    "breadth": 0.927,
-   "competitiveRatio": 36,
+   "competitiveRatio": 35,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 9.9,
    "anchorRate": 10.9,
    "breadth": 0.911,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 35.5,
    "winRate": 49.3
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 7.2,
    "anchorRate": 11.5,
    "breadth": 0.922,
-   "competitiveRatio": 51.1,
+   "competitiveRatio": 50,
    "winRate": 52.1
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 13.3,
    "anchorRate": 6.9,
    "breadth": 0.921,
-   "competitiveRatio": 47,
+   "competitiveRatio": 44.9,
    "winRate": 43.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 8.9,
    "anchorRate": 7.6,
    "breadth": 0.803,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 35.4,
    "winRate": 47.8
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 39.1,
    "anchorRate": 2,
    "breadth": 0.753,
-   "competitiveRatio": 16.8,
+   "competitiveRatio": 16.4,
    "winRate": 18.8
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 2,
    "anchorRate": 13.6,
    "breadth": 0.781,
-   "competitiveRatio": 39.4,
+   "competitiveRatio": 38.7,
    "winRate": 62.9
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 17.1,
    "anchorRate": 8,
    "breadth": 0.749,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 32.6,
    "winRate": 56.9
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 23.2,
    "anchorRate": 13.4,
    "breadth": 0.937,
-   "competitiveRatio": 27.3,
+   "competitiveRatio": 26.9,
    "winRate": 29.5
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 21.1,
    "breadth": 0.715,
-   "competitiveRatio": 36.8,
+   "competitiveRatio": 35.5,
    "winRate": 62.4
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 0,
    "anchorRate": 25.9,
    "breadth": 0.595,
-   "competitiveRatio": 29.8,
+   "competitiveRatio": 28.4,
    "winRate": 77
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 11.9,
    "breadth": 0.749,
-   "competitiveRatio": 54.9,
+   "competitiveRatio": 51.3,
    "winRate": 49.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 13.5,
    "breadth": 0.743,
-   "competitiveRatio": 29.9,
+   "competitiveRatio": 28.8,
    "winRate": 52.9
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 25.1,
    "anchorRate": 12.4,
    "breadth": 0.925,
-   "competitiveRatio": 37.1,
+   "competitiveRatio": 36,
    "winRate": 41.9
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 12.1,
    "anchorRate": 10.6,
    "breadth": 0.815,
-   "competitiveRatio": 24.8,
+   "competitiveRatio": 23.3,
    "winRate": 40.9
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0,
    "anchorRate": 33.3,
    "breadth": 0.76,
-   "competitiveRatio": 41.3,
+   "competitiveRatio": 38.9,
    "winRate": 77.8
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 1.2,
    "anchorRate": 9.8,
    "breadth": 0.8,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 46.3,
    "winRate": 45.3
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 56.6,
    "anchorRate": 0,
    "breadth": 0.607,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 24.6,
    "winRate": 30.9
   }
  ]

--- a/public/data/conferences/southland-conference.json
+++ b/public/data/conferences/southland-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 450,
     "UP": 1929,
-    "EVEN": 848,
-    "DOWN": 1882,
+    "EVEN": 801,
+    "DOWN": 1929,
     "ANCHOR": 732
    },
    "bandPct": {
     "STRETCH": 7.7,
     "UP": 33,
-    "EVEN": 14.5,
-    "DOWN": 32.2,
+    "EVEN": 13.7,
+    "DOWN": 33,
     "ANCHOR": 12.5
    },
    "stretchRate": 7.7,
    "anchorRate": 12.5,
-   "breadth": 0.913,
-   "competitiveRatio": 43,
+   "breadth": 0.908,
+   "competitiveRatio": 42.3,
    "winRate": 53.6
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 42,
     "UP": 943,
-    "EVEN": 440,
-    "DOWN": 943,
+    "EVEN": 417,
+    "DOWN": 966,
     "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 1.7,
     "UP": 39.1,
-    "EVEN": 18.3,
-    "DOWN": 39.1,
+    "EVEN": 17.3,
+    "DOWN": 40.1,
     "ANCHOR": 1.7
    },
    "stretchRate": 1.7,
    "anchorRate": 1.7,
-   "breadth": 0.737,
-   "competitiveRatio": 49.9,
+   "breadth": 0.732,
+   "competitiveRatio": 48.9,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 408,
     "UP": 986,
-    "EVEN": 408,
-    "DOWN": 939,
+    "EVEN": 384,
+    "DOWN": 963,
     "ANCHOR": 690
    },
    "bandPct": {
     "STRETCH": 11.9,
     "UP": 28.7,
-    "EVEN": 11.9,
-    "DOWN": 27.4,
+    "EVEN": 11.2,
+    "DOWN": 28.1,
     "ANCHOR": 20.1
    },
    "stretchRate": 11.9,
    "anchorRate": 20.1,
-   "breadth": 0.958,
-   "competitiveRatio": 38.2,
+   "breadth": 0.954,
+   "competitiveRatio": 37.7,
    "winRate": 56.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 19.2,
    "anchorRate": 16.3,
    "breadth": 0.967,
-   "competitiveRatio": 45.8,
+   "competitiveRatio": 45,
    "winRate": 48.8
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 17.7,
    "breadth": 0.755,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 35.4,
    "winRate": 72.8
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 25.9,
    "anchorRate": 0.8,
    "breadth": 0.876,
-   "competitiveRatio": 51,
+   "competitiveRatio": 49.6,
    "winRate": 36.9
   },
   {
@@ -198,21 +198,21 @@
    "bands": {
     "STRETCH": 6,
     "UP": 129,
-    "EVEN": 50,
-    "DOWN": 124,
+    "EVEN": 38,
+    "DOWN": 136,
     "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 1.7,
     "UP": 36.8,
-    "EVEN": 14.2,
-    "DOWN": 35.3,
+    "EVEN": 10.8,
+    "DOWN": 38.7,
     "ANCHOR": 12
    },
    "stretchRate": 1.7,
    "anchorRate": 12,
-   "breadth": 0.831,
-   "competitiveRatio": 44.6,
+   "breadth": 0.807,
+   "competitiveRatio": 44.3,
    "winRate": 53.6
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0.9,
    "anchorRate": 6.2,
    "breadth": 0.73,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 47.5,
    "winRate": 70.1
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 7,
    "anchorRate": 3.5,
    "breadth": 0.832,
-   "competitiveRatio": 45.7,
+   "competitiveRatio": 45.5,
    "winRate": 41.9
   },
   {
@@ -279,21 +279,21 @@
    "bands": {
     "STRETCH": 3,
     "UP": 7,
-    "EVEN": 44,
-    "DOWN": 196,
+    "EVEN": 21,
+    "DOWN": 219,
     "ANCHOR": 89
    },
    "bandPct": {
     "STRETCH": 0.9,
     "UP": 2.1,
-    "EVEN": 13,
-    "DOWN": 57.8,
+    "EVEN": 6.2,
+    "DOWN": 64.6,
     "ANCHOR": 26.3
    },
    "stretchRate": 0.9,
    "anchorRate": 26.3,
-   "breadth": 0.655,
-   "competitiveRatio": 31.3,
+   "breadth": 0.576,
+   "competitiveRatio": 30.4,
    "winRate": 81.7
   },
   {
@@ -306,21 +306,21 @@
    "bands": {
     "STRETCH": 9,
     "UP": 107,
-    "EVEN": 103,
-    "DOWN": 108,
+    "EVEN": 91,
+    "DOWN": 120,
     "ANCHOR": 4
    },
    "bandPct": {
     "STRETCH": 2.7,
     "UP": 32.3,
-    "EVEN": 31.1,
-    "DOWN": 32.6,
+    "EVEN": 27.5,
+    "DOWN": 36.3,
     "ANCHOR": 1.2
    },
    "stretchRate": 2.7,
    "anchorRate": 1.2,
-   "breadth": 0.774,
-   "competitiveRatio": 47.7,
+   "breadth": 0.77,
+   "competitiveRatio": 46.5,
    "winRate": 62.5
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 3.6,
    "anchorRate": 16.9,
    "breadth": 0.771,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 38.4,
    "winRate": 41.7
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 1.9,
    "anchorRate": 2.8,
    "breadth": 0.638,
-   "competitiveRatio": 42.5,
+   "competitiveRatio": 41.6,
    "winRate": 50.6
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 5.7,
    "anchorRate": 6.6,
    "breadth": 0.637,
-   "competitiveRatio": 42.5,
+   "competitiveRatio": 42.1,
    "winRate": 37.1
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 7.9,
    "anchorRate": 20.4,
    "breadth": 0.885,
-   "competitiveRatio": 48.5,
+   "competitiveRatio": 47.5,
    "winRate": 53.6
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 5.9,
    "anchorRate": 0,
    "breadth": 0.711,
-   "competitiveRatio": 42.4,
+   "competitiveRatio": 41.4,
    "winRate": 35.9
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 5,
    "anchorRate": 37.3,
    "breadth": 0.799,
-   "competitiveRatio": 39,
+   "competitiveRatio": 37.7,
    "winRate": 68.7
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 3.7,
    "anchorRate": 9.8,
    "breadth": 0.807,
-   "competitiveRatio": 44.6,
+   "competitiveRatio": 44.2,
    "winRate": 57.2
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 5.3,
    "anchorRate": 28.4,
    "breadth": 0.842,
-   "competitiveRatio": 45.1,
+   "competitiveRatio": 44.4,
    "winRate": 62.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 6,
    "anchorRate": 9.8,
    "breadth": 0.668,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 42.3,
    "winRate": 43.5
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 36.3,
    "anchorRate": 12.8,
    "breadth": 0.818,
-   "competitiveRatio": 37.9,
+   "competitiveRatio": 37.1,
    "winRate": 43.4
   }
  ]

--- a/public/data/conferences/southwestern-athletic-conference.json
+++ b/public/data/conferences/southwestern-athletic-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 1242,
     "UP": 1063,
-    "EVEN": 180,
-    "DOWN": 640,
+    "EVEN": 174,
+    "DOWN": 646,
     "ANCHOR": 231
    },
    "bandPct": {
     "STRETCH": 37,
     "UP": 31.7,
-    "EVEN": 5.4,
-    "DOWN": 19.1,
+    "EVEN": 5.2,
+    "DOWN": 19.2,
     "ANCHOR": 6.9
    },
    "stretchRate": 37,
    "anchorRate": 6.9,
-   "breadth": 0.863,
-   "competitiveRatio": 24.4,
+   "breadth": 0.862,
+   "competitiveRatio": 23.8,
    "winRate": 32.5
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 13,
    "anchorRate": 13,
    "breadth": 0.878,
-   "competitiveRatio": 20.8,
+   "competitiveRatio": 20,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 1094,
     "UP": 669,
-    "EVEN": 124,
-    "DOWN": 246,
+    "EVEN": 118,
+    "DOWN": 252,
     "ANCHOR": 83
    },
    "bandPct": {
     "STRETCH": 49.4,
     "UP": 30.2,
-    "EVEN": 5.6,
-    "DOWN": 11.1,
+    "EVEN": 5.3,
+    "DOWN": 11.4,
     "ANCHOR": 3.7
    },
    "stretchRate": 49.4,
    "anchorRate": 3.7,
-   "breadth": 0.769,
-   "competitiveRatio": 26.3,
+   "breadth": 0.768,
+   "competitiveRatio": 25.7,
    "winRate": 23.6
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 65.2,
    "anchorRate": 10.9,
    "breadth": 0.664,
-   "competitiveRatio": 18.7,
+   "competitiveRatio": 17.7,
    "winRate": 21.9
   },
   {
@@ -144,21 +144,21 @@
    "bands": {
     "STRETCH": 24,
     "UP": 61,
-    "EVEN": 25,
-    "DOWN": 142,
+    "EVEN": 19,
+    "DOWN": 148,
     "ANCHOR": 49
    },
    "bandPct": {
     "STRETCH": 8,
     "UP": 20.3,
-    "EVEN": 8.3,
-    "DOWN": 47.2,
+    "EVEN": 6.3,
+    "DOWN": 49.2,
     "ANCHOR": 16.3
    },
    "stretchRate": 8,
    "anchorRate": 16.3,
-   "breadth": 0.859,
-   "competitiveRatio": 37,
+   "breadth": 0.835,
+   "competitiveRatio": 36.3,
    "winRate": 55.5
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 5.2,
    "anchorRate": 3.8,
    "breadth": 0.786,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 33.3,
    "winRate": 54.5
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 19.9,
    "anchorRate": 9.9,
    "breadth": 0.878,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 34.6,
    "winRate": 52.6
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 5.7,
    "anchorRate": 1.9,
    "breadth": 0.711,
-   "competitiveRatio": 31,
+   "competitiveRatio": 30.3,
    "winRate": 34.9
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 25.3,
    "anchorRate": 4.8,
    "breadth": 0.69,
-   "competitiveRatio": 32.4,
+   "competitiveRatio": 31.6,
    "winRate": 36.5
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 35.3,
    "anchorRate": 4.8,
    "breadth": 0.823,
-   "competitiveRatio": 12.8,
+   "competitiveRatio": 11.8,
    "winRate": 23.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 32.8,
    "anchorRate": 2.7,
    "breadth": 0.649,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 26.6,
    "winRate": 29
   },
   {

--- a/public/data/conferences/state-university-of-new-york-athletic-conference.json
+++ b/public/data/conferences/state-university-of-new-york-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 10.3,
    "anchorRate": 4.1,
    "breadth": 0.873,
-   "competitiveRatio": 25.5,
+   "competitiveRatio": 24.7,
    "winRate": 47.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 4.6,
    "anchorRate": 4.6,
    "breadth": 0.809,
-   "competitiveRatio": 26,
+   "competitiveRatio": 24.8,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 13.5,
    "anchorRate": 3.9,
    "breadth": 0.894,
-   "competitiveRatio": 25.3,
+   "competitiveRatio": 24.7,
    "winRate": 46.3
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -159,7 +159,7 @@
    "stretchRate": 18.8,
    "anchorRate": 0,
    "breadth": 0.702,
-   "competitiveRatio": 28,
+   "competitiveRatio": 26.5,
    "winRate": 36.2
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 3.8,
    "anchorRate": 9.2,
    "breadth": 0.875,
-   "competitiveRatio": 21.7,
+   "competitiveRatio": 22.3,
    "winRate": 57.6
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 17.2,
    "breadth": 0.528,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 21.1,
    "winRate": 64.3
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.632,
-   "competitiveRatio": 20.9,
+   "competitiveRatio": 20,
    "winRate": 60.4
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 2.7,
    "anchorRate": 0,
    "breadth": 0.721,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 28.6,
    "winRate": 52.3
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 5.9,
    "anchorRate": 0,
    "breadth": 0.653,
-   "competitiveRatio": 25.9,
+   "competitiveRatio": 24.9,
    "winRate": 29.8
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 4.5,
    "anchorRate": 0,
    "breadth": 0.697,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.8,
    "winRate": 54.2
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 6,
    "breadth": 0.778,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 26.1,
    "winRate": 51.8
   }
  ]

--- a/public/data/conferences/summit-league.json
+++ b/public/data/conferences/summit-league.json
@@ -30,7 +30,7 @@
    "stretchRate": 9.2,
    "anchorRate": 5.6,
    "breadth": 0.895,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 46.9,
    "winRate": 48.4
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 1.5,
    "anchorRate": 1.5,
    "breadth": 0.758,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 50.4,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 12.7,
    "anchorRate": 7.6,
    "breadth": 0.921,
-   "competitiveRatio": 46.5,
+   "competitiveRatio": 45.3,
    "winRate": 47.7
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 7.5,
    "anchorRate": 1.5,
    "breadth": 0.789,
-   "competitiveRatio": 46.2,
+   "competitiveRatio": 45.4,
    "winRate": 50.4
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 3.1,
    "anchorRate": 5.9,
    "breadth": 0.816,
-   "competitiveRatio": 49.7,
+   "competitiveRatio": 48.5,
    "winRate": 52.3
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 1.6,
    "anchorRate": 0,
    "breadth": 0.59,
-   "competitiveRatio": 55.4,
+   "competitiveRatio": 54.7,
    "winRate": 71.8
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 7.1,
    "anchorRate": 5.2,
    "breadth": 0.841,
-   "competitiveRatio": 57.2,
+   "competitiveRatio": 56.4,
    "winRate": 49
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 4.2,
    "anchorRate": 5.5,
    "breadth": 0.853,
-   "competitiveRatio": 55.4,
+   "competitiveRatio": 54.9,
    "winRate": 49.9
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 17.2,
    "anchorRate": 9.5,
    "breadth": 0.964,
-   "competitiveRatio": 52.1,
+   "competitiveRatio": 51.1,
    "winRate": 43.1
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 22.2,
    "anchorRate": 3,
    "breadth": 0.526,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 41.5,
    "winRate": 45
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 1.8,
    "anchorRate": 6.3,
    "breadth": 0.739,
-   "competitiveRatio": 43.2,
+   "competitiveRatio": 42.3,
    "winRate": 64.3
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 7.7,
    "anchorRate": 6.7,
    "breadth": 0.878,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 38.3,
    "winRate": 34.8
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 25.2,
    "anchorRate": 9.3,
    "breadth": 0.774,
-   "competitiveRatio": 34.3,
+   "competitiveRatio": 33.7,
    "winRate": 29.4
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 1.3,
    "anchorRate": 2,
    "breadth": 0.763,
-   "competitiveRatio": 50.5,
+   "competitiveRatio": 48.5,
    "winRate": 42
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 13.2,
    "anchorRate": 13.8,
    "breadth": 0.969,
-   "competitiveRatio": 47.7,
+   "competitiveRatio": 46.4,
    "winRate": 50.3
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 10.7,
    "anchorRate": 7.1,
    "breadth": 0.899,
-   "competitiveRatio": 42.5,
+   "competitiveRatio": 41.7,
    "winRate": 37.5
   }
  ]

--- a/public/data/conferences/sun-belt-conference.json
+++ b/public/data/conferences/sun-belt-conference.json
@@ -16,21 +16,21 @@
    "bands": {
     "STRETCH": 360,
     "UP": 2265,
-    "EVEN": 1260,
-    "DOWN": 2571,
+    "EVEN": 1233,
+    "DOWN": 2598,
     "ANCHOR": 400
    },
    "bandPct": {
     "STRETCH": 5.3,
     "UP": 33,
-    "EVEN": 18.4,
-    "DOWN": 37.5,
+    "EVEN": 18,
+    "DOWN": 37.9,
     "ANCHOR": 5.8
    },
    "stretchRate": 5.3,
    "anchorRate": 5.8,
-   "breadth": 0.848,
-   "competitiveRatio": 46.1,
+   "breadth": 0.847,
+   "competitiveRatio": 44.1,
    "winRate": 53.1
   },
   "inConference": {
@@ -38,21 +38,21 @@
    "bands": {
     "STRETCH": 10,
     "UP": 1034,
-    "EVEN": 552,
-    "DOWN": 1034,
+    "EVEN": 537,
+    "DOWN": 1049,
     "ANCHOR": 10
    },
    "bandPct": {
     "STRETCH": 0.4,
     "UP": 39.2,
-    "EVEN": 20.9,
-    "DOWN": 39.2,
+    "EVEN": 20.3,
+    "DOWN": 39.7,
     "ANCHOR": 0.4
    },
    "stretchRate": 0.4,
    "anchorRate": 0.4,
-   "breadth": 0.686,
-   "competitiveRatio": 45,
+   "breadth": 0.683,
+   "competitiveRatio": 42.3,
    "winRate": 50
   },
   "nonConference": {
@@ -60,21 +60,21 @@
    "bands": {
     "STRETCH": 350,
     "UP": 1231,
-    "EVEN": 708,
-    "DOWN": 1537,
+    "EVEN": 696,
+    "DOWN": 1549,
     "ANCHOR": 390
    },
    "bandPct": {
     "STRETCH": 8.3,
     "UP": 29.2,
-    "EVEN": 16.8,
-    "DOWN": 36.5,
+    "EVEN": 16.5,
+    "DOWN": 36.7,
     "ANCHOR": 9.3
    },
    "stretchRate": 8.3,
    "anchorRate": 9.3,
-   "breadth": 0.903,
-   "competitiveRatio": 46.7,
+   "breadth": 0.902,
+   "competitiveRatio": 45.3,
    "winRate": 55
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 2.2,
    "anchorRate": 26.5,
    "breadth": 0.848,
-   "competitiveRatio": 39,
+   "competitiveRatio": 36,
    "winRate": 70.8
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 1.6,
    "anchorRate": 4.1,
    "breadth": 0.534,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 41.3,
    "winRate": 55.8
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 1.7,
    "anchorRate": 0.8,
    "breadth": 0.694,
-   "competitiveRatio": 47.5,
+   "competitiveRatio": 45,
    "winRate": 59.7
   },
   {
@@ -225,21 +225,21 @@
    "bands": {
     "STRETCH": 0,
     "UP": 51,
-    "EVEN": 90,
-    "DOWN": 174,
+    "EVEN": 75,
+    "DOWN": 189,
     "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.3,
-    "EVEN": 27,
-    "DOWN": 52.3,
+    "EVEN": 22.5,
+    "DOWN": 56.8,
     "ANCHOR": 5.4
    },
    "stretchRate": 0,
    "anchorRate": 5.4,
-   "breadth": 0.707,
-   "competitiveRatio": 45.9,
+   "breadth": 0.685,
+   "competitiveRatio": 44.1,
    "winRate": 53.5
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 8.2,
    "anchorRate": 0,
    "breadth": 0.78,
-   "competitiveRatio": 55.5,
+   "competitiveRatio": 52.1,
    "winRate": 56.4
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 21.8,
    "anchorRate": 3.7,
    "breadth": 0.565,
-   "competitiveRatio": 43.6,
+   "competitiveRatio": 42.4,
    "winRate": 36.1
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 6.3,
    "anchorRate": 5.7,
    "breadth": 0.743,
-   "competitiveRatio": 50.2,
+   "competitiveRatio": 48.3,
    "winRate": 50.2
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 8.5,
    "anchorRate": 1.3,
    "breadth": 0.795,
-   "competitiveRatio": 46.1,
+   "competitiveRatio": 44.5,
    "winRate": 44.2
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0.9,
    "anchorRate": 8.8,
    "breadth": 0.772,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 45.7,
    "winRate": 57.7
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 12.5,
    "anchorRate": 5.8,
    "breadth": 0.916,
-   "competitiveRatio": 53.2,
+   "competitiveRatio": 48.4,
    "winRate": 47.4
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 5.4,
    "anchorRate": 2.6,
    "breadth": 0.73,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 41.3,
    "winRate": 57.1
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 4.9,
    "anchorRate": 1.9,
    "breadth": 0.685,
-   "competitiveRatio": 51.9,
+   "competitiveRatio": 50.6,
    "winRate": 45.5
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 11.1,
    "anchorRate": 10.1,
    "breadth": 0.895,
-   "competitiveRatio": 54.9,
+   "competitiveRatio": 51.6,
    "winRate": 49
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 0,
    "anchorRate": 1.7,
    "breadth": 0.572,
-   "competitiveRatio": 43,
+   "competitiveRatio": 42.7,
    "winRate": 69.9
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 2,
    "breadth": 0.668,
-   "competitiveRatio": 41.9,
+   "competitiveRatio": 40.9,
    "winRate": 57.9
   },
   {
@@ -549,21 +549,21 @@
    "bands": {
     "STRETCH": 9,
     "UP": 137,
-    "EVEN": 45,
-    "DOWN": 96,
+    "EVEN": 33,
+    "DOWN": 108,
     "ANCHOR": 5
    },
    "bandPct": {
     "STRETCH": 3.1,
     "UP": 46.9,
-    "EVEN": 15.4,
-    "DOWN": 32.9,
+    "EVEN": 11.3,
+    "DOWN": 37,
     "ANCHOR": 1.7
    },
    "stretchRate": 3.1,
    "anchorRate": 1.7,
-   "breadth": 0.737,
-   "competitiveRatio": 44.2,
+   "breadth": 0.712,
+   "competitiveRatio": 42.8,
    "winRate": 59.2
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 9.6,
    "anchorRate": 0,
    "breadth": 0.601,
-   "competitiveRatio": 44.1,
+   "competitiveRatio": 40.2,
    "winRate": 37.2
   },
   {
@@ -617,7 +617,7 @@
    "stretchRate": 1.1,
    "anchorRate": 2.2,
    "breadth": 0.756,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 46.9,
    "winRate": 61.2
   },
   {
@@ -698,7 +698,7 @@
    "stretchRate": 1.4,
    "anchorRate": 4.1,
    "breadth": 0.697,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 35.2,
    "winRate": 32
   }
  ]

--- a/public/data/conferences/sunshine-state-conference.json
+++ b/public/data/conferences/sunshine-state-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 5.9,
    "anchorRate": 14,
    "breadth": 0.88,
-   "competitiveRatio": 41.4,
+   "competitiveRatio": 40.3,
    "winRate": 58.4
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 8.4,
    "anchorRate": 8.4,
    "breadth": 0.89,
-   "competitiveRatio": 42.6,
+   "competitiveRatio": 42,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 3.5,
    "anchorRate": 19.6,
    "breadth": 0.821,
-   "competitiveRatio": 40.2,
+   "competitiveRatio": 38.6,
    "winRate": 66.8
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 10.9,
    "breadth": 0.599,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 37.3,
    "winRate": 76.2
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 9.2,
    "breadth": 0.644,
-   "competitiveRatio": 38.3,
+   "competitiveRatio": 37.8,
    "winRate": 69.2
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 29.6,
    "breadth": 0.474,
-   "competitiveRatio": 34.7,
+   "competitiveRatio": 34.4,
    "winRate": 81.8
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 14.2,
    "breadth": 0.82,
-   "competitiveRatio": 48.2,
+   "competitiveRatio": 43.9,
    "winRate": 68.3
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 1.5,
    "anchorRate": 16.3,
    "breadth": 0.873,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 48.1,
    "winRate": 62.6
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 23.4,
    "breadth": 0.338,
-   "competitiveRatio": 52.4,
+   "competitiveRatio": 47.6,
    "winRate": 77.4
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 3.4,
    "breadth": 0.653,
-   "competitiveRatio": 44,
+   "competitiveRatio": 44.5,
    "winRate": 62
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 5.1,
    "anchorRate": 6.6,
    "breadth": 0.729,
-   "competitiveRatio": 40.6,
+   "competitiveRatio": 38.3,
    "winRate": 48.9
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 19.8,
    "breadth": 0.808,
-   "competitiveRatio": 44.8,
+   "competitiveRatio": 43.7,
    "winRate": 63.8
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 23.1,
    "breadth": 0.833,
-   "competitiveRatio": 42.9,
+   "competitiveRatio": 41.1,
    "winRate": 66.3
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 27.5,
    "anchorRate": 1.9,
    "breadth": 0.687,
-   "competitiveRatio": 30,
+   "competitiveRatio": 30.3,
    "winRate": 25.6
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 0,
    "anchorRate": 12.3,
    "breadth": 0.716,
-   "competitiveRatio": 42.3,
+   "competitiveRatio": 41.6,
    "winRate": 54.6
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 21.5,
    "breadth": 0.707,
-   "competitiveRatio": 38.9,
+   "competitiveRatio": 36.9,
    "winRate": 63.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 5.5,
    "anchorRate": 11,
    "breadth": 0.789,
-   "competitiveRatio": 42.1,
+   "competitiveRatio": 41,
    "winRate": 44.7
   },
   {
@@ -590,7 +590,7 @@
    "stretchRate": 0,
    "anchorRate": 18.8,
    "breadth": 0.836,
-   "competitiveRatio": 49.2,
+   "competitiveRatio": 49.6,
    "winRate": 49.2
   }
  ]

--- a/public/data/conferences/the-sun-conference.json
+++ b/public/data/conferences/the-sun-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 9.6,
    "anchorRate": 14.6,
    "breadth": 0.933,
-   "competitiveRatio": 30.1,
+   "competitiveRatio": 28.5,
    "winRate": 50
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 11,
    "anchorRate": 11,
    "breadth": 0.904,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 18.6,
    "winRate": 49.9
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 8.8,
    "anchorRate": 16.5,
    "breadth": 0.942,
-   "competitiveRatio": 35.7,
+   "competitiveRatio": 33.9,
    "winRate": 50.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -158,7 +158,7 @@
    "stretchRate": 7.2,
    "anchorRate": 9.6,
    "breadth": 0.896,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 30.9,
    "winRate": 36.8
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 19.6,
    "breadth": 0.757,
-   "competitiveRatio": 34.2,
+   "competitiveRatio": 31.2,
    "winRate": 70.7
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 0,
    "anchorRate": 13.2,
    "breadth": 0.806,
-   "competitiveRatio": 32.1,
+   "competitiveRatio": 30.9,
    "winRate": 58.5
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 38.8,
    "breadth": 0.721,
-   "competitiveRatio": 32.8,
+   "competitiveRatio": 31.6,
    "winRate": 79.6
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 8.9,
    "anchorRate": 19.4,
    "breadth": 0.868,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 35.9,
    "winRate": 50.2
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 12.9,
    "breadth": 0.811,
-   "competitiveRatio": 39.1,
+   "competitiveRatio": 38.2,
    "winRate": 33.3
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 17.3,
    "anchorRate": 0,
    "breadth": 0.758,
-   "competitiveRatio": 40.3,
+   "competitiveRatio": 38.3,
    "winRate": 42.6
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 6.5,
    "anchorRate": 21.2,
    "breadth": 0.873,
-   "competitiveRatio": 19.6,
+   "competitiveRatio": 17.9,
    "winRate": 48.9
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 31.3,
    "anchorRate": 3.4,
    "breadth": 0.727,
-   "competitiveRatio": 36.4,
+   "competitiveRatio": 31.8,
    "winRate": 37.5
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 55.4,
    "anchorRate": 2.9,
    "breadth": 0.663,
-   "competitiveRatio": 19.4,
+   "competitiveRatio": 20.1,
    "winRate": 20.9
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 20.3,
    "anchorRate": 0,
    "breadth": 0.655,
-   "competitiveRatio": 14.4,
+   "competitiveRatio": 11,
    "winRate": 13.6
   }
  ]

--- a/public/data/conferences/united-east-conference.json
+++ b/public/data/conferences/united-east-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 6.2,
    "anchorRate": 3.8,
    "breadth": 0.796,
-   "competitiveRatio": 25.7,
+   "competitiveRatio": 25.3,
    "winRate": 44.4
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 4,
    "anchorRate": 4,
    "breadth": 0.775,
-   "competitiveRatio": 22.9,
+   "competitiveRatio": 22.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 8.5,
    "anchorRate": 3.7,
    "breadth": 0.808,
-   "competitiveRatio": 28.7,
+   "competitiveRatio": 28.3,
    "winRate": 38.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 1.5,
    "anchorRate": 11.4,
    "breadth": 0.756,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 27.2,
    "winRate": 61.7
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 6.2,
    "anchorRate": 0,
    "breadth": 0.688,
-   "competitiveRatio": 22.8,
+   "competitiveRatio": 22.5,
    "winRate": 60.6
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 0,
    "anchorRate": 4.8,
    "breadth": 0.672,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 31.3,
    "winRate": 54.8
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.2,
    "anchorRate": 15.1,
    "breadth": 0.631,
-   "competitiveRatio": 22.4,
+   "competitiveRatio": 22,
    "winRate": 62.9
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 0,
    "anchorRate": 4.2,
    "breadth": 0.464,
-   "competitiveRatio": 28.7,
+   "competitiveRatio": 27.8,
    "winRate": 53.8
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 10.2,
    "anchorRate": 0,
    "breadth": 0.759,
-   "competitiveRatio": 38.2,
+   "competitiveRatio": 37.8,
    "winRate": 54.9
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 19.2,
    "anchorRate": 0,
    "breadth": 0.521,
-   "competitiveRatio": 19.7,
+   "competitiveRatio": 18.9,
    "winRate": 32.8
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 5.3,
    "anchorRate": 0,
    "breadth": 0.643,
-   "competitiveRatio": 31.7,
+   "competitiveRatio": 31.3,
    "winRate": 21.6
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.571,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 30.6,
    "winRate": 36.1
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 0,
    "anchorRate": 11.1,
    "breadth": 0.765,
-   "competitiveRatio": 30.2,
+   "competitiveRatio": 27.5,
    "winRate": 47.6
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 11.8,
    "anchorRate": 0,
    "breadth": 0.705,
-   "competitiveRatio": 26.1,
+   "competitiveRatio": 25.5,
    "winRate": 25.5
   },
   {
@@ -537,7 +537,7 @@
    "stretchRate": 14.6,
    "anchorRate": 0,
    "breadth": 0.643,
-   "competitiveRatio": 13,
+   "competitiveRatio": 12.2,
    "winRate": 17.1
   }
  ]

--- a/public/data/conferences/university-athletic-association.json
+++ b/public/data/conferences/university-athletic-association.json
@@ -17,20 +17,20 @@
     "STRETCH": 229,
     "UP": 1143,
     "EVEN": 750,
-    "DOWN": 2121,
-    "ANCHOR": 1357
+    "DOWN": 2092,
+    "ANCHOR": 1386
    },
    "bandPct": {
     "STRETCH": 4.1,
     "UP": 20.4,
     "EVEN": 13.4,
-    "DOWN": 37.9,
-    "ANCHOR": 24.2
+    "DOWN": 37.4,
+    "ANCHOR": 24.8
    },
    "stretchRate": 4.1,
-   "anchorRate": 24.2,
-   "breadth": 0.892,
-   "competitiveRatio": 39.9,
+   "anchorRate": 24.8,
+   "breadth": 0.893,
+   "competitiveRatio": 38.7,
    "winRate": 65.2
   },
   "inConference": {
@@ -61,20 +61,20 @@
     "STRETCH": 107,
     "UP": 785,
     "EVEN": 478,
-    "DOWN": 1763,
-    "ANCHOR": 1235
+    "DOWN": 1734,
+    "ANCHOR": 1264
    },
    "bandPct": {
     "STRETCH": 2.4,
     "UP": 18,
     "EVEN": 10.9,
-    "DOWN": 40.4,
-    "ANCHOR": 28.3
+    "DOWN": 39.7,
+    "ANCHOR": 28.9
    },
    "stretchRate": 2.4,
-   "anchorRate": 28.3,
-   "breadth": 0.848,
-   "competitiveRatio": 39.9,
+   "anchorRate": 28.9,
+   "breadth": 0.849,
+   "competitiveRatio": 38.5,
    "winRate": 69.4
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -131,7 +131,7 @@
    "stretchRate": 0,
    "anchorRate": 46.7,
    "breadth": 0.722,
-   "competitiveRatio": 37.8,
+   "competitiveRatio": 36.9,
    "winRate": 77
   },
   {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 36,
    "breadth": 0.468,
-   "competitiveRatio": 44,
+   "competitiveRatio": 41.6,
    "winRate": 78
   },
   {
@@ -199,20 +199,20 @@
     "STRETCH": 0,
     "UP": 10,
     "EVEN": 97,
-    "DOWN": 133,
-    "ANCHOR": 149
+    "DOWN": 127,
+    "ANCHOR": 155
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 2.6,
     "EVEN": 24.9,
-    "DOWN": 34.2,
-    "ANCHOR": 38.3
+    "DOWN": 32.6,
+    "ANCHOR": 39.8
    },
    "stretchRate": 0,
-   "anchorRate": 38.3,
-   "breadth": 0.73,
-   "competitiveRatio": 34.7,
+   "anchorRate": 39.8,
+   "breadth": 0.729,
+   "competitiveRatio": 34.4,
    "winRate": 75.3
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 21,
    "breadth": 0.777,
-   "competitiveRatio": 49,
+   "competitiveRatio": 48.2,
    "winRate": 57.8
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 11.3,
    "breadth": 0.713,
-   "competitiveRatio": 39.4,
+   "competitiveRatio": 38,
    "winRate": 72
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 27.7,
    "breadth": 0.802,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 39.3,
    "winRate": 64.7
   },
   {
@@ -334,20 +334,20 @@
     "STRETCH": 0,
     "UP": 97,
     "EVEN": 61,
-    "DOWN": 160,
-    "ANCHOR": 32
+    "DOWN": 148,
+    "ANCHOR": 44
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 27.7,
     "EVEN": 17.4,
-    "DOWN": 45.7,
-    "ANCHOR": 9.1
+    "DOWN": 42.3,
+    "ANCHOR": 12.6
    },
    "stretchRate": 0,
-   "anchorRate": 9.1,
-   "breadth": 0.768,
-   "competitiveRatio": 49.6,
+   "anchorRate": 12.6,
+   "breadth": 0.798,
+   "competitiveRatio": 47.6,
    "winRate": 55.4
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 0,
    "anchorRate": 24.1,
    "breadth": 0.794,
-   "competitiveRatio": 34.1,
+   "competitiveRatio": 33.7,
    "winRate": 65.1
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 43.4,
    "anchorRate": 0,
    "breadth": 0.733,
-   "competitiveRatio": 28.1,
+   "competitiveRatio": 25.5,
    "winRate": 45.5
   },
   {
@@ -415,20 +415,20 @@
     "STRETCH": 0,
     "UP": 102,
     "EVEN": 40,
-    "DOWN": 117,
-    "ANCHOR": 58
+    "DOWN": 106,
+    "ANCHOR": 69
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.2,
     "EVEN": 12.6,
-    "DOWN": 36.9,
-    "ANCHOR": 18.3
+    "DOWN": 33.4,
+    "ANCHOR": 21.8
    },
    "stretchRate": 0,
-   "anchorRate": 18.3,
-   "breadth": 0.811,
-   "competitiveRatio": 34.3,
+   "anchorRate": 21.8,
+   "breadth": 0.823,
+   "competitiveRatio": 34.6,
    "winRate": 55.8
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 23.8,
    "anchorRate": 8.2,
    "breadth": 0.802,
-   "competitiveRatio": 38.8,
+   "competitiveRatio": 38.1,
    "winRate": 51.4
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 0.7,
    "anchorRate": 13.4,
    "breadth": 0.812,
-   "competitiveRatio": 53.9,
+   "competitiveRatio": 52.5,
    "winRate": 51.4
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 6.2,
    "anchorRate": 2.3,
    "breadth": 0.742,
-   "competitiveRatio": 52.9,
+   "competitiveRatio": 50.6,
    "winRate": 54.1
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 0,
    "anchorRate": 30.6,
    "breadth": 0.841,
-   "competitiveRatio": 32,
+   "competitiveRatio": 30.6,
    "winRate": 64.6
   }
  ]

--- a/public/data/conferences/upper-midwest-athletic-conference.json
+++ b/public/data/conferences/upper-midwest-athletic-conference.json
@@ -17,21 +17,21 @@
    "bands": {
     "STRETCH": 874,
     "UP": 2489,
-    "EVEN": 639,
-    "DOWN": 1490,
+    "EVEN": 627,
+    "DOWN": 1502,
     "ANCHOR": 329
    },
    "bandPct": {
     "STRETCH": 15,
     "UP": 42.8,
-    "EVEN": 11,
-    "DOWN": 25.6,
+    "EVEN": 10.8,
+    "DOWN": 25.8,
     "ANCHOR": 5.7
    },
    "stretchRate": 15,
    "anchorRate": 5.7,
-   "breadth": 0.871,
-   "competitiveRatio": 28.5,
+   "breadth": 0.87,
+   "competitiveRatio": 27.9,
    "winRate": 42.6
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 10.7,
    "anchorRate": 10.7,
    "breadth": 0.902,
-   "competitiveRatio": 22.6,
+   "competitiveRatio": 22.2,
    "winRate": 50
   },
   "nonConference": {
@@ -61,21 +61,21 @@
    "bands": {
     "STRETCH": 692,
     "UP": 1910,
-    "EVEN": 455,
-    "DOWN": 911,
+    "EVEN": 443,
+    "DOWN": 923,
     "ANCHOR": 147
    },
    "bandPct": {
     "STRETCH": 16.8,
     "UP": 46.4,
-    "EVEN": 11.1,
-    "DOWN": 22.1,
+    "EVEN": 10.8,
+    "DOWN": 22.4,
     "ANCHOR": 3.6
    },
    "stretchRate": 16.8,
    "anchorRate": 3.6,
-   "breadth": 0.84,
-   "competitiveRatio": 30.9,
+   "breadth": 0.839,
+   "competitiveRatio": 30.3,
    "winRate": 39.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.6,
    "anchorRate": 1.3,
    "breadth": 0.596,
-   "competitiveRatio": 32.4,
+   "competitiveRatio": 32,
    "winRate": 50.2
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 6.7,
    "anchorRate": 0,
    "breadth": 0.607,
-   "competitiveRatio": 31.9,
+   "competitiveRatio": 31.3,
    "winRate": 50.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 1.3,
    "anchorRate": 20.6,
    "breadth": 0.835,
-   "competitiveRatio": 28.9,
+   "competitiveRatio": 27.7,
    "winRate": 65.8
   },
   {
@@ -199,21 +199,21 @@
    "bands": {
     "STRETCH": 42,
     "UP": 177,
-    "EVEN": 56,
-    "DOWN": 106,
+    "EVEN": 44,
+    "DOWN": 118,
     "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 9.8,
     "UP": 41.3,
-    "EVEN": 13.1,
-    "DOWN": 24.7,
+    "EVEN": 10.3,
+    "DOWN": 27.5,
     "ANCHOR": 11.2
    },
    "stretchRate": 9.8,
    "anchorRate": 11.2,
-   "breadth": 0.9,
-   "competitiveRatio": 46.4,
+   "breadth": 0.886,
+   "competitiveRatio": 47.3,
    "winRate": 49.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 3.9,
    "anchorRate": 6.7,
    "breadth": 0.797,
-   "competitiveRatio": 39.3,
+   "competitiveRatio": 37.8,
    "winRate": 65.5
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 0,
    "anchorRate": 6,
    "breadth": 0.753,
-   "competitiveRatio": 35.4,
+   "competitiveRatio": 34.8,
    "winRate": 58.6
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 28.7,
    "anchorRate": 0,
    "breadth": 0.661,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.2,
    "winRate": 41.9
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 26.7,
    "anchorRate": 4.7,
    "breadth": 0.833,
-   "competitiveRatio": 30.7,
+   "competitiveRatio": 31.1,
    "winRate": 52
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 20.1,
    "anchorRate": 0,
    "breadth": 0.694,
-   "competitiveRatio": 28,
+   "competitiveRatio": 26.9,
    "winRate": 42.4
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 18.3,
    "anchorRate": 0,
    "breadth": 0.573,
-   "competitiveRatio": 17.9,
+   "competitiveRatio": 16.8,
    "winRate": 12.6
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 2.3,
    "anchorRate": 18.9,
    "breadth": 0.711,
-   "competitiveRatio": 23.6,
+   "competitiveRatio": 22.8,
    "winRate": 36.7
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 14.2,
    "anchorRate": 0,
    "breadth": 0.785,
-   "competitiveRatio": 24.9,
+   "competitiveRatio": 23.7,
    "winRate": 35.6
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 8,
    "anchorRate": 0,
    "breadth": 0.702,
-   "competitiveRatio": 24.8,
+   "competitiveRatio": 24,
    "winRate": 50
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 25.7,
    "anchorRate": 0,
    "breadth": 0.752,
-   "competitiveRatio": 24.1,
+   "competitiveRatio": 24.5,
    "winRate": 20.9
   },
   {
@@ -510,7 +510,7 @@
    "stretchRate": 37.1,
    "anchorRate": 0,
    "breadth": 0.734,
-   "competitiveRatio": 19.2,
+   "competitiveRatio": 18.8,
    "winRate": 17.9
   },
   {
@@ -564,7 +564,7 @@
    "stretchRate": 46.8,
    "anchorRate": 0,
    "breadth": 0.566,
-   "competitiveRatio": 18.9,
+   "competitiveRatio": 19.4,
    "winRate": 20.3
   },
   {
@@ -591,7 +591,7 @@
    "stretchRate": 9.1,
    "anchorRate": 0,
    "breadth": 0.708,
-   "competitiveRatio": 16.8,
+   "competitiveRatio": 15.7,
    "winRate": 26.4
   },
   {
@@ -618,7 +618,7 @@
    "stretchRate": 66.9,
    "anchorRate": 0,
    "breadth": 0.394,
-   "competitiveRatio": 8.3,
+   "competitiveRatio": 9,
    "winRate": 4.8
   },
   {
@@ -645,7 +645,7 @@
    "stretchRate": 45.9,
    "anchorRate": 0,
    "breadth": 0.429,
-   "competitiveRatio": 12.8,
+   "competitiveRatio": 11.9,
    "winRate": 11.9
   }
  ]

--- a/public/data/conferences/usa-south-athletic-conference.json
+++ b/public/data/conferences/usa-south-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 15.5,
    "anchorRate": 11,
    "breadth": 0.896,
-   "competitiveRatio": 29.4,
+   "competitiveRatio": 28.7,
    "winRate": 48.5
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 17.2,
    "anchorRate": 17.2,
    "breadth": 0.872,
-   "competitiveRatio": 23.9,
+   "competitiveRatio": 23.3,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 14.4,
    "anchorRate": 7.1,
    "breadth": 0.886,
-   "competitiveRatio": 32.9,
+   "competitiveRatio": 32.2,
    "winRate": 47.6
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.5,
    "anchorRate": 14.4,
    "breadth": 0.826,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 41.2,
    "winRate": 56.1
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 16.4,
    "anchorRate": 10.3,
    "breadth": 0.764,
-   "competitiveRatio": 33.1,
+   "competitiveRatio": 32.5,
    "winRate": 61.1
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 2,
    "anchorRate": 32.6,
    "breadth": 0.812,
-   "competitiveRatio": 32.6,
+   "competitiveRatio": 31.3,
    "winRate": 60.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 1.7,
    "anchorRate": 13.7,
    "breadth": 0.835,
-   "competitiveRatio": 25.3,
+   "competitiveRatio": 24.7,
    "winRate": 67.7
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 13.3,
    "anchorRate": 7.3,
    "breadth": 0.779,
-   "competitiveRatio": 27.3,
+   "competitiveRatio": 26.6,
    "winRate": 56.6
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 9.6,
    "anchorRate": 17,
    "breadth": 0.867,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 27.7,
    "winRate": 41.7
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 25.3,
    "anchorRate": 6.9,
    "breadth": 0.734,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 29.6,
    "winRate": 27.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 5.2,
    "anchorRate": 0,
    "breadth": 0.63,
-   "competitiveRatio": 27.7,
+   "competitiveRatio": 26.4,
    "winRate": 53.2
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 7.3,
    "anchorRate": 5.5,
    "breadth": 0.79,
-   "competitiveRatio": 26.9,
+   "competitiveRatio": 26,
    "winRate": 32.9
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 60.8,
    "anchorRate": 0,
    "breadth": 0.471,
-   "competitiveRatio": 18.5,
+   "competitiveRatio": 18,
    "winRate": 14.2
   },
   {

--- a/public/data/conferences/west-coast-conference.json
+++ b/public/data/conferences/west-coast-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 6.3,
    "anchorRate": 5.9,
    "breadth": 0.864,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 46.5,
    "winRate": 51.6
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 10.4,
    "anchorRate": 10.4,
    "breadth": 0.941,
-   "competitiveRatio": 44,
+   "competitiveRatio": 42.6,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 4.3,
    "anchorRate": 3.7,
    "breadth": 0.81,
-   "competitiveRatio": 50.1,
+   "competitiveRatio": 48.4,
    "winRate": 52.3
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -158,7 +158,7 @@
    "stretchRate": 0,
    "anchorRate": 27,
    "breadth": 0.65,
-   "competitiveRatio": 40.1,
+   "competitiveRatio": 37.4,
    "winRate": 67.9
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 0,
    "anchorRate": 13.5,
    "breadth": 0.766,
-   "competitiveRatio": 50.4,
+   "competitiveRatio": 48,
    "winRate": 70.9
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 11,
    "breadth": 0.677,
-   "competitiveRatio": 51.7,
+   "competitiveRatio": 48.9,
    "winRate": 63
   },
   {
@@ -266,7 +266,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.644,
-   "competitiveRatio": 47.1,
+   "competitiveRatio": 45.8,
    "winRate": 57.2
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 12.4,
    "anchorRate": 1.9,
    "breadth": 0.861,
-   "competitiveRatio": 47.5,
+   "competitiveRatio": 44.1,
    "winRate": 49.7
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 2.9,
    "anchorRate": 3.5,
    "breadth": 0.783,
-   "competitiveRatio": 46,
+   "competitiveRatio": 45,
    "winRate": 45
   },
   {
@@ -347,7 +347,7 @@
    "stretchRate": 3.9,
    "anchorRate": 1.9,
    "breadth": 0.77,
-   "competitiveRatio": 46,
+   "competitiveRatio": 45,
    "winRate": 40.5
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 8.5,
    "anchorRate": 0,
    "breadth": 0.765,
-   "competitiveRatio": 41.8,
+   "competitiveRatio": 40.2,
    "winRate": 44.4
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 22.5,
    "anchorRate": 3.9,
    "breadth": 0.831,
-   "competitiveRatio": 50,
+   "competitiveRatio": 48,
    "winRate": 33.3
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 2,
    "anchorRate": 5.9,
    "breadth": 0.803,
-   "competitiveRatio": 50.8,
+   "competitiveRatio": 49.8,
    "winRate": 48.2
   },
   {
@@ -455,7 +455,7 @@
    "stretchRate": 6.9,
    "anchorRate": 0,
    "breadth": 0.767,
-   "competitiveRatio": 42.1,
+   "competitiveRatio": 40.1,
    "winRate": 43.8
   },
   {
@@ -482,7 +482,7 @@
    "stretchRate": 21.8,
    "anchorRate": 2,
    "breadth": 0.85,
-   "competitiveRatio": 50.2,
+   "competitiveRatio": 49.5,
    "winRate": 49.5
   },
   {
@@ -509,7 +509,7 @@
    "stretchRate": 7.7,
    "anchorRate": 5.6,
    "breadth": 0.841,
-   "competitiveRatio": 41.5,
+   "competitiveRatio": 40.8,
    "winRate": 43.7
   },
   {
@@ -536,7 +536,7 @@
    "stretchRate": 8.1,
    "anchorRate": 0,
    "breadth": 0.744,
-   "competitiveRatio": 55,
+   "competitiveRatio": 50.9,
    "winRate": 49.1
   },
   {
@@ -563,7 +563,7 @@
    "stretchRate": 12.8,
    "anchorRate": 0,
    "breadth": 0.789,
-   "competitiveRatio": 58.3,
+   "competitiveRatio": 56.6,
    "winRate": 38
   }
  ]

--- a/public/data/conferences/western-athletic-conference.json
+++ b/public/data/conferences/western-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 8.3,
    "anchorRate": 9.5,
    "breadth": 0.91,
-   "competitiveRatio": 44,
+   "competitiveRatio": 42.9,
    "winRate": 50.8
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 3.8,
    "anchorRate": 3.8,
    "breadth": 0.785,
-   "competitiveRatio": 48.1,
+   "competitiveRatio": 47.5,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 8.8,
    "anchorRate": 10.1,
    "breadth": 0.92,
-   "competitiveRatio": 43.6,
+   "competitiveRatio": 42.4,
    "winRate": 50.9
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 15.3,
    "breadth": 0.687,
-   "competitiveRatio": 44.7,
+   "competitiveRatio": 44.2,
    "winRate": 61.6
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 0,
    "anchorRate": 10.7,
    "breadth": 0.641,
-   "competitiveRatio": 47.8,
+   "competitiveRatio": 45.9,
    "winRate": 76.4
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 12.5,
    "anchorRate": 12.2,
    "breadth": 0.909,
-   "competitiveRatio": 44.5,
+   "competitiveRatio": 43.3,
    "winRate": 44.3
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 9.4,
    "anchorRate": 0,
    "breadth": 0.731,
-   "competitiveRatio": 41.7,
+   "competitiveRatio": 41.2,
    "winRate": 34.3
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 1.6,
    "anchorRate": 18.9,
    "breadth": 0.817,
-   "competitiveRatio": 48.6,
+   "competitiveRatio": 48.3,
    "winRate": 62.2
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 13.6,
    "anchorRate": 12.5,
    "breadth": 0.94,
-   "competitiveRatio": 34.4,
+   "competitiveRatio": 33.3,
    "winRate": 42.5
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 1.8,
    "anchorRate": 10.9,
    "breadth": 0.831,
-   "competitiveRatio": 45.3,
+   "competitiveRatio": 43.8,
    "winRate": 62.6
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 2.4,
    "anchorRate": 15.5,
    "breadth": 0.774,
-   "competitiveRatio": 43.9,
+   "competitiveRatio": 42.7,
    "winRate": 64.2
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 21.9,
    "anchorRate": 13.4,
    "breadth": 0.906,
-   "competitiveRatio": 51.4,
+   "competitiveRatio": 50.2,
    "winRate": 47.1
   },
   {
@@ -375,7 +375,7 @@
    "stretchRate": 3.4,
    "anchorRate": 9.3,
    "breadth": 0.827,
-   "competitiveRatio": 43.6,
+   "competitiveRatio": 42.5,
    "winRate": 54.7
   },
   {
@@ -402,7 +402,7 @@
    "stretchRate": 23.7,
    "anchorRate": 3.8,
    "breadth": 0.854,
-   "competitiveRatio": 47.3,
+   "competitiveRatio": 44.5,
    "winRate": 29
   },
   {
@@ -429,7 +429,7 @@
    "stretchRate": 11,
    "anchorRate": 2,
    "breadth": 0.818,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 44,
    "winRate": 37.5
   },
   {
@@ -456,7 +456,7 @@
    "stretchRate": 5.8,
    "anchorRate": 0,
    "breadth": 0.494,
-   "competitiveRatio": 39.1,
+   "competitiveRatio": 37.2,
    "winRate": 32.9
   },
   {
@@ -483,7 +483,7 @@
    "stretchRate": 16.3,
    "anchorRate": 0,
    "breadth": 0.791,
-   "competitiveRatio": 36.1,
+   "competitiveRatio": 35.3,
    "winRate": 48.4
   }
  ]

--- a/public/data/conferences/western-state-conference.json
+++ b/public/data/conferences/western-state-conference.json
@@ -30,7 +30,7 @@
    "stretchRate": 5.2,
    "anchorRate": 9.4,
    "breadth": 0.882,
-   "competitiveRatio": 29.1,
+   "competitiveRatio": 28.7,
    "winRate": 52.1
   },
   "inConference": {
@@ -52,7 +52,7 @@
    "stretchRate": 4.4,
    "anchorRate": 4.4,
    "breadth": 0.832,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 30.1,
    "winRate": 50
   },
   "nonConference": {
@@ -74,7 +74,7 @@
    "stretchRate": 6.8,
    "anchorRate": 19.2,
    "breadth": 0.921,
-   "competitiveRatio": 26.3,
+   "competitiveRatio": 26.1,
    "winRate": 56.1
   }
  },
@@ -83,21 +83,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -158,7 +158,7 @@
    "stretchRate": 34.7,
    "anchorRate": 0,
    "breadth": 0.536,
-   "competitiveRatio": 21.2,
+   "competitiveRatio": 20.9,
    "winRate": 17.9
   },
   {
@@ -185,7 +185,7 @@
    "stretchRate": 3.7,
    "anchorRate": 26.2,
    "breadth": 0.843,
-   "competitiveRatio": 30.9,
+   "competitiveRatio": 30.6,
    "winRate": 71.3
   },
   {
@@ -212,7 +212,7 @@
    "stretchRate": 1.9,
    "anchorRate": 0,
    "breadth": 0.516,
-   "competitiveRatio": 28.3,
+   "competitiveRatio": 28,
    "winRate": 42.9
   },
   {
@@ -239,7 +239,7 @@
    "stretchRate": 0,
    "anchorRate": 17.8,
    "breadth": 0.601,
-   "competitiveRatio": 27.1,
+   "competitiveRatio": 26.7,
    "winRate": 60.9
   },
   {
@@ -293,7 +293,7 @@
    "stretchRate": 0,
    "anchorRate": 18.9,
    "breadth": 0.621,
-   "competitiveRatio": 23.5,
+   "competitiveRatio": 23.2,
    "winRate": 66.3
   },
   {
@@ -320,7 +320,7 @@
    "stretchRate": 0,
    "anchorRate": 0,
    "breadth": 0.431,
-   "competitiveRatio": 31.3,
+   "competitiveRatio": 30.6,
    "winRate": 51.1
   },
   {
@@ -374,7 +374,7 @@
    "stretchRate": 2.4,
    "anchorRate": 13.8,
    "breadth": 0.87,
-   "competitiveRatio": 33.3,
+   "competitiveRatio": 32.9,
    "winRate": 41.5
   },
   {
@@ -401,7 +401,7 @@
    "stretchRate": 0,
    "anchorRate": 15.8,
    "breadth": 0.583,
-   "competitiveRatio": 35.2,
+   "competitiveRatio": 33.9,
    "winRate": 66.7
   },
   {
@@ -428,7 +428,7 @@
    "stretchRate": 4.5,
    "anchorRate": 0,
    "breadth": 0.445,
-   "competitiveRatio": 27.6,
+   "competitiveRatio": 27.1,
    "winRate": 40.5
   }
  ]

--- a/public/data/conferences/wisconsin-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/wisconsin-intercollegiate-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 7.6,
    "anchorRate": 11.1,
    "breadth": 0.879,
-   "competitiveRatio": 32.4,
+   "competitiveRatio": 31.6,
    "winRate": 53
   },
   "inConference": {
@@ -53,7 +53,7 @@
    "stretchRate": 9.6,
    "anchorRate": 9.6,
    "breadth": 0.914,
-   "competitiveRatio": 26.4,
+   "competitiveRatio": 25.9,
    "winRate": 50
   },
   "nonConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 6.8,
    "anchorRate": 11.7,
    "breadth": 0.857,
-   "competitiveRatio": 34.8,
+   "competitiveRatio": 33.9,
    "winRate": 54.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 0,
    "anchorRate": 5.6,
    "breadth": 0.62,
-   "competitiveRatio": 30.7,
+   "competitiveRatio": 29.7,
    "winRate": 55.8
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 16.3,
    "anchorRate": 0,
    "breadth": 0.773,
-   "competitiveRatio": 35.9,
+   "competitiveRatio": 33.7,
    "winRate": 38.9
   },
   {
@@ -186,7 +186,7 @@
    "stretchRate": 7.7,
    "anchorRate": 24.4,
    "breadth": 0.761,
-   "competitiveRatio": 45.2,
+   "competitiveRatio": 45.5,
    "winRate": 59.9
   },
   {
@@ -213,7 +213,7 @@
    "stretchRate": 0,
    "anchorRate": 35.8,
    "breadth": 0.679,
-   "competitiveRatio": 21.9,
+   "competitiveRatio": 21.4,
    "winRate": 80
   },
   {
@@ -240,7 +240,7 @@
    "stretchRate": 3.3,
    "anchorRate": 5.2,
    "breadth": 0.811,
-   "competitiveRatio": 30.5,
+   "competitiveRatio": 29.7,
    "winRate": 60.3
   },
   {
@@ -267,7 +267,7 @@
    "stretchRate": 10,
    "anchorRate": 14.7,
    "breadth": 0.915,
-   "competitiveRatio": 28.4,
+   "competitiveRatio": 29.2,
    "winRate": 57.8
   },
   {
@@ -294,7 +294,7 @@
    "stretchRate": 0,
    "anchorRate": 13.4,
    "breadth": 0.589,
-   "competitiveRatio": 44.3,
+   "competitiveRatio": 41.8,
    "winRate": 63.5
   },
   {
@@ -321,7 +321,7 @@
    "stretchRate": 14.7,
    "anchorRate": 0,
    "breadth": 0.768,
-   "competitiveRatio": 27.6,
+   "competitiveRatio": 26.4,
    "winRate": 28.5
   },
   {
@@ -348,7 +348,7 @@
    "stretchRate": 18.2,
    "anchorRate": 0,
    "breadth": 0.685,
-   "competitiveRatio": 25,
+   "competitiveRatio": 24.4,
    "winRate": 25.3
   },
   {

--- a/public/data/conferences/wolverine-hoosier-athletic-conference.json
+++ b/public/data/conferences/wolverine-hoosier-athletic-conference.json
@@ -31,7 +31,7 @@
    "stretchRate": 17.1,
    "anchorRate": 1.4,
    "breadth": 0.711,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.8,
    "winRate": 42.2
   },
   "inConference": {
@@ -75,7 +75,7 @@
    "stretchRate": 17.1,
    "anchorRate": 1.4,
    "breadth": 0.711,
-   "competitiveRatio": 40.5,
+   "competitiveRatio": 39.8,
    "winRate": 42.2
   }
  },
@@ -84,21 +84,21 @@
   "bands": {
    "STRETCH": 51471,
    "UP": 174555,
-   "EVEN": 76349,
-   "DOWN": 176225,
-   "ANCHOR": 52814
+   "EVEN": 75766,
+   "DOWN": 176643,
+   "ANCHOR": 52979
   },
   "bandPct": {
    "STRETCH": 9.7,
    "UP": 32.8,
-   "EVEN": 14.4,
+   "EVEN": 14.3,
    "DOWN": 33.2,
-   "ANCHOR": 9.9
+   "ANCHOR": 10
   },
   "stretchRate": 9.7,
-  "anchorRate": 9.9,
+  "anchorRate": 10,
   "breadth": 0.911,
-  "competitiveRatio": 37.9,
+  "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
@@ -132,7 +132,7 @@
    "stretchRate": 2.7,
    "anchorRate": 0,
    "breadth": 0.571,
-   "competitiveRatio": 34.4,
+   "competitiveRatio": 34.9,
    "winRate": 37.9
   },
   {
@@ -159,7 +159,7 @@
    "stretchRate": 31.5,
    "anchorRate": 2.7,
    "breadth": 0.725,
-   "competitiveRatio": 46.6,
+   "competitiveRatio": 44.7,
    "winRate": 46.6
   }
  ]


### PR DESCRIPTION
The deployed conference pages have been serving Competitive Ratio figures computed by a score parser that **claimed** to implement the factory's model and did not.

> [!IMPORTANT]
> **DRAFT — merge courthive-ingest [#67](https://github.com/CourtHive/courthive-ingest/pull/67) first.** This data is generated by #67's ported scripts. If this lands first, anyone regenerating from ingest `main` would reproduce the *old* numbers and silently revert the correction. Ordering matters; the content is already verified.

## Why the numbers were wrong

The old `parseSets` stripped parenthesised tiebreak detail (`7-6(5)` → `7-6`); the factory's score model awards the tiebreak winner an extra game. **18.4% of sampled ITA score strings carry that detail**, so CR read consistently *high* — a longer game denominator means fewer matches clear the >50% COMPETITIVE threshold.

## What moves — measured over all 54,782 duals, not estimated

**Competitive Ratio — 126 of 131 conferences, mean `-0.85pp`:**

| conference | was | now |
|---|---|---|
| Southeastern | 48.7% | **45.4%** |
| Atlantic Coast | 46.8% | **44.1%** |
| Big Ten | 48.6% | **46.1%** |
| Mountain West | 49.1% | **46.7%** |
| Big 12 | 46.7% | **44.8%** |
| Ivy League | 49.1% | **47.5%** |

**Exposure bands — 1,412 reassignments, entirely on the negative side:**

| STRETCH | UP | EVEN | DOWN | ANCHOR |
|---|---|---|---|---|
| 0 | 0 | 583 | 664 | 165 |

The old `bandOf` read `d >= -T ? DOWN : ANCHOR`, so a delta of exactly `-T` was DOWN; the factory walks "first band whose `max` the delta does not exceed", matching the long-standing `profileBands` convention, so exactly `-T` is ANCHOR. **That STRETCH and UP are untouched is the evidence** the sign convention was otherwise identical — a wrong orientation could not have left the positive side at zero.

Southeastern shows both effects in one document: CR `48.7 → 45.4`, and 19 rows move `DOWN 4974 → 4955` / `ANCHOR 1985 → 2004` with STRETCH/UP/EVEN unchanged.

## Verification

- **Stable across pins** — regenerated under factory **6.24.0** and **6.25.0**; output byte-identical under both, so the numbers don't depend on which pin ingest lands on.
- **File set unchanged** — 131 conference docs + `index.json`, no additions or removals.
- **Shape additive** — `index.json` gains `policy` and `deltaBands` provenance keys; nothing removed, `threshold` preserved, and `ConferenceIndex` consumers ignore extra keys.
- **All 132 files re-parsed and structurally validated** (`fingerprint.{overall,inConference,nonConference}`, `members`, `stretchGap`, `baseline`).
- **Generation formatting preserved** — this data has never been prettier-managed (the tracked files fail `prettier --check` too), so reformatting would have produced a 132-file noise diff on top of a numbers change.
- `e2e/journeys/18-conference-pages.spec.ts` asserts structure, not figures, so it is unaffected.

## A pre-existing bug this surfaced — deliberately not fixed here

**"Mid-American Conference" and "Mid American Conference" both slugify to `mid-american-conference`.** The index carries **132 entries for 131 files**, so one of those two conferences' page silently serves the other's data. Present in the tracked data too, so it predates this change.

It is the same real conference under two feed spellings — a normalization fix in the ingest tier that changes conference membership and therefore every affected figure. Folding it into a pure recomputation would make both changes unreviewable. Worth its own PR, ideally with a loud guard so a future slug collision fails instead of overwriting.
