### PR TITLE
fix(conferences): regenerate under the factory's shipped deltaBands policy

### DIFF
--- a/public/data/conferences/alabama-ccc.json
+++ b/public/data/conferences/alabama-ccc.json
@@ -15,44 +15,44 @@
   "overall": {
    "matches": 1325,
    "bands": {
-    "STRETCH": 417,
-    "UP": 402,
+    "STRETCH": 381,
+    "UP": 438,
     "EVEN": 86,
-    "DOWN": 362,
-    "ANCHOR": 58
+    "DOWN": 398,
+    "ANCHOR": 22
    },
    "bandPct": {
-    "STRETCH": 31.5,
-    "UP": 30.3,
+    "STRETCH": 28.8,
+    "UP": 33.1,
     "EVEN": 6.5,
-    "DOWN": 27.3,
-    "ANCHOR": 4.4
+    "DOWN": 30,
+    "ANCHOR": 1.7
    },
-   "stretchRate": 31.5,
-   "anchorRate": 4.4,
-   "breadth": 0.867,
+   "stretchRate": 28.8,
+   "anchorRate": 1.7,
+   "breadth": 0.827,
    "competitiveRatio": 21.1,
    "winRate": 35.5
   },
   "inConference": {
    "matches": 336,
    "bands": {
-    "STRETCH": 36,
-    "UP": 118,
+    "STRETCH": 0,
+    "UP": 154,
     "EVEN": 28,
-    "DOWN": 118,
-    "ANCHOR": 36
+    "DOWN": 154,
+    "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 10.7,
-    "UP": 35.1,
+    "STRETCH": 0,
+    "UP": 45.8,
     "EVEN": 8.3,
-    "DOWN": 35.1,
-    "ANCHOR": 10.7
+    "DOWN": 45.8,
+    "ANCHOR": 0
    },
-   "stretchRate": 10.7,
-   "anchorRate": 10.7,
-   "breadth": 0.883,
+   "stretchRate": 0,
+   "anchorRate": 0,
+   "breadth": 0.573,
    "competitiveRatio": 27.4,
    "winRate": 50
   },
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 10.7,
+  "inConference": 0,
   "nonConference": 38.5,
-  "delta": 27.8,
+  "delta": 38.5,
   "nonConferenceShare": 74.6
  },
  "members": [
@@ -119,19 +119,19 @@
     "STRETCH": 36,
     "UP": 69,
     "EVEN": 0,
-    "DOWN": 105,
-    "ANCHOR": 58
+    "DOWN": 141,
+    "ANCHOR": 22
    },
    "bandPct": {
     "STRETCH": 13.4,
     "UP": 25.7,
     "EVEN": 0,
-    "DOWN": 39.2,
-    "ANCHOR": 21.6
+    "DOWN": 52.6,
+    "ANCHOR": 8.2
    },
    "stretchRate": 13.4,
-   "anchorRate": 21.6,
-   "breadth": 0.819,
+   "anchorRate": 8.2,
+   "breadth": 0.722,
    "competitiveRatio": 27.2,
    "winRate": 41.4
   },
@@ -143,22 +143,22 @@
    "lineupWTN": 28.86,
    "matches": 247,
    "bands": {
-    "STRETCH": 132,
-    "UP": 83,
+    "STRETCH": 96,
+    "UP": 119,
     "EVEN": 0,
     "DOWN": 32,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 53.4,
-    "UP": 33.6,
+    "STRETCH": 38.9,
+    "UP": 48.2,
     "EVEN": 0,
     "DOWN": 13,
     "ANCHOR": 0
    },
-   "stretchRate": 53.4,
+   "stretchRate": 38.9,
    "anchorRate": 0,
-   "breadth": 0.6,
+   "breadth": 0.611,
    "competitiveRatio": 23.1,
    "winRate": 29.1
   },

--- a/public/data/conferences/allegheny-mountain-collegiate-conference.json
+++ b/public/data/conferences/allegheny-mountain-collegiate-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/american-athletic-conference.json
+++ b/public/data/conferences/american-athletic-conference.json
@@ -15,21 +15,21 @@
    "matches": 8033,
    "bands": {
     "STRETCH": 283,
-    "UP": 2766,
-    "EVEN": 1438,
-    "DOWN": 2969,
-    "ANCHOR": 577
+    "UP": 2751,
+    "EVEN": 1488,
+    "DOWN": 2940,
+    "ANCHOR": 571
    },
    "bandPct": {
     "STRETCH": 3.5,
-    "UP": 34.4,
-    "EVEN": 17.9,
-    "DOWN": 37,
-    "ANCHOR": 7.2
+    "UP": 34.2,
+    "EVEN": 18.5,
+    "DOWN": 36.6,
+    "ANCHOR": 7.1
    },
    "stretchRate": 3.5,
-   "anchorRate": 7.2,
-   "breadth": 0.839,
+   "anchorRate": 7.1,
+   "breadth": 0.841,
    "competitiveRatio": 47.5,
    "winRate": 53.5
   },
@@ -37,21 +37,21 @@
    "matches": 2254,
    "bands": {
     "STRETCH": 34,
-    "UP": 882,
-    "EVEN": 422,
-    "DOWN": 882,
+    "UP": 867,
+    "EVEN": 452,
+    "DOWN": 867,
     "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 1.5,
-    "UP": 39.1,
-    "EVEN": 18.7,
-    "DOWN": 39.1,
+    "UP": 38.5,
+    "EVEN": 20.1,
+    "DOWN": 38.5,
     "ANCHOR": 1.5
    },
    "stretchRate": 1.5,
    "anchorRate": 1.5,
-   "breadth": 0.73,
+   "breadth": 0.736,
    "competitiveRatio": 50,
    "winRate": 50
   },
@@ -60,19 +60,19 @@
    "bands": {
     "STRETCH": 249,
     "UP": 1884,
-    "EVEN": 1016,
-    "DOWN": 2087,
-    "ANCHOR": 543
+    "EVEN": 1036,
+    "DOWN": 2073,
+    "ANCHOR": 537
    },
    "bandPct": {
     "STRETCH": 4.3,
     "UP": 32.6,
-    "EVEN": 17.6,
-    "DOWN": 36.1,
-    "ANCHOR": 9.4
+    "EVEN": 17.9,
+    "DOWN": 35.9,
+    "ANCHOR": 9.3
    },
    "stretchRate": 4.3,
-   "anchorRate": 9.4,
+   "anchorRate": 9.3,
    "breadth": 0.868,
    "competitiveRatio": 46.5,
    "winRate": 54.8
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -117,20 +117,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 65,
-    "EVEN": 33,
-    "DOWN": 282,
+    "EVEN": 45,
+    "DOWN": 270,
     "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 16.1,
-    "EVEN": 8.2,
-    "DOWN": 69.8,
+    "EVEN": 11.1,
+    "DOWN": 66.8,
     "ANCHOR": 5.9
    },
    "stretchRate": 0,
    "anchorRate": 5.9,
-   "breadth": 0.57,
+   "breadth": 0.606,
    "competitiveRatio": 55.2,
    "winRate": 59.7
   },
@@ -172,19 +172,19 @@
     "STRETCH": 6,
     "UP": 122,
     "EVEN": 93,
-    "DOWN": 80,
-    "ANCHOR": 97
+    "DOWN": 86,
+    "ANCHOR": 91
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 30.7,
     "EVEN": 23.4,
-    "DOWN": 20.1,
-    "ANCHOR": 24.4
+    "DOWN": 21.6,
+    "ANCHOR": 22.9
    },
    "stretchRate": 1.5,
-   "anchorRate": 24.4,
-   "breadth": 0.89,
+   "anchorRate": 22.9,
+   "breadth": 0.891,
    "competitiveRatio": 45.2,
    "winRate": 52.5
   },
@@ -251,21 +251,21 @@
    "matches": 370,
    "bands": {
     "STRETCH": 0,
-    "UP": 48,
-    "EVEN": 71,
+    "UP": 33,
+    "EVEN": 86,
     "DOWN": 184,
     "ANCHOR": 67
    },
    "bandPct": {
     "STRETCH": 0,
-    "UP": 13,
-    "EVEN": 19.2,
+    "UP": 8.9,
+    "EVEN": 23.2,
     "DOWN": 49.7,
     "ANCHOR": 18.1
    },
    "stretchRate": 0,
    "anchorRate": 18.1,
-   "breadth": 0.77,
+   "breadth": 0.753,
    "competitiveRatio": 43,
    "winRate": 71.9
   },
@@ -495,20 +495,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 25,
-    "EVEN": 52,
-    "DOWN": 188,
+    "EVEN": 67,
+    "DOWN": 173,
     "ANCHOR": 50
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 7.9,
-    "EVEN": 16.5,
-    "DOWN": 59.7,
+    "EVEN": 21.3,
+    "DOWN": 54.9,
     "ANCHOR": 15.9
    },
    "stretchRate": 0,
    "anchorRate": 15.9,
-   "breadth": 0.683,
+   "breadth": 0.716,
    "competitiveRatio": 39,
    "winRate": 64.1
   },
@@ -549,20 +549,20 @@
    "bands": {
     "STRETCH": 3,
     "UP": 189,
-    "EVEN": 40,
-    "DOWN": 81,
+    "EVEN": 48,
+    "DOWN": 73,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1,
     "UP": 60.4,
-    "EVEN": 12.8,
-    "DOWN": 25.9,
+    "EVEN": 15.3,
+    "DOWN": 23.3,
     "ANCHOR": 0
    },
    "stretchRate": 1,
    "anchorRate": 0,
-   "breadth": 0.598,
+   "breadth": 0.607,
    "competitiveRatio": 46.6,
    "winRate": 46.6
   },

--- a/public/data/conferences/american-rivers-conference.json
+++ b/public/data/conferences/american-rivers-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/american-southwest-conference.json
+++ b/public/data/conferences/american-southwest-conference.json
@@ -17,15 +17,15 @@
    "bands": {
     "STRETCH": 892,
     "UP": 1997,
-    "EVEN": 575,
-    "DOWN": 1302,
+    "EVEN": 581,
+    "DOWN": 1296,
     "ANCHOR": 477
    },
    "bandPct": {
     "STRETCH": 17,
     "UP": 38.1,
-    "EVEN": 11,
-    "DOWN": 24.8,
+    "EVEN": 11.1,
+    "DOWN": 24.7,
     "ANCHOR": 9.1
    },
    "stretchRate": 17,
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 689,
     "UP": 1365,
-    "EVEN": 409,
-    "DOWN": 670,
+    "EVEN": 415,
+    "DOWN": 664,
     "ANCHOR": 274
    },
    "bandPct": {
     "STRETCH": 20.2,
     "UP": 40.1,
-    "EVEN": 12,
-    "DOWN": 19.7,
+    "EVEN": 12.2,
+    "DOWN": 19.5,
     "ANCHOR": 8
    },
    "stretchRate": 20.2,
    "anchorRate": 8,
-   "breadth": 0.911,
+   "breadth": 0.912,
    "competitiveRatio": 29.6,
    "winRate": 40.3
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -496,20 +496,20 @@
    "bands": {
     "STRETCH": 42,
     "UP": 118,
-    "EVEN": 24,
-    "DOWN": 58,
+    "EVEN": 30,
+    "DOWN": 52,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 15.6,
     "UP": 43.7,
-    "EVEN": 8.9,
-    "DOWN": 21.5,
+    "EVEN": 11.1,
+    "DOWN": 19.3,
     "ANCHOR": 10.4
    },
    "stretchRate": 15.6,
    "anchorRate": 10.4,
-   "breadth": 0.89,
+   "breadth": 0.899,
    "competitiveRatio": 32.6,
    "winRate": 35.6
   },

--- a/public/data/conferences/appalachian-athletic-conference.json
+++ b/public/data/conferences/appalachian-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/atlantic-10-conference.json
+++ b/public/data/conferences/atlantic-10-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 7223,
    "bands": {
-    "STRETCH": 418,
-    "UP": 2750,
-    "EVEN": 1162,
-    "DOWN": 2497,
-    "ANCHOR": 396
+    "STRETCH": 400,
+    "UP": 2768,
+    "EVEN": 1174,
+    "DOWN": 2493,
+    "ANCHOR": 388
    },
    "bandPct": {
-    "STRETCH": 5.8,
-    "UP": 38.1,
-    "EVEN": 16.1,
-    "DOWN": 34.6,
-    "ANCHOR": 5.5
+    "STRETCH": 5.5,
+    "UP": 38.3,
+    "EVEN": 16.3,
+    "DOWN": 34.5,
+    "ANCHOR": 5.4
    },
-   "stretchRate": 5.8,
-   "anchorRate": 5.5,
-   "breadth": 0.841,
+   "stretchRate": 5.5,
+   "anchorRate": 5.4,
+   "breadth": 0.837,
    "competitiveRatio": 43.4,
    "winRate": 47.5
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 5229,
    "bands": {
-    "STRETCH": 395,
-    "UP": 1925,
-    "EVEN": 864,
-    "DOWN": 1672,
-    "ANCHOR": 373
+    "STRETCH": 377,
+    "UP": 1943,
+    "EVEN": 876,
+    "DOWN": 1668,
+    "ANCHOR": 365
    },
    "bandPct": {
-    "STRETCH": 7.6,
-    "UP": 36.8,
-    "EVEN": 16.5,
-    "DOWN": 32,
-    "ANCHOR": 7.1
+    "STRETCH": 7.2,
+    "UP": 37.2,
+    "EVEN": 16.8,
+    "DOWN": 31.9,
+    "ANCHOR": 7
    },
-   "stretchRate": 7.6,
-   "anchorRate": 7.1,
-   "breadth": 0.878,
+   "stretchRate": 7.2,
+   "anchorRate": 7,
+   "breadth": 0.874,
    "competitiveRatio": 44.3,
    "winRate": 46.5
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 1.2,
-  "nonConference": 7.6,
-  "delta": 6.4,
+  "nonConference": 7.2,
+  "delta": 6,
   "nonConferenceShare": 72.4
  },
  "members": [
@@ -442,20 +442,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 60,
-    "EVEN": 28,
-    "DOWN": 192,
+    "EVEN": 31,
+    "DOWN": 189,
     "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19.1,
-    "EVEN": 8.9,
-    "DOWN": 61.1,
+    "EVEN": 9.9,
+    "DOWN": 60.2,
     "ANCHOR": 10.8
    },
    "stretchRate": 0,
    "anchorRate": 10.8,
-   "breadth": 0.667,
+   "breadth": 0.678,
    "competitiveRatio": 45.9,
    "winRate": 63.7
   },
@@ -577,20 +577,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 152,
-    "EVEN": 49,
-    "DOWN": 81,
+    "EVEN": 58,
+    "DOWN": 72,
     "ANCHOR": 5
    },
    "bandPct": {
     "STRETCH": 2,
     "UP": 51.9,
-    "EVEN": 16.7,
-    "DOWN": 27.6,
+    "EVEN": 19.8,
+    "DOWN": 24.6,
     "ANCHOR": 1.7
    },
    "stretchRate": 2,
    "anchorRate": 1.7,
-   "breadth": 0.711,
+   "breadth": 0.718,
    "competitiveRatio": 41.1,
    "winRate": 43
   },
@@ -629,22 +629,22 @@
    "lineupWTN": 22.51,
    "matches": 271,
    "bands": {
-    "STRETCH": 28,
-    "UP": 109,
+    "STRETCH": 10,
+    "UP": 127,
     "EVEN": 61,
-    "DOWN": 54,
-    "ANCHOR": 19
+    "DOWN": 62,
+    "ANCHOR": 11
    },
    "bandPct": {
-    "STRETCH": 10.3,
-    "UP": 40.2,
+    "STRETCH": 3.7,
+    "UP": 46.9,
     "EVEN": 22.5,
-    "DOWN": 19.9,
-    "ANCHOR": 7
+    "DOWN": 22.9,
+    "ANCHOR": 4.1
    },
-   "stretchRate": 10.3,
-   "anchorRate": 7,
-   "breadth": 0.897,
+   "stretchRate": 3.7,
+   "anchorRate": 4.1,
+   "breadth": 0.795,
    "competitiveRatio": 33.3,
    "winRate": 32.5
   },

--- a/public/data/conferences/atlantic-coast-conference.json
+++ b/public/data/conferences/atlantic-coast-conference.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 238,
     "UP": 3270,
-    "EVEN": 2328,
-    "DOWN": 4637,
+    "EVEN": 2346,
+    "DOWN": 4619,
     "ANCHOR": 1854
    },
    "bandPct": {
     "STRETCH": 1.9,
     "UP": 26.5,
-    "EVEN": 18.9,
-    "DOWN": 37.6,
+    "EVEN": 19,
+    "DOWN": 37.5,
     "ANCHOR": 15
    },
    "stretchRate": 1.9,
    "anchorRate": 15,
-   "breadth": 0.867,
+   "breadth": 0.868,
    "competitiveRatio": 44.1,
    "winRate": 59.1
   },
@@ -38,20 +38,20 @@
    "bands": {
     "STRETCH": 193,
     "UP": 2317,
-    "EVEN": 1404,
-    "DOWN": 2335,
+    "EVEN": 1422,
+    "DOWN": 2317,
     "ANCHOR": 193
    },
    "bandPct": {
     "STRETCH": 3,
     "UP": 36,
-    "EVEN": 21.8,
-    "DOWN": 36.2,
+    "EVEN": 22.1,
+    "DOWN": 36,
     "ANCHOR": 3
    },
    "stretchRate": 3,
    "anchorRate": 3,
-   "breadth": 0.794,
+   "breadth": 0.795,
    "competitiveRatio": 46.2,
    "winRate": 50
   },
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -225,20 +225,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 91,
-    "EVEN": 88,
-    "DOWN": 130,
+    "EVEN": 102,
+    "DOWN": 116,
     "ANCHOR": 105
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 22,
-    "EVEN": 21.3,
-    "DOWN": 31.4,
+    "EVEN": 24.6,
+    "DOWN": 28,
     "ANCHOR": 25.4
    },
    "stretchRate": 0,
    "anchorRate": 25.4,
-   "breadth": 0.854,
+   "breadth": 0.859,
    "competitiveRatio": 46.4,
    "winRate": 63
   },
@@ -765,20 +765,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 113,
-    "EVEN": 66,
-    "DOWN": 158,
+    "EVEN": 70,
+    "DOWN": 154,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.9,
-    "EVEN": 19.2,
-    "DOWN": 46.1,
+    "EVEN": 20.4,
+    "DOWN": 44.9,
     "ANCHOR": 1.7
    },
    "stretchRate": 0,
    "anchorRate": 1.7,
-   "breadth": 0.69,
+   "breadth": 0.696,
    "competitiveRatio": 47.5,
    "winRate": 60.6
   },

--- a/public/data/conferences/atlantic-east-conference.json
+++ b/public/data/conferences/atlantic-east-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/atlantic-sun-conference.json
+++ b/public/data/conferences/atlantic-sun-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/big-12-conference.json
+++ b/public/data/conferences/big-12-conference.json
@@ -17,19 +17,19 @@
     "STRETCH": 174,
     "UP": 2373,
     "EVEN": 1405,
-    "DOWN": 3605,
-    "ANCHOR": 1106
+    "DOWN": 3618,
+    "ANCHOR": 1093
    },
    "bandPct": {
     "STRETCH": 2,
     "UP": 27.4,
     "EVEN": 16.2,
-    "DOWN": 41.6,
-    "ANCHOR": 12.8
+    "DOWN": 41.8,
+    "ANCHOR": 12.6
    },
    "stretchRate": 2,
-   "anchorRate": 12.8,
-   "breadth": 0.842,
+   "anchorRate": 12.6,
+   "breadth": 0.841,
    "competitiveRatio": 44.8,
    "winRate": 57.6
   },
@@ -61,19 +61,19 @@
     "STRETCH": 60,
     "UP": 916,
     "EVEN": 771,
-    "DOWN": 2148,
-    "ANCHOR": 992
+    "DOWN": 2161,
+    "ANCHOR": 979
    },
    "bandPct": {
     "STRETCH": 1.2,
     "UP": 18.7,
     "EVEN": 15.8,
-    "DOWN": 44,
-    "ANCHOR": 20.3
+    "DOWN": 44.2,
+    "ANCHOR": 20
    },
    "stretchRate": 1.2,
-   "anchorRate": 20.3,
-   "breadth": 0.835,
+   "anchorRate": 20,
+   "breadth": 0.834,
    "competitiveRatio": 43.9,
    "winRate": 63.5
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -253,19 +253,19 @@
     "STRETCH": 0,
     "UP": 59,
     "EVEN": 114,
-    "DOWN": 109,
-    "ANCHOR": 109
+    "DOWN": 118,
+    "ANCHOR": 100
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.1,
     "EVEN": 29.2,
-    "DOWN": 27.9,
-    "ANCHOR": 27.9
+    "DOWN": 30.2,
+    "ANCHOR": 25.6
    },
    "stretchRate": 0,
-   "anchorRate": 27.9,
-   "breadth": 0.843,
+   "anchorRate": 25.6,
+   "breadth": 0.842,
    "competitiveRatio": 38.1,
    "winRate": 79.3
   },
@@ -712,19 +712,19 @@
     "STRETCH": 0,
     "UP": 39,
     "EVEN": 78,
-    "DOWN": 152,
-    "ANCHOR": 28
+    "DOWN": 156,
+    "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 13.1,
     "EVEN": 26.3,
-    "DOWN": 51.2,
-    "ANCHOR": 9.4
+    "DOWN": 52.5,
+    "ANCHOR": 8.1
    },
    "stretchRate": 0,
-   "anchorRate": 9.4,
-   "breadth": 0.735,
+   "anchorRate": 8.1,
+   "breadth": 0.72,
    "competitiveRatio": 45.8,
    "winRate": 65
   },

--- a/public/data/conferences/big-8-conference-north.json
+++ b/public/data/conferences/big-8-conference-north.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/big-8-conference-south.json
+++ b/public/data/conferences/big-8-conference-south.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/big-east-conference.json
+++ b/public/data/conferences/big-east-conference.json
@@ -14,22 +14,22 @@
   "overall": {
    "matches": 6349,
    "bands": {
-    "STRETCH": 525,
-    "UP": 2469,
-    "EVEN": 1174,
+    "STRETCH": 516,
+    "UP": 2478,
+    "EVEN": 1180,
     "DOWN": 1881,
-    "ANCHOR": 300
+    "ANCHOR": 294
    },
    "bandPct": {
-    "STRETCH": 8.3,
-    "UP": 38.9,
-    "EVEN": 18.5,
+    "STRETCH": 8.1,
+    "UP": 39,
+    "EVEN": 18.6,
     "DOWN": 29.6,
-    "ANCHOR": 4.7
+    "ANCHOR": 4.6
    },
-   "stretchRate": 8.3,
-   "anchorRate": 4.7,
-   "breadth": 0.864,
+   "stretchRate": 8.1,
+   "anchorRate": 4.6,
+   "breadth": 0.862,
    "competitiveRatio": 46.6,
    "winRate": 46.6
   },
@@ -38,42 +38,42 @@
    "bands": {
     "STRETCH": 75,
     "UP": 746,
-    "EVEN": 486,
-    "DOWN": 752,
+    "EVEN": 492,
+    "DOWN": 746,
     "ANCHOR": 75
    },
    "bandPct": {
     "STRETCH": 3.5,
     "UP": 35,
-    "EVEN": 22.8,
-    "DOWN": 35.2,
+    "EVEN": 23.1,
+    "DOWN": 35,
     "ANCHOR": 3.5
    },
    "stretchRate": 3.5,
    "anchorRate": 3.5,
-   "breadth": 0.812,
+   "breadth": 0.813,
    "competitiveRatio": 50.5,
    "winRate": 50
   },
   "nonConference": {
    "matches": 4215,
    "bands": {
-    "STRETCH": 450,
-    "UP": 1723,
+    "STRETCH": 441,
+    "UP": 1732,
     "EVEN": 688,
-    "DOWN": 1129,
-    "ANCHOR": 225
+    "DOWN": 1135,
+    "ANCHOR": 219
    },
    "bandPct": {
-    "STRETCH": 10.7,
-    "UP": 40.9,
+    "STRETCH": 10.5,
+    "UP": 41.1,
     "EVEN": 16.3,
-    "DOWN": 26.8,
-    "ANCHOR": 5.3
+    "DOWN": 26.9,
+    "ANCHOR": 5.2
    },
-   "stretchRate": 10.7,
-   "anchorRate": 5.3,
-   "breadth": 0.876,
+   "stretchRate": 10.5,
+   "anchorRate": 5.2,
+   "breadth": 0.873,
    "competitiveRatio": 44.7,
    "winRate": 44.9
   }
@@ -81,29 +81,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 3.5,
-  "nonConference": 10.7,
-  "delta": 7.2,
+  "nonConference": 10.5,
+  "delta": 7,
   "nonConferenceShare": 66.4
  },
  "members": [
@@ -306,20 +306,20 @@
    "bands": {
     "STRETCH": 12,
     "UP": 171,
-    "EVEN": 43,
+    "EVEN": 49,
     "DOWN": 126,
-    "ANCHOR": 15
+    "ANCHOR": 9
    },
    "bandPct": {
     "STRETCH": 3.3,
     "UP": 46.6,
-    "EVEN": 11.7,
+    "EVEN": 13.4,
     "DOWN": 34.3,
-    "ANCHOR": 4.1
+    "ANCHOR": 2.5
    },
    "stretchRate": 3.3,
-   "anchorRate": 4.1,
-   "breadth": 0.756,
+   "anchorRate": 2.5,
+   "breadth": 0.742,
    "competitiveRatio": 43.8,
    "winRate": 49.9
   },
@@ -412,22 +412,22 @@
    "lineupWTN": 17.6,
    "matches": 349,
    "bands": {
-    "STRETCH": 90,
-    "UP": 220,
+    "STRETCH": 81,
+    "UP": 229,
     "EVEN": 27,
     "DOWN": 12,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 25.8,
-    "UP": 63,
+    "STRETCH": 23.2,
+    "UP": 65.6,
     "EVEN": 7.7,
     "DOWN": 3.4,
     "ANCHOR": 0
    },
-   "stretchRate": 25.8,
+   "stretchRate": 23.2,
    "anchorRate": 0,
-   "breadth": 0.593,
+   "breadth": 0.577,
    "competitiveRatio": 51.9,
    "winRate": 30.7
   },

--- a/public/data/conferences/big-sky-conference.json
+++ b/public/data/conferences/big-sky-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/big-south-conference.json
+++ b/public/data/conferences/big-south-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/big-ten-conference.json
+++ b/public/data/conferences/big-ten-conference.json
@@ -14,22 +14,22 @@
   "overall": {
    "matches": 11038,
    "bands": {
-    "STRETCH": 146,
-    "UP": 3203,
-    "EVEN": 2116,
-    "DOWN": 4460,
+    "STRETCH": 137,
+    "UP": 3212,
+    "EVEN": 2141,
+    "DOWN": 4435,
     "ANCHOR": 1113
    },
    "bandPct": {
-    "STRETCH": 1.3,
-    "UP": 29,
-    "EVEN": 19.2,
-    "DOWN": 40.4,
+    "STRETCH": 1.2,
+    "UP": 29.1,
+    "EVEN": 19.4,
+    "DOWN": 40.2,
     "ANCHOR": 10.1
    },
-   "stretchRate": 1.3,
+   "stretchRate": 1.2,
    "anchorRate": 10.1,
-   "breadth": 0.827,
+   "breadth": 0.826,
    "competitiveRatio": 46.1,
    "winRate": 57.2
   },
@@ -38,42 +38,42 @@
    "bands": {
     "STRETCH": 119,
     "UP": 2043,
-    "EVEN": 1031,
-    "DOWN": 2056,
+    "EVEN": 1044,
+    "DOWN": 2043,
     "ANCHOR": 119
    },
    "bandPct": {
     "STRETCH": 2.2,
     "UP": 38.1,
-    "EVEN": 19.2,
-    "DOWN": 38.3,
+    "EVEN": 19.4,
+    "DOWN": 38.1,
     "ANCHOR": 2.2
    },
    "stretchRate": 2.2,
    "anchorRate": 2.2,
-   "breadth": 0.759,
+   "breadth": 0.76,
    "competitiveRatio": 47.2,
    "winRate": 50
   },
   "nonConference": {
    "matches": 5670,
    "bands": {
-    "STRETCH": 27,
-    "UP": 1160,
-    "EVEN": 1085,
-    "DOWN": 2404,
+    "STRETCH": 18,
+    "UP": 1169,
+    "EVEN": 1097,
+    "DOWN": 2392,
     "ANCHOR": 994
    },
    "bandPct": {
-    "STRETCH": 0.5,
-    "UP": 20.5,
-    "EVEN": 19.1,
-    "DOWN": 42.4,
+    "STRETCH": 0.3,
+    "UP": 20.6,
+    "EVEN": 19.3,
+    "DOWN": 42.2,
     "ANCHOR": 17.5
    },
-   "stretchRate": 0.5,
+   "stretchRate": 0.3,
    "anchorRate": 17.5,
-   "breadth": 0.83,
+   "breadth": 0.827,
    "competitiveRatio": 45,
    "winRate": 64.1
   }
@@ -81,29 +81,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 2.2,
-  "nonConference": 0.5,
-  "delta": -1.7,
+  "nonConference": 0.3,
+  "delta": -1.9,
   "nonConferenceShare": 51.4
  },
  "members": [
@@ -279,20 +279,20 @@
    "bands": {
     "STRETCH": 4,
     "UP": 143,
-    "EVEN": 74,
-    "DOWN": 133,
+    "EVEN": 82,
+    "DOWN": 125,
     "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 1.1,
     "UP": 37.8,
-    "EVEN": 19.6,
-    "DOWN": 35.2,
+    "EVEN": 21.7,
+    "DOWN": 33.1,
     "ANCHOR": 6.3
    },
    "stretchRate": 1.1,
    "anchorRate": 6.3,
-   "breadth": 0.794,
+   "breadth": 0.8,
    "competitiveRatio": 46.2,
    "winRate": 52.6
   },
@@ -414,20 +414,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 57,
-    "EVEN": 97,
-    "DOWN": 172,
+    "EVEN": 101,
+    "DOWN": 168,
     "ANCHOR": 36
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.7,
-    "EVEN": 26.8,
-    "DOWN": 47.5,
+    "EVEN": 27.9,
+    "DOWN": 46.4,
     "ANCHOR": 9.9
    },
    "stretchRate": 0,
    "anchorRate": 9.9,
-   "breadth": 0.762,
+   "breadth": 0.766,
    "competitiveRatio": 42.3,
    "winRate": 59.9
   },
@@ -682,22 +682,22 @@
    "lineupWTN": 11.89,
    "matches": 341,
    "bands": {
-    "STRETCH": 54,
-    "UP": 184,
+    "STRETCH": 45,
+    "UP": 193,
     "EVEN": 32,
     "DOWN": 71,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 15.8,
-    "UP": 54,
+    "STRETCH": 13.2,
+    "UP": 56.6,
     "EVEN": 9.4,
     "DOWN": 20.8,
     "ANCHOR": 0
    },
-   "stretchRate": 15.8,
+   "stretchRate": 13.2,
    "anchorRate": 0,
-   "breadth": 0.729,
+   "breadth": 0.707,
    "competitiveRatio": 54.5,
    "winRate": 49
   },
@@ -819,20 +819,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 62,
-    "EVEN": 94,
-    "DOWN": 116,
+    "EVEN": 107,
+    "DOWN": 103,
     "ANCHOR": 55
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19,
-    "EVEN": 28.7,
-    "DOWN": 35.5,
+    "EVEN": 32.7,
+    "DOWN": 31.5,
     "ANCHOR": 16.8
    },
    "stretchRate": 0,
    "anchorRate": 16.8,
-   "breadth": 0.833,
+   "breadth": 0.835,
    "competitiveRatio": 41.6,
    "winRate": 48
   },

--- a/public/data/conferences/big-west-conference.json
+++ b/public/data/conferences/big-west-conference.json
@@ -16,15 +16,15 @@
    "bands": {
     "STRETCH": 373,
     "UP": 1934,
-    "EVEN": 1281,
-    "DOWN": 1852,
+    "EVEN": 1287,
+    "DOWN": 1846,
     "ANCHOR": 406
    },
    "bandPct": {
     "STRETCH": 6.4,
     "UP": 33.1,
-    "EVEN": 21.9,
-    "DOWN": 31.7,
+    "EVEN": 22,
+    "DOWN": 31.6,
     "ANCHOR": 6.9
    },
    "stretchRate": 6.4,
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 267,
     "UP": 1140,
-    "EVEN": 587,
-    "DOWN": 1058,
+    "EVEN": 593,
+    "DOWN": 1052,
     "ANCHOR": 300
    },
    "bandPct": {
     "STRETCH": 8,
     "UP": 34,
-    "EVEN": 17.5,
-    "DOWN": 31.6,
+    "EVEN": 17.7,
+    "DOWN": 31.4,
     "ANCHOR": 8.9
    },
    "stretchRate": 8,
    "anchorRate": 8.9,
-   "breadth": 0.903,
+   "breadth": 0.904,
    "competitiveRatio": 45.6,
    "winRate": 48.8
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -414,20 +414,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 92,
-    "EVEN": 25,
-    "DOWN": 148,
+    "EVEN": 31,
+    "DOWN": 142,
     "ANCHOR": 58
    },
    "bandPct": {
     "STRETCH": 1.8,
     "UP": 28,
-    "EVEN": 7.6,
-    "DOWN": 45,
+    "EVEN": 9.4,
+    "DOWN": 43.2,
     "ANCHOR": 17.6
    },
    "stretchRate": 1.8,
    "anchorRate": 17.6,
-   "breadth": 0.802,
+   "breadth": 0.821,
    "competitiveRatio": 46,
    "winRate": 58.1
   },

--- a/public/data/conferences/centennial-conference.json
+++ b/public/data/conferences/centennial-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 6402,
    "bands": {
-    "STRETCH": 616,
-    "UP": 1938,
-    "EVEN": 782,
-    "DOWN": 2238,
-    "ANCHOR": 828
+    "STRETCH": 610,
+    "UP": 1944,
+    "EVEN": 788,
+    "DOWN": 2250,
+    "ANCHOR": 810
    },
    "bandPct": {
-    "STRETCH": 9.6,
-    "UP": 30.3,
-    "EVEN": 12.2,
-    "DOWN": 35,
-    "ANCHOR": 12.9
+    "STRETCH": 9.5,
+    "UP": 30.4,
+    "EVEN": 12.3,
+    "DOWN": 35.1,
+    "ANCHOR": 12.7
    },
-   "stretchRate": 9.6,
-   "anchorRate": 12.9,
-   "breadth": 0.917,
+   "stretchRate": 9.5,
+   "anchorRate": 12.7,
+   "breadth": 0.915,
    "competitiveRatio": 34.7,
    "winRate": 53.5
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 3630,
    "bands": {
-    "STRETCH": 131,
-    "UP": 1152,
-    "EVEN": 552,
-    "DOWN": 1452,
-    "ANCHOR": 343
+    "STRETCH": 125,
+    "UP": 1158,
+    "EVEN": 558,
+    "DOWN": 1464,
+    "ANCHOR": 325
    },
    "bandPct": {
-    "STRETCH": 3.6,
-    "UP": 31.7,
-    "EVEN": 15.2,
-    "DOWN": 40,
-    "ANCHOR": 9.4
+    "STRETCH": 3.4,
+    "UP": 31.9,
+    "EVEN": 15.4,
+    "DOWN": 40.3,
+    "ANCHOR": 9
    },
-   "stretchRate": 3.6,
-   "anchorRate": 9.4,
-   "breadth": 0.845,
+   "stretchRate": 3.4,
+   "anchorRate": 9,
+   "breadth": 0.839,
    "competitiveRatio": 40,
    "winRate": 56.2
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 17.5,
-  "nonConference": 3.6,
-  "delta": -13.9,
+  "nonConference": 3.4,
+  "delta": -14.1,
   "nonConferenceShare": 56.7
  },
  "members": [
@@ -173,19 +173,19 @@
     "STRETCH": 0,
     "UP": 19,
     "EVEN": 92,
-    "DOWN": 142,
-    "ANCHOR": 124
+    "DOWN": 160,
+    "ANCHOR": 106
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 5,
     "EVEN": 24.4,
-    "DOWN": 37.7,
-    "ANCHOR": 32.9
+    "DOWN": 42.4,
+    "ANCHOR": 28.1
    },
    "stretchRate": 0,
-   "anchorRate": 32.9,
-   "breadth": 0.763,
+   "anchorRate": 28.1,
+   "breadth": 0.755,
    "competitiveRatio": 37.9,
    "winRate": 66.6
   },
@@ -442,20 +442,20 @@
    "bands": {
     "STRETCH": 12,
     "UP": 38,
-    "EVEN": 42,
-    "DOWN": 200,
+    "EVEN": 48,
+    "DOWN": 194,
     "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 3.7,
     "UP": 11.7,
-    "EVEN": 12.9,
-    "DOWN": 61.3,
+    "EVEN": 14.7,
+    "DOWN": 59.5,
     "ANCHOR": 10.4
    },
    "stretchRate": 3.7,
    "anchorRate": 10.4,
-   "breadth": 0.728,
+   "breadth": 0.745,
    "competitiveRatio": 27,
    "winRate": 58
   },
@@ -467,22 +467,22 @@
    "lineupWTN": 24.43,
    "matches": 315,
    "bands": {
-    "STRETCH": 24,
-    "UP": 90,
+    "STRETCH": 18,
+    "UP": 96,
     "EVEN": 63,
     "DOWN": 87,
     "ANCHOR": 51
    },
    "bandPct": {
-    "STRETCH": 7.6,
-    "UP": 28.6,
+    "STRETCH": 5.7,
+    "UP": 30.5,
     "EVEN": 20,
     "DOWN": 27.6,
     "ANCHOR": 16.2
    },
-   "stretchRate": 7.6,
+   "stretchRate": 5.7,
    "anchorRate": 16.2,
-   "breadth": 0.948,
+   "breadth": 0.931,
    "competitiveRatio": 37.8,
    "winRate": 57.5
   },

--- a/public/data/conferences/central-atlantic-collegiate-conference.json
+++ b/public/data/conferences/central-atlantic-collegiate-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/central-intercollegiate-athletic-association.json
+++ b/public/data/conferences/central-intercollegiate-athletic-association.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 2080,
    "bands": {
-    "STRETCH": 443,
-    "UP": 760,
+    "STRETCH": 434,
+    "UP": 769,
     "EVEN": 165,
     "DOWN": 520,
     "ANCHOR": 192
    },
    "bandPct": {
-    "STRETCH": 21.3,
-    "UP": 36.5,
+    "STRETCH": 20.9,
+    "UP": 37,
     "EVEN": 7.9,
     "DOWN": 25,
     "ANCHOR": 9.2
    },
-   "stretchRate": 21.3,
+   "stretchRate": 20.9,
    "anchorRate": 9.2,
-   "breadth": 0.91,
+   "breadth": 0.909,
    "competitiveRatio": 16.1,
    "winRate": 40.4
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 906,
    "bands": {
-    "STRETCH": 278,
-    "UP": 388,
+    "STRETCH": 269,
+    "UP": 397,
     "EVEN": 65,
     "DOWN": 148,
     "ANCHOR": 27
    },
    "bandPct": {
-    "STRETCH": 30.7,
-    "UP": 42.8,
+    "STRETCH": 29.7,
+    "UP": 43.8,
     "EVEN": 7.2,
     "DOWN": 16.3,
     "ANCHOR": 3
    },
-   "stretchRate": 30.7,
+   "stretchRate": 29.7,
    "anchorRate": 3,
-   "breadth": 0.817,
+   "breadth": 0.815,
    "competitiveRatio": 25.4,
    "winRate": 28
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 14.1,
-  "nonConference": 30.7,
-  "delta": 16.6,
+  "nonConference": 29.7,
+  "delta": 15.6,
   "nonConferenceShare": 43.6
  },
  "members": [
@@ -251,22 +251,22 @@
    "lineupWTN": 22.46,
    "matches": 169,
    "bands": {
-    "STRETCH": 65,
-    "UP": 40,
+    "STRETCH": 56,
+    "UP": 49,
     "EVEN": 22,
     "DOWN": 22,
     "ANCHOR": 20
    },
    "bandPct": {
-    "STRETCH": 38.5,
-    "UP": 23.7,
+    "STRETCH": 33.1,
+    "UP": 29,
     "EVEN": 13,
     "DOWN": 13,
     "ANCHOR": 11.8
    },
-   "stretchRate": 38.5,
+   "stretchRate": 33.1,
    "anchorRate": 11.8,
-   "breadth": 0.927,
+   "breadth": 0.937,
    "competitiveRatio": 26,
    "winRate": 37.3
   },

--- a/public/data/conferences/chicagoland-collegiate-athletic-conference.json
+++ b/public/data/conferences/chicagoland-collegiate-athletic-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 317,
     "UP": 645,
     "EVEN": 109,
-    "DOWN": 481,
-    "ANCHOR": 169
+    "DOWN": 487,
+    "ANCHOR": 163
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 37.5,
     "EVEN": 6.3,
-    "DOWN": 27.9,
-    "ANCHOR": 9.8
+    "DOWN": 28.3,
+    "ANCHOR": 9.5
    },
    "stretchRate": 18.4,
-   "anchorRate": 9.8,
-   "breadth": 0.894,
+   "anchorRate": 9.5,
+   "breadth": 0.891,
    "competitiveRatio": 30.5,
    "winRate": 43.6
   },
@@ -62,19 +62,19 @@
     "STRETCH": 204,
     "UP": 539,
     "EVEN": 81,
-    "DOWN": 375,
-    "ANCHOR": 56
+    "DOWN": 381,
+    "ANCHOR": 50
    },
    "bandPct": {
     "STRETCH": 16.3,
     "UP": 42.9,
     "EVEN": 6.5,
-    "DOWN": 29.9,
-    "ANCHOR": 4.5
+    "DOWN": 30.4,
+    "ANCHOR": 4
    },
    "stretchRate": 16.3,
-   "anchorRate": 4.5,
-   "breadth": 0.829,
+   "anchorRate": 4,
+   "breadth": 0.824,
    "competitiveRatio": 36.2,
    "winRate": 41.3
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -173,19 +173,19 @@
     "STRETCH": 40,
     "UP": 77,
     "EVEN": 11,
-    "DOWN": 45,
-    "ANCHOR": 36
+    "DOWN": 51,
+    "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 19.1,
     "UP": 36.8,
     "EVEN": 5.3,
-    "DOWN": 21.5,
-    "ANCHOR": 17.2
+    "DOWN": 24.4,
+    "ANCHOR": 14.4
    },
    "stretchRate": 19.1,
-   "anchorRate": 17.2,
-   "breadth": 0.915,
+   "anchorRate": 14.4,
+   "breadth": 0.908,
    "competitiveRatio": 30.9,
    "winRate": 37.3
   },

--- a/public/data/conferences/city-university-of-new-york-athletic-conference.json
+++ b/public/data/conferences/city-university-of-new-york-athletic-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 339,
     "UP": 749,
-    "EVEN": 203,
-    "DOWN": 554,
+    "EVEN": 231,
+    "DOWN": 526,
     "ANCHOR": 296
    },
    "bandPct": {
     "STRETCH": 15.8,
     "UP": 35,
-    "EVEN": 9.5,
-    "DOWN": 25.9,
+    "EVEN": 10.8,
+    "DOWN": 24.6,
     "ANCHOR": 13.8
    },
    "stretchRate": 15.8,
    "anchorRate": 13.8,
-   "breadth": 0.936,
+   "breadth": 0.943,
    "competitiveRatio": 15.4,
    "winRate": 44.2
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 150,
     "UP": 497,
-    "EVEN": 149,
-    "DOWN": 302,
+    "EVEN": 177,
+    "DOWN": 274,
     "ANCHOR": 107
    },
    "bandPct": {
     "STRETCH": 12.4,
     "UP": 41.2,
-    "EVEN": 12.4,
-    "DOWN": 25.1,
+    "EVEN": 14.7,
+    "DOWN": 22.7,
     "ANCHOR": 8.9
    },
    "stretchRate": 12.4,
    "anchorRate": 8.9,
-   "breadth": 0.898,
+   "breadth": 0.906,
    "competitiveRatio": 19.1,
    "winRate": 39.7
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -253,20 +253,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 18,
-    "EVEN": 6,
-    "DOWN": 126,
+    "EVEN": 34,
+    "DOWN": 98,
     "ANCHOR": 41
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 9.4,
-    "EVEN": 3.1,
-    "DOWN": 66,
+    "EVEN": 17.8,
+    "DOWN": 51.3,
     "ANCHOR": 21.5
    },
    "stretchRate": 0,
    "anchorRate": 21.5,
-   "breadth": 0.582,
+   "breadth": 0.747,
    "competitiveRatio": 16.2,
    "winRate": 66.5
   },

--- a/public/data/conferences/coast-conference.json
+++ b/public/data/conferences/coast-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/coast-to-coast-conference.json
+++ b/public/data/conferences/coast-to-coast-conference.json
@@ -15,66 +15,66 @@
   "overall": {
    "matches": 3072,
    "bands": {
-    "STRETCH": 173,
-    "UP": 1003,
+    "STRETCH": 142,
+    "UP": 1034,
     "EVEN": 391,
-    "DOWN": 1207,
-    "ANCHOR": 298
+    "DOWN": 1220,
+    "ANCHOR": 285
    },
    "bandPct": {
-    "STRETCH": 5.6,
-    "UP": 32.6,
+    "STRETCH": 4.6,
+    "UP": 33.7,
     "EVEN": 12.7,
-    "DOWN": 39.3,
-    "ANCHOR": 9.7
+    "DOWN": 39.7,
+    "ANCHOR": 9.3
    },
-   "stretchRate": 5.6,
-   "anchorRate": 9.7,
-   "breadth": 0.859,
+   "stretchRate": 4.6,
+   "anchorRate": 9.3,
+   "breadth": 0.844,
    "competitiveRatio": 40.4,
    "winRate": 57.9
   },
   "inConference": {
    "matches": 384,
    "bands": {
-    "STRETCH": 27,
-    "UP": 128,
+    "STRETCH": 14,
+    "UP": 141,
     "EVEN": 74,
-    "DOWN": 128,
-    "ANCHOR": 27
+    "DOWN": 141,
+    "ANCHOR": 14
    },
    "bandPct": {
-    "STRETCH": 7,
-    "UP": 33.3,
+    "STRETCH": 3.6,
+    "UP": 36.7,
     "EVEN": 19.3,
-    "DOWN": 33.3,
-    "ANCHOR": 7
+    "DOWN": 36.7,
+    "ANCHOR": 3.6
    },
-   "stretchRate": 7,
-   "anchorRate": 7,
-   "breadth": 0.884,
+   "stretchRate": 3.6,
+   "anchorRate": 3.6,
+   "breadth": 0.804,
    "competitiveRatio": 47.7,
    "winRate": 50
   },
   "nonConference": {
    "matches": 2688,
    "bands": {
-    "STRETCH": 146,
-    "UP": 875,
+    "STRETCH": 128,
+    "UP": 893,
     "EVEN": 317,
     "DOWN": 1079,
     "ANCHOR": 271
    },
    "bandPct": {
-    "STRETCH": 5.4,
-    "UP": 32.6,
+    "STRETCH": 4.8,
+    "UP": 33.2,
     "EVEN": 11.8,
     "DOWN": 40.1,
     "ANCHOR": 10.1
    },
-   "stretchRate": 5.4,
+   "stretchRate": 4.8,
    "anchorRate": 10.1,
-   "breadth": 0.853,
+   "breadth": 0.846,
    "competitiveRatio": 39.3,
    "winRate": 59
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 7,
-  "nonConference": 5.4,
-  "delta": -1.6,
+  "inConference": 3.6,
+  "nonConference": 4.8,
+  "delta": 1.2,
   "nonConferenceShare": 87.5
  },
  "members": [
@@ -119,19 +119,19 @@
     "STRETCH": 0,
     "UP": 138,
     "EVEN": 40,
-    "DOWN": 214,
-    "ANCHOR": 76
+    "DOWN": 227,
+    "ANCHOR": 63
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 29.5,
     "EVEN": 8.5,
-    "DOWN": 45.7,
-    "ANCHOR": 16.2
+    "DOWN": 48.5,
+    "ANCHOR": 13.5
    },
    "stretchRate": 0,
-   "anchorRate": 16.2,
-   "breadth": 0.76,
+   "anchorRate": 13.5,
+   "breadth": 0.74,
    "competitiveRatio": 57.4,
    "winRate": 59.2
   },
@@ -143,22 +143,22 @@
    "lineupWTN": 21.77,
    "matches": 391,
    "bands": {
-    "STRETCH": 69,
-    "UP": 142,
+    "STRETCH": 56,
+    "UP": 155,
     "EVEN": 51,
     "DOWN": 101,
     "ANCHOR": 28
    },
    "bandPct": {
-    "STRETCH": 17.6,
-    "UP": 36.3,
+    "STRETCH": 14.3,
+    "UP": 39.6,
     "EVEN": 13,
     "DOWN": 25.8,
     "ANCHOR": 7.2
    },
-   "stretchRate": 17.6,
+   "stretchRate": 14.3,
    "anchorRate": 7.2,
-   "breadth": 0.918,
+   "breadth": 0.9,
    "competitiveRatio": 41.7,
    "winRate": 45.5
   },
@@ -224,22 +224,22 @@
    "lineupWTN": 23.73,
    "matches": 340,
    "bands": {
-    "STRETCH": 24,
-    "UP": 123,
+    "STRETCH": 6,
+    "UP": 141,
     "EVEN": 50,
     "DOWN": 137,
     "ANCHOR": 6
    },
    "bandPct": {
-    "STRETCH": 7.1,
-    "UP": 36.2,
+    "STRETCH": 1.8,
+    "UP": 41.5,
     "EVEN": 14.7,
     "DOWN": 40.3,
     "ANCHOR": 1.8
    },
-   "stretchRate": 7.1,
+   "stretchRate": 1.8,
    "anchorRate": 1.8,
-   "breadth": 0.792,
+   "breadth": 0.718,
    "competitiveRatio": 40.9,
    "winRate": 57.9
   },

--- a/public/data/conferences/coastal-athletic-association.json
+++ b/public/data/conferences/coastal-athletic-association.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/college-conference-of-illinois-and-wisconsin.json
+++ b/public/data/conferences/college-conference-of-illinois-and-wisconsin.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 548,
     "UP": 1893,
-    "EVEN": 612,
-    "DOWN": 1892,
-    "ANCHOR": 478
+    "EVEN": 623,
+    "DOWN": 1889,
+    "ANCHOR": 470
    },
    "bandPct": {
     "STRETCH": 10.1,
     "UP": 34.9,
-    "EVEN": 11.3,
-    "DOWN": 34.9,
-    "ANCHOR": 8.8
+    "EVEN": 11.5,
+    "DOWN": 34.8,
+    "ANCHOR": 8.7
    },
    "stretchRate": 10.1,
-   "anchorRate": 8.8,
-   "breadth": 0.886,
+   "anchorRate": 8.7,
+   "breadth": 0.887,
    "competitiveRatio": 34.5,
    "winRate": 52.4
   },
@@ -61,19 +61,19 @@
    "bands": {
     "STRETCH": 266,
     "UP": 1135,
-    "EVEN": 328,
-    "DOWN": 1134,
-    "ANCHOR": 196
+    "EVEN": 339,
+    "DOWN": 1131,
+    "ANCHOR": 188
    },
    "bandPct": {
     "STRETCH": 8.7,
     "UP": 37.1,
-    "EVEN": 10.7,
-    "DOWN": 37.1,
-    "ANCHOR": 6.4
+    "EVEN": 11.1,
+    "DOWN": 37,
+    "ANCHOR": 6.1
    },
    "stretchRate": 8.7,
-   "anchorRate": 6.4,
+   "anchorRate": 6.1,
    "breadth": 0.847,
    "competitiveRatio": 37.7,
    "winRate": 54.2
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -145,20 +145,20 @@
    "bands": {
     "STRETCH": 47,
     "UP": 108,
-    "EVEN": 41,
+    "EVEN": 46,
     "DOWN": 180,
-    "ANCHOR": 53
+    "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 11,
     "UP": 25.2,
-    "EVEN": 9.6,
+    "EVEN": 10.7,
     "DOWN": 42,
-    "ANCHOR": 12.4
+    "ANCHOR": 11.2
    },
    "stretchRate": 11,
-   "anchorRate": 12.4,
-   "breadth": 0.893,
+   "anchorRate": 11.2,
+   "breadth": 0.894,
    "competitiveRatio": 32.2,
    "winRate": 60.6
   },
@@ -173,19 +173,19 @@
     "STRETCH": 48,
     "UP": 118,
     "EVEN": 12,
-    "DOWN": 185,
-    "ANCHOR": 36
+    "DOWN": 188,
+    "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 12,
     "UP": 29.6,
     "EVEN": 3,
-    "DOWN": 46.4,
-    "ANCHOR": 9
+    "DOWN": 47.1,
+    "ANCHOR": 8.3
    },
    "stretchRate": 12,
-   "anchorRate": 9,
-   "breadth": 0.804,
+   "anchorRate": 8.3,
+   "breadth": 0.796,
    "competitiveRatio": 45.4,
    "winRate": 66.4
   },
@@ -199,20 +199,20 @@
    "bands": {
     "STRETCH": 12,
     "UP": 172,
-    "EVEN": 18,
-    "DOWN": 159,
+    "EVEN": 24,
+    "DOWN": 153,
     "ANCHOR": 16
    },
    "bandPct": {
     "STRETCH": 3.2,
     "UP": 45.6,
-    "EVEN": 4.8,
-    "DOWN": 42.2,
+    "EVEN": 6.4,
+    "DOWN": 40.6,
     "ANCHOR": 4.2
    },
    "stretchRate": 3.2,
    "anchorRate": 4.2,
-   "breadth": 0.69,
+   "breadth": 0.71,
    "competitiveRatio": 42,
    "winRate": 61.8
   },

--- a/public/data/conferences/collegiate-conference-of-the-south.json
+++ b/public/data/conferences/collegiate-conference-of-the-south.json
@@ -18,19 +18,19 @@
     "STRETCH": 722,
     "UP": 1537,
     "EVEN": 557,
-    "DOWN": 1200,
-    "ANCHOR": 402
+    "DOWN": 1221,
+    "ANCHOR": 381
    },
    "bandPct": {
     "STRETCH": 16.3,
     "UP": 34.8,
     "EVEN": 12.6,
-    "DOWN": 27.2,
-    "ANCHOR": 9.1
+    "DOWN": 27.6,
+    "ANCHOR": 8.6
    },
    "stretchRate": 16.3,
-   "anchorRate": 9.1,
-   "breadth": 0.93,
+   "anchorRate": 8.6,
+   "breadth": 0.927,
    "competitiveRatio": 26.7,
    "winRate": 44.5
   },
@@ -40,19 +40,19 @@
     "STRETCH": 178,
     "UP": 532,
     "EVEN": 164,
-    "DOWN": 511,
-    "ANCHOR": 199
+    "DOWN": 532,
+    "ANCHOR": 178
    },
    "bandPct": {
     "STRETCH": 11.2,
     "UP": 33.6,
     "EVEN": 10.4,
-    "DOWN": 32.3,
-    "ANCHOR": 12.6
+    "DOWN": 33.6,
+    "ANCHOR": 11.2
    },
    "stretchRate": 11.2,
-   "anchorRate": 12.6,
-   "breadth": 0.915,
+   "anchorRate": 11.2,
+   "breadth": 0.907,
    "competitiveRatio": 22.1,
    "winRate": 50
   },
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -200,19 +200,19 @@
     "STRETCH": 24,
     "UP": 66,
     "EVEN": 77,
-    "DOWN": 167,
-    "ANCHOR": 51
+    "DOWN": 188,
+    "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 6.2,
     "UP": 17.1,
     "EVEN": 20,
-    "DOWN": 43.4,
-    "ANCHOR": 13.2
+    "DOWN": 48.8,
+    "ANCHOR": 7.8
    },
    "stretchRate": 6.2,
-   "anchorRate": 13.2,
-   "breadth": 0.887,
+   "anchorRate": 7.8,
+   "breadth": 0.836,
    "competitiveRatio": 37.7,
    "winRate": 62.3
   },

--- a/public/data/conferences/conference-carolinas.json
+++ b/public/data/conferences/conference-carolinas.json
@@ -18,20 +18,20 @@
    "bands": {
     "STRETCH": 874,
     "UP": 3515,
-    "EVEN": 1403,
-    "DOWN": 2698,
+    "EVEN": 1460,
+    "DOWN": 2641,
     "ANCHOR": 877
    },
    "bandPct": {
     "STRETCH": 9.3,
     "UP": 37.5,
-    "EVEN": 15,
-    "DOWN": 28.8,
+    "EVEN": 15.6,
+    "DOWN": 28.2,
     "ANCHOR": 9.4
    },
    "stretchRate": 9.3,
    "anchorRate": 9.4,
-   "breadth": 0.903,
+   "breadth": 0.906,
    "competitiveRatio": 40.3,
    "winRate": 44.8
   },
@@ -40,20 +40,20 @@
    "bands": {
     "STRETCH": 336,
     "UP": 1661,
-    "EVEN": 746,
-    "DOWN": 1685,
+    "EVEN": 770,
+    "DOWN": 1661,
     "ANCHOR": 336
    },
    "bandPct": {
     "STRETCH": 7.1,
     "UP": 34.9,
-    "EVEN": 15.7,
-    "DOWN": 35.4,
+    "EVEN": 16.2,
+    "DOWN": 34.9,
     "ANCHOR": 7.1
    },
    "stretchRate": 7.1,
    "anchorRate": 7.1,
-   "breadth": 0.869,
+   "breadth": 0.872,
    "competitiveRatio": 43.3,
    "winRate": 50
   },
@@ -62,20 +62,20 @@
    "bands": {
     "STRETCH": 538,
     "UP": 1854,
-    "EVEN": 657,
-    "DOWN": 1013,
+    "EVEN": 690,
+    "DOWN": 980,
     "ANCHOR": 541
    },
    "bandPct": {
     "STRETCH": 11.7,
     "UP": 40.3,
-    "EVEN": 14.3,
-    "DOWN": 22,
+    "EVEN": 15,
+    "DOWN": 21.3,
     "ANCHOR": 11.8
    },
    "stretchRate": 11.7,
    "anchorRate": 11.8,
-   "breadth": 0.919,
+   "breadth": 0.921,
    "competitiveRatio": 37.2,
    "winRate": 39.4
   }
@@ -83,22 +83,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -119,20 +119,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 109,
-    "EVEN": 57,
-    "DOWN": 329,
+    "EVEN": 90,
+    "DOWN": 296,
     "ANCHOR": 211
    },
    "bandPct": {
     "STRETCH": 0.8,
     "UP": 15.3,
-    "EVEN": 8,
-    "DOWN": 46.2,
+    "EVEN": 12.6,
+    "DOWN": 41.6,
     "ANCHOR": 29.6
    },
    "stretchRate": 0.8,
    "anchorRate": 29.6,
-   "breadth": 0.775,
+   "breadth": 0.817,
    "competitiveRatio": 44.3,
    "winRate": 48.7
   },
@@ -470,20 +470,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 54,
-    "EVEN": 118,
-    "DOWN": 150,
+    "EVEN": 136,
+    "DOWN": 132,
     "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.9,
-    "EVEN": 34.7,
-    "DOWN": 44.1,
+    "EVEN": 40,
+    "DOWN": 38.8,
     "ANCHOR": 5.3
    },
    "stretchRate": 0,
    "anchorRate": 5.3,
-   "breadth": 0.731,
+   "breadth": 0.734,
    "competitiveRatio": 35.3,
    "winRate": 41.2
   },
@@ -686,20 +686,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 84,
-    "EVEN": 92,
-    "DOWN": 115,
+    "EVEN": 98,
+    "DOWN": 109,
     "ANCHOR": 9
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 28,
-    "EVEN": 30.7,
-    "DOWN": 38.3,
+    "EVEN": 32.7,
+    "DOWN": 36.3,
     "ANCHOR": 3
    },
    "stretchRate": 0,
    "anchorRate": 3,
-   "breadth": 0.74,
+   "breadth": 0.742,
    "competitiveRatio": 44.3,
    "winRate": 49.7
   },

--- a/public/data/conferences/conference-of-new-england.json
+++ b/public/data/conferences/conference-of-new-england.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 4331,
    "bands": {
-    "STRETCH": 816,
-    "UP": 1399,
+    "STRETCH": 810,
+    "UP": 1405,
     "EVEN": 377,
-    "DOWN": 1184,
-    "ANCHOR": 555
+    "DOWN": 1190,
+    "ANCHOR": 549
    },
    "bandPct": {
-    "STRETCH": 18.8,
-    "UP": 32.3,
+    "STRETCH": 18.7,
+    "UP": 32.4,
     "EVEN": 8.7,
-    "DOWN": 27.3,
-    "ANCHOR": 12.8
+    "DOWN": 27.5,
+    "ANCHOR": 12.7
    },
-   "stretchRate": 18.8,
-   "anchorRate": 12.8,
-   "breadth": 0.938,
+   "stretchRate": 18.7,
+   "anchorRate": 12.7,
+   "breadth": 0.937,
    "competitiveRatio": 25.7,
    "winRate": 45
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 2519,
    "bands": {
-    "STRETCH": 452,
-    "UP": 920,
+    "STRETCH": 446,
+    "UP": 926,
     "EVEN": 251,
-    "DOWN": 705,
-    "ANCHOR": 191
+    "DOWN": 711,
+    "ANCHOR": 185
    },
    "bandPct": {
-    "STRETCH": 17.9,
-    "UP": 36.5,
+    "STRETCH": 17.7,
+    "UP": 36.8,
     "EVEN": 10,
-    "DOWN": 28,
-    "ANCHOR": 7.6
+    "DOWN": 28.2,
+    "ANCHOR": 7.3
    },
-   "stretchRate": 17.9,
-   "anchorRate": 7.6,
-   "breadth": 0.906,
+   "stretchRate": 17.7,
+   "anchorRate": 7.3,
+   "breadth": 0.903,
    "competitiveRatio": 29.2,
    "winRate": 41.4
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 20.1,
-  "nonConference": 17.9,
-  "delta": -2.2,
+  "nonConference": 17.7,
+  "delta": -2.4,
   "nonConferenceShare": 58.2
  },
  "members": [
@@ -173,19 +173,19 @@
     "STRETCH": 74,
     "UP": 128,
     "EVEN": 6,
-    "DOWN": 57,
-    "ANCHOR": 81
+    "DOWN": 63,
+    "ANCHOR": 75
    },
    "bandPct": {
     "STRETCH": 21.4,
     "UP": 37,
     "EVEN": 1.7,
-    "DOWN": 16.5,
-    "ANCHOR": 23.4
+    "DOWN": 18.2,
+    "ANCHOR": 21.7
    },
    "stretchRate": 21.4,
-   "anchorRate": 23.4,
-   "breadth": 0.873,
+   "anchorRate": 21.7,
+   "breadth": 0.876,
    "competitiveRatio": 30.1,
    "winRate": 54.9
   },
@@ -359,22 +359,22 @@
    "lineupWTN": 26.35,
    "matches": 289,
    "bands": {
-    "STRETCH": 42,
-    "UP": 104,
+    "STRETCH": 36,
+    "UP": 110,
     "EVEN": 24,
     "DOWN": 102,
     "ANCHOR": 17
    },
    "bandPct": {
-    "STRETCH": 14.5,
-    "UP": 36,
+    "STRETCH": 12.5,
+    "UP": 38.1,
     "EVEN": 8.3,
     "DOWN": 35.3,
     "ANCHOR": 5.9
    },
-   "stretchRate": 14.5,
+   "stretchRate": 12.5,
    "anchorRate": 5.9,
-   "breadth": 0.863,
+   "breadth": 0.85,
    "competitiveRatio": 27.3,
    "winRate": 37.7
   },

--- a/public/data/conferences/conference-usa.json
+++ b/public/data/conferences/conference-usa.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 199,
     "UP": 1828,
-    "EVEN": 1139,
-    "DOWN": 1866,
+    "EVEN": 1156,
+    "DOWN": 1849,
     "ANCHOR": 517
    },
    "bandPct": {
     "STRETCH": 3.6,
     "UP": 32.9,
-    "EVEN": 20.5,
-    "DOWN": 33.6,
+    "EVEN": 20.8,
+    "DOWN": 33.3,
     "ANCHOR": 9.3
    },
    "stretchRate": 3.6,
    "anchorRate": 9.3,
-   "breadth": 0.868,
+   "breadth": 0.869,
    "competitiveRatio": 43.8,
    "winRate": 56.2
   },
@@ -38,20 +38,20 @@
    "bands": {
     "STRETCH": 3,
     "UP": 334,
-    "EVEN": 167,
-    "DOWN": 345,
+    "EVEN": 178,
+    "DOWN": 334,
     "ANCHOR": 3
    },
    "bandPct": {
     "STRETCH": 0.4,
     "UP": 39.2,
-    "EVEN": 19.6,
-    "DOWN": 40.5,
+    "EVEN": 20.9,
+    "DOWN": 39.2,
     "ANCHOR": 0.4
    },
    "stretchRate": 0.4,
    "anchorRate": 0.4,
-   "breadth": 0.679,
+   "breadth": 0.684,
    "competitiveRatio": 40,
    "winRate": 50
   },
@@ -60,15 +60,15 @@
    "bands": {
     "STRETCH": 196,
     "UP": 1494,
-    "EVEN": 972,
-    "DOWN": 1521,
+    "EVEN": 978,
+    "DOWN": 1515,
     "ANCHOR": 514
    },
    "bandPct": {
     "STRETCH": 4.2,
     "UP": 31.8,
-    "EVEN": 20.7,
-    "DOWN": 32.4,
+    "EVEN": 20.8,
+    "DOWN": 32.3,
     "ANCHOR": 10.9
    },
    "stretchRate": 4.2,
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -198,20 +198,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 141,
-    "EVEN": 65,
-    "DOWN": 111,
+    "EVEN": 71,
+    "DOWN": 105,
     "ANCHOR": 44
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 38.4,
-    "EVEN": 17.7,
-    "DOWN": 30.2,
+    "EVEN": 19.3,
+    "DOWN": 28.6,
     "ANCHOR": 12
    },
    "stretchRate": 1.6,
    "anchorRate": 12,
-   "breadth": 0.843,
+   "breadth": 0.848,
    "competitiveRatio": 39.5,
    "winRate": 56.7
   },
@@ -441,20 +441,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 74,
-    "EVEN": 93,
-    "DOWN": 84,
+    "EVEN": 104,
+    "DOWN": 73,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 26.5,
-    "EVEN": 33.3,
-    "DOWN": 30.1,
+    "EVEN": 37.3,
+    "DOWN": 26.2,
     "ANCHOR": 10
    },
    "stretchRate": 0,
    "anchorRate": 10,
-   "breadth": 0.814,
+   "breadth": 0.809,
    "competitiveRatio": 43.5,
    "winRate": 49.5
   },

--- a/public/data/conferences/crossroads-league.json
+++ b/public/data/conferences/crossroads-league.json
@@ -18,19 +18,19 @@
     "STRETCH": 750,
     "UP": 1801,
     "EVEN": 655,
-    "DOWN": 1724,
-    "ANCHOR": 946
+    "DOWN": 1730,
+    "ANCHOR": 940
    },
    "bandPct": {
     "STRETCH": 12.8,
     "UP": 30.7,
     "EVEN": 11.1,
-    "DOWN": 29.3,
-    "ANCHOR": 16.1
+    "DOWN": 29.4,
+    "ANCHOR": 16
    },
    "stretchRate": 12.8,
-   "anchorRate": 16.1,
-   "breadth": 0.947,
+   "anchorRate": 16,
+   "breadth": 0.946,
    "competitiveRatio": 31.8,
    "winRate": 50.1
   },
@@ -62,19 +62,19 @@
     "STRETCH": 216,
     "UP": 965,
     "EVEN": 293,
-    "DOWN": 888,
-    "ANCHOR": 412
+    "DOWN": 894,
+    "ANCHOR": 406
    },
    "bandPct": {
     "STRETCH": 7.8,
     "UP": 34.8,
     "EVEN": 10.6,
-    "DOWN": 32,
-    "ANCHOR": 14.9
+    "DOWN": 32.2,
+    "ANCHOR": 14.6
    },
    "stretchRate": 7.8,
-   "anchorRate": 14.9,
-   "breadth": 0.902,
+   "anchorRate": 14.6,
+   "breadth": 0.901,
    "competitiveRatio": 37.1,
    "winRate": 50.4
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -497,19 +497,19 @@
     "STRETCH": 67,
     "UP": 81,
     "EVEN": 0,
-    "DOWN": 47,
-    "ANCHOR": 48
+    "DOWN": 53,
+    "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 27.6,
     "UP": 33.3,
     "EVEN": 0,
-    "DOWN": 19.3,
-    "ANCHOR": 19.8
+    "DOWN": 21.8,
+    "ANCHOR": 17.3
    },
    "stretchRate": 27.6,
-   "anchorRate": 19.8,
-   "breadth": 0.845,
+   "anchorRate": 17.3,
+   "breadth": 0.843,
    "competitiveRatio": 29.6,
    "winRate": 36.6
   },

--- a/public/data/conferences/east-coast-conference.json
+++ b/public/data/conferences/east-coast-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 266,
     "UP": 734,
     "EVEN": 184,
-    "DOWN": 809,
-    "ANCHOR": 383
+    "DOWN": 842,
+    "ANCHOR": 350
    },
    "bandPct": {
     "STRETCH": 11.2,
     "UP": 30.9,
     "EVEN": 7.7,
-    "DOWN": 34,
-    "ANCHOR": 16.1
+    "DOWN": 35.4,
+    "ANCHOR": 14.7
    },
    "stretchRate": 11.2,
-   "anchorRate": 16.1,
-   "breadth": 0.912,
+   "anchorRate": 14.7,
+   "breadth": 0.905,
    "competitiveRatio": 35.2,
    "winRate": 56.6
   },
@@ -40,19 +40,19 @@
     "STRETCH": 129,
     "UP": 236,
     "EVEN": 34,
-    "DOWN": 203,
-    "ANCHOR": 162
+    "DOWN": 236,
+    "ANCHOR": 129
    },
    "bandPct": {
     "STRETCH": 16.9,
     "UP": 30.9,
     "EVEN": 4.5,
-    "DOWN": 26.6,
-    "ANCHOR": 21.2
+    "DOWN": 30.9,
+    "ANCHOR": 16.9
    },
    "stretchRate": 16.9,
-   "anchorRate": 21.2,
-   "breadth": 0.921,
+   "anchorRate": 16.9,
+   "breadth": 0.91,
    "competitiveRatio": 32.3,
    "winRate": 50
   },
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -227,19 +227,19 @@
     "STRETCH": 0,
     "UP": 55,
     "EVEN": 4,
-    "DOWN": 139,
-    "ANCHOR": 86
+    "DOWN": 172,
+    "ANCHOR": 53
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 19.4,
     "EVEN": 1.4,
-    "DOWN": 48.9,
-    "ANCHOR": 30.3
+    "DOWN": 60.6,
+    "ANCHOR": 18.7
    },
    "stretchRate": 0,
-   "anchorRate": 30.3,
-   "breadth": 0.677,
+   "anchorRate": 18.7,
+   "breadth": 0.618,
    "competitiveRatio": 32.7,
    "winRate": 69.4
   },

--- a/public/data/conferences/eastern-metro-athletic-conference.json
+++ b/public/data/conferences/eastern-metro-athletic-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/empire-8.json
+++ b/public/data/conferences/empire-8.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/florida-ccaa.json
+++ b/public/data/conferences/florida-ccaa.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/golden-state-athletic-conference.json
+++ b/public/data/conferences/golden-state-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/great-american-conference.json
+++ b/public/data/conferences/great-american-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 108,
     "UP": 1240,
-    "EVEN": 476,
-    "DOWN": 1144,
+    "EVEN": 511,
+    "DOWN": 1109,
     "ANCHOR": 197
    },
    "bandPct": {
     "STRETCH": 3.4,
     "UP": 39.2,
-    "EVEN": 15,
-    "DOWN": 36.1,
+    "EVEN": 16.1,
+    "DOWN": 35,
     "ANCHOR": 6.2
    },
    "stretchRate": 3.4,
    "anchorRate": 6.2,
-   "breadth": 0.813,
+   "breadth": 0.818,
    "competitiveRatio": 46.8,
    "winRate": 54.7
   },
@@ -39,20 +39,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 310,
-    "EVEN": 173,
-    "DOWN": 345,
+    "EVEN": 208,
+    "DOWN": 310,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 37.4,
-    "EVEN": 20.9,
-    "DOWN": 41.7,
+    "EVEN": 25.1,
+    "DOWN": 37.4,
     "ANCHOR": 0
    },
    "stretchRate": 0,
    "anchorRate": 0,
-   "breadth": 0.658,
+   "breadth": 0.673,
    "competitiveRatio": 51.7,
    "winRate": 50
   },
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -307,20 +307,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 71,
-    "EVEN": 6,
-    "DOWN": 215,
+    "EVEN": 24,
+    "DOWN": 197,
     "ANCHOR": 29
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 22.1,
-    "EVEN": 1.9,
-    "DOWN": 67,
+    "EVEN": 7.5,
+    "DOWN": 61.4,
     "ANCHOR": 9
    },
    "stretchRate": 0,
    "anchorRate": 9,
-   "breadth": 0.555,
+   "breadth": 0.649,
    "competitiveRatio": 44.1,
    "winRate": 58.9
   },
@@ -334,20 +334,20 @@
    "bands": {
     "STRETCH": 16,
     "UP": 117,
-    "EVEN": 18,
-    "DOWN": 104,
+    "EVEN": 35,
+    "DOWN": 87,
     "ANCHOR": 28
    },
    "bandPct": {
     "STRETCH": 5.7,
     "UP": 41.3,
-    "EVEN": 6.4,
-    "DOWN": 36.7,
+    "EVEN": 12.4,
+    "DOWN": 30.7,
     "ANCHOR": 9.9
    },
    "stretchRate": 5.7,
    "anchorRate": 9.9,
-   "breadth": 0.807,
+   "breadth": 0.856,
    "competitiveRatio": 37.7,
    "winRate": 42
   }

--- a/public/data/conferences/great-lakes-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/great-lakes-intercollegiate-athletic-conference.json
@@ -18,15 +18,15 @@
    "bands": {
     "STRETCH": 271,
     "UP": 1677,
-    "EVEN": 665,
-    "DOWN": 1824,
+    "EVEN": 671,
+    "DOWN": 1818,
     "ANCHOR": 444
    },
    "bandPct": {
     "STRETCH": 5.6,
     "UP": 34.4,
-    "EVEN": 13.6,
-    "DOWN": 37.4,
+    "EVEN": 13.7,
+    "DOWN": 37.2,
     "ANCHOR": 9.1
    },
    "stretchRate": 5.6,
@@ -62,20 +62,20 @@
    "bands": {
     "STRETCH": 120,
     "UP": 1087,
-    "EVEN": 351,
-    "DOWN": 1234,
+    "EVEN": 357,
+    "DOWN": 1228,
     "ANCHOR": 293
    },
    "bandPct": {
     "STRETCH": 3.9,
     "UP": 35.2,
-    "EVEN": 11.4,
-    "DOWN": 40,
+    "EVEN": 11.6,
+    "DOWN": 39.8,
     "ANCHOR": 9.5
    },
    "stretchRate": 3.9,
    "anchorRate": 9.5,
-   "breadth": 0.827,
+   "breadth": 0.829,
    "competitiveRatio": 42.4,
    "winRate": 51.7
   }
@@ -83,22 +83,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -146,20 +146,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 152,
-    "EVEN": 42,
-    "DOWN": 185,
+    "EVEN": 48,
+    "DOWN": 179,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 39.5,
-    "EVEN": 10.9,
-    "DOWN": 48.1,
+    "EVEN": 12.5,
+    "DOWN": 46.5,
     "ANCHOR": 1.6
    },
    "stretchRate": 0,
    "anchorRate": 1.6,
-   "breadth": 0.637,
+   "breadth": 0.651,
    "competitiveRatio": 36.6,
    "winRate": 45.2
   },

--- a/public/data/conferences/great-lakes-valley-conference.json
+++ b/public/data/conferences/great-lakes-valley-conference.json
@@ -15,44 +15,44 @@
   "overall": {
    "matches": 6218,
    "bands": {
-    "STRETCH": 674,
-    "UP": 2209,
+    "STRETCH": 666,
+    "UP": 2217,
     "EVEN": 895,
-    "DOWN": 1924,
-    "ANCHOR": 516
+    "DOWN": 1932,
+    "ANCHOR": 508
    },
    "bandPct": {
-    "STRETCH": 10.8,
-    "UP": 35.5,
+    "STRETCH": 10.7,
+    "UP": 35.7,
     "EVEN": 14.4,
-    "DOWN": 30.9,
-    "ANCHOR": 8.3
+    "DOWN": 31.1,
+    "ANCHOR": 8.2
    },
-   "stretchRate": 10.8,
-   "anchorRate": 8.3,
-   "breadth": 0.905,
+   "stretchRate": 10.7,
+   "anchorRate": 8.2,
+   "breadth": 0.903,
    "competitiveRatio": 43,
    "winRate": 49.6
   },
   "inConference": {
    "matches": 2868,
    "bands": {
-    "STRETCH": 267,
-    "UP": 996,
+    "STRETCH": 259,
+    "UP": 1004,
     "EVEN": 342,
-    "DOWN": 996,
-    "ANCHOR": 267
+    "DOWN": 1004,
+    "ANCHOR": 259
    },
    "bandPct": {
-    "STRETCH": 9.3,
-    "UP": 34.7,
+    "STRETCH": 9,
+    "UP": 35,
     "EVEN": 11.9,
-    "DOWN": 34.7,
-    "ANCHOR": 9.3
+    "DOWN": 35,
+    "ANCHOR": 9
    },
-   "stretchRate": 9.3,
-   "anchorRate": 9.3,
-   "breadth": 0.889,
+   "stretchRate": 9,
+   "anchorRate": 9,
+   "breadth": 0.884,
    "competitiveRatio": 44,
    "winRate": 50
   },
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 9.3,
+  "inConference": 9,
   "nonConference": 12.1,
-  "delta": 2.8,
+  "delta": 3.1,
   "nonConferenceShare": 53.9
  },
  "members": [
@@ -281,19 +281,19 @@
     "STRETCH": 5,
     "UP": 107,
     "EVEN": 31,
-    "DOWN": 147,
-    "ANCHOR": 26
+    "DOWN": 155,
+    "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 33.9,
     "EVEN": 9.8,
-    "DOWN": 46.5,
-    "ANCHOR": 8.2
+    "DOWN": 49.1,
+    "ANCHOR": 5.7
    },
    "stretchRate": 1.6,
-   "anchorRate": 8.2,
-   "breadth": 0.759,
+   "anchorRate": 5.7,
+   "breadth": 0.729,
    "competitiveRatio": 33.9,
    "winRate": 63
   },
@@ -440,22 +440,22 @@
    "lineupWTN": 26.04,
    "matches": 294,
    "bands": {
-    "STRETCH": 59,
-    "UP": 150,
+    "STRETCH": 51,
+    "UP": 158,
     "EVEN": 13,
     "DOWN": 72,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 20.1,
-    "UP": 51,
+    "STRETCH": 17.3,
+    "UP": 53.7,
     "EVEN": 4.4,
     "DOWN": 24.5,
     "ANCHOR": 0
    },
-   "stretchRate": 20.1,
+   "stretchRate": 17.3,
    "anchorRate": 0,
-   "breadth": 0.713,
+   "breadth": 0.696,
    "competitiveRatio": 41.8,
    "winRate": 51
   },

--- a/public/data/conferences/great-midwest-athletic-conference.json
+++ b/public/data/conferences/great-midwest-athletic-conference.json
@@ -15,15 +15,15 @@
   "overall": {
    "matches": 6158,
    "bands": {
-    "STRETCH": 641,
-    "UP": 2108,
+    "STRETCH": 639,
+    "UP": 2110,
     "EVEN": 651,
     "DOWN": 2109,
     "ANCHOR": 649
    },
    "bandPct": {
     "STRETCH": 10.4,
-    "UP": 34.2,
+    "UP": 34.3,
     "EVEN": 10.6,
     "DOWN": 34.2,
     "ANCHOR": 10.5
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 3460,
    "bands": {
-    "STRETCH": 208,
-    "UP": 1302,
+    "STRETCH": 206,
+    "UP": 1304,
     "EVEN": 431,
     "DOWN": 1303,
     "ANCHOR": 216
    },
    "bandPct": {
     "STRETCH": 6,
-    "UP": 37.6,
+    "UP": 37.7,
     "EVEN": 12.5,
     "DOWN": 37.7,
     "ANCHOR": 6.2
    },
    "stretchRate": 6,
    "anchorRate": 6.2,
-   "breadth": 0.831,
+   "breadth": 0.83,
    "competitiveRatio": 42.2,
    "winRate": 49
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -575,22 +575,22 @@
    "lineupWTN": 28.52,
    "matches": 192,
    "bands": {
-    "STRETCH": 94,
-    "UP": 46,
+    "STRETCH": 92,
+    "UP": 48,
     "EVEN": 14,
     "DOWN": 38,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 49,
-    "UP": 24,
+    "STRETCH": 47.9,
+    "UP": 25,
     "EVEN": 7.3,
     "DOWN": 19.8,
     "ANCHOR": 0
    },
-   "stretchRate": 49,
+   "stretchRate": 47.9,
    "anchorRate": 0,
-   "breadth": 0.748,
+   "breadth": 0.752,
    "competitiveRatio": 8.3,
    "winRate": 17.2
   },

--- a/public/data/conferences/great-northeast-athletic-conference.json
+++ b/public/data/conferences/great-northeast-athletic-conference.json
@@ -15,44 +15,44 @@
   "overall": {
    "matches": 1789,
    "bands": {
-    "STRETCH": 183,
-    "UP": 616,
-    "EVEN": 276,
-    "DOWN": 602,
-    "ANCHOR": 112
+    "STRETCH": 165,
+    "UP": 634,
+    "EVEN": 285,
+    "DOWN": 611,
+    "ANCHOR": 94
    },
    "bandPct": {
-    "STRETCH": 10.2,
-    "UP": 34.4,
-    "EVEN": 15.4,
-    "DOWN": 33.7,
-    "ANCHOR": 6.3
+    "STRETCH": 9.2,
+    "UP": 35.4,
+    "EVEN": 15.9,
+    "DOWN": 34.2,
+    "ANCHOR": 5.3
    },
-   "stretchRate": 10.2,
-   "anchorRate": 6.3,
-   "breadth": 0.888,
+   "stretchRate": 9.2,
+   "anchorRate": 5.3,
+   "breadth": 0.871,
    "competitiveRatio": 29.4,
    "winRate": 51.1
   },
   "inConference": {
    "matches": 214,
    "bands": {
-    "STRETCH": 18,
-    "UP": 69,
+    "STRETCH": 0,
+    "UP": 87,
     "EVEN": 40,
-    "DOWN": 69,
-    "ANCHOR": 18
+    "DOWN": 87,
+    "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 8.4,
-    "UP": 32.2,
+    "STRETCH": 0,
+    "UP": 40.7,
     "EVEN": 18.7,
-    "DOWN": 32.2,
-    "ANCHOR": 8.4
+    "DOWN": 40.7,
+    "ANCHOR": 0
    },
-   "stretchRate": 8.4,
-   "anchorRate": 8.4,
-   "breadth": 0.907,
+   "stretchRate": 0,
+   "anchorRate": 0,
+   "breadth": 0.649,
    "competitiveRatio": 23.4,
    "winRate": 50
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 165,
     "UP": 547,
-    "EVEN": 236,
-    "DOWN": 533,
+    "EVEN": 245,
+    "DOWN": 524,
     "ANCHOR": 94
    },
    "bandPct": {
     "STRETCH": 10.5,
     "UP": 34.7,
-    "EVEN": 15,
-    "DOWN": 33.8,
+    "EVEN": 15.6,
+    "DOWN": 33.3,
     "ANCHOR": 6
    },
    "stretchRate": 10.5,
    "anchorRate": 6,
-   "breadth": 0.884,
+   "breadth": 0.887,
    "competitiveRatio": 30.2,
    "winRate": 51.2
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 8.4,
+  "inConference": 0,
   "nonConference": 10.5,
-  "delta": 2.1,
+  "delta": 10.5,
   "nonConferenceShare": 88
  },
  "members": [
@@ -119,19 +119,19 @@
     "STRETCH": 29,
     "UP": 192,
     "EVEN": 36,
-    "DOWN": 105,
-    "ANCHOR": 36
+    "DOWN": 123,
+    "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 7.3,
     "UP": 48.2,
     "EVEN": 9,
-    "DOWN": 26.4,
-    "ANCHOR": 9
+    "DOWN": 30.9,
+    "ANCHOR": 4.5
    },
    "stretchRate": 7.3,
-   "anchorRate": 9,
-   "breadth": 0.826,
+   "anchorRate": 4.5,
+   "breadth": 0.785,
    "competitiveRatio": 33.9,
    "winRate": 50.3
   },
@@ -197,22 +197,22 @@
    "lineupWTN": 28.38,
    "matches": 268,
    "bands": {
-    "STRETCH": 137,
-    "UP": 104,
+    "STRETCH": 119,
+    "UP": 122,
     "EVEN": 17,
     "DOWN": 10,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 51.1,
-    "UP": 38.8,
+    "STRETCH": 44.4,
+    "UP": 45.5,
     "EVEN": 6.3,
     "DOWN": 3.7,
     "ANCHOR": 0
    },
-   "stretchRate": 51.1,
+   "stretchRate": 44.4,
    "anchorRate": 0,
-   "breadth": 0.626,
+   "breadth": 0.632,
    "competitiveRatio": 37.7,
    "winRate": 50.7
   },
@@ -280,20 +280,20 @@
    "bands": {
     "STRETCH": 9,
     "UP": 18,
-    "EVEN": 11,
-    "DOWN": 60,
+    "EVEN": 20,
+    "DOWN": 51,
     "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 8.7,
     "UP": 17.3,
-    "EVEN": 10.6,
-    "DOWN": 57.7,
+    "EVEN": 19.2,
+    "DOWN": 49,
     "ANCHOR": 5.8
    },
    "stretchRate": 8.7,
    "anchorRate": 5.8,
-   "breadth": 0.767,
+   "breadth": 0.837,
    "competitiveRatio": 25,
    "winRate": 38.5
   }

--- a/public/data/conferences/great-plains-athletic-conference.json
+++ b/public/data/conferences/great-plains-athletic-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 4177,
    "bands": {
-    "STRETCH": 699,
-    "UP": 1195,
+    "STRETCH": 679,
+    "UP": 1215,
     "EVEN": 341,
     "DOWN": 1316,
     "ANCHOR": 626
    },
    "bandPct": {
-    "STRETCH": 16.7,
-    "UP": 28.6,
+    "STRETCH": 16.3,
+    "UP": 29.1,
     "EVEN": 8.2,
     "DOWN": 31.5,
     "ANCHOR": 15
    },
-   "stretchRate": 16.7,
+   "stretchRate": 16.3,
    "anchorRate": 15,
-   "breadth": 0.938,
+   "breadth": 0.937,
    "competitiveRatio": 30.6,
    "winRate": 51.2
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 2359,
    "bands": {
-    "STRETCH": 318,
-    "UP": 710,
+    "STRETCH": 298,
+    "UP": 730,
     "EVEN": 255,
     "DOWN": 831,
     "ANCHOR": 245
    },
    "bandPct": {
-    "STRETCH": 13.5,
-    "UP": 30.1,
+    "STRETCH": 12.6,
+    "UP": 30.9,
     "EVEN": 10.8,
     "DOWN": 35.2,
     "ANCHOR": 10.4
    },
-   "stretchRate": 13.5,
+   "stretchRate": 12.6,
    "anchorRate": 10.4,
-   "breadth": 0.916,
+   "breadth": 0.912,
    "competitiveRatio": 31.5,
    "winRate": 52.1
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 21,
-  "nonConference": 13.5,
-  "delta": -7.5,
+  "nonConference": 12.6,
+  "delta": -8.4,
   "nonConferenceShare": 56.5
  },
  "members": [
@@ -386,22 +386,22 @@
    "lineupWTN": 28.42,
    "matches": 222,
    "bands": {
-    "STRETCH": 163,
-    "UP": 45,
+    "STRETCH": 143,
+    "UP": 65,
     "EVEN": 10,
     "DOWN": 4,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 73.4,
-    "UP": 20.3,
+    "STRETCH": 64.4,
+    "UP": 29.3,
     "EVEN": 4.5,
     "DOWN": 1.8,
     "ANCHOR": 0
    },
-   "stretchRate": 73.4,
+   "stretchRate": 64.4,
    "anchorRate": 0,
-   "breadth": 0.474,
+   "breadth": 0.531,
    "competitiveRatio": 33.3,
    "winRate": 47.3
   },

--- a/public/data/conferences/gulf-south-conference.json
+++ b/public/data/conferences/gulf-south-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/heart-of-america-athletic-conference.json
+++ b/public/data/conferences/heart-of-america-athletic-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 315,
     "UP": 978,
-    "EVEN": 499,
-    "DOWN": 945,
+    "EVEN": 526,
+    "DOWN": 918,
     "ANCHOR": 440
    },
    "bandPct": {
     "STRETCH": 9.9,
     "UP": 30.8,
-    "EVEN": 15.7,
-    "DOWN": 29.7,
+    "EVEN": 16.6,
+    "DOWN": 28.9,
     "ANCHOR": 13.8
    },
    "stretchRate": 9.9,
    "anchorRate": 13.8,
-   "breadth": 0.943,
+   "breadth": 0.946,
    "competitiveRatio": 36,
    "winRate": 48
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 231,
     "UP": 772,
-    "EVEN": 401,
-    "DOWN": 739,
+    "EVEN": 428,
+    "DOWN": 712,
     "ANCHOR": 356
    },
    "bandPct": {
     "STRETCH": 9.2,
     "UP": 30.9,
-    "EVEN": 16,
-    "DOWN": 29.6,
+    "EVEN": 17.1,
+    "DOWN": 28.5,
     "ANCHOR": 14.2
    },
    "stretchRate": 9.2,
    "anchorRate": 14.2,
-   "breadth": 0.941,
+   "breadth": 0.945,
    "competitiveRatio": 36.6,
    "winRate": 47.4
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -118,20 +118,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 72,
-    "EVEN": 84,
-    "DOWN": 142,
+    "EVEN": 88,
+    "DOWN": 138,
     "ANCHOR": 96
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 18,
-    "EVEN": 21,
-    "DOWN": 35.5,
+    "EVEN": 22,
+    "DOWN": 34.5,
     "ANCHOR": 24
    },
    "stretchRate": 1.5,
    "anchorRate": 24,
-   "breadth": 0.876,
+   "breadth": 0.879,
    "competitiveRatio": 44.5,
    "winRate": 63
   },
@@ -145,20 +145,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 96,
-    "EVEN": 6,
-    "DOWN": 156,
+    "EVEN": 29,
+    "DOWN": 133,
     "ANCHOR": 125
    },
    "bandPct": {
     "STRETCH": 1.5,
     "UP": 24.7,
-    "EVEN": 1.5,
-    "DOWN": 40.1,
+    "EVEN": 7.5,
+    "DOWN": 34.2,
     "ANCHOR": 32.1
    },
    "stretchRate": 1.5,
    "anchorRate": 32.1,
-   "breadth": 0.749,
+   "breadth": 0.829,
    "competitiveRatio": 46.3,
    "winRate": 63.8
   },

--- a/public/data/conferences/heartland-collegiate-athletic-conference.json
+++ b/public/data/conferences/heartland-collegiate-athletic-conference.json
@@ -15,44 +15,44 @@
   "overall": {
    "matches": 4464,
    "bands": {
-    "STRETCH": 553,
-    "UP": 1558,
+    "STRETCH": 537,
+    "UP": 1574,
     "EVEN": 772,
-    "DOWN": 1152,
-    "ANCHOR": 429
+    "DOWN": 1168,
+    "ANCHOR": 413
    },
    "bandPct": {
-    "STRETCH": 12.4,
-    "UP": 34.9,
+    "STRETCH": 12,
+    "UP": 35.3,
     "EVEN": 17.3,
-    "DOWN": 25.8,
-    "ANCHOR": 9.6
+    "DOWN": 26.2,
+    "ANCHOR": 9.3
    },
-   "stretchRate": 12.4,
-   "anchorRate": 9.6,
-   "breadth": 0.935,
+   "stretchRate": 12,
+   "anchorRate": 9.3,
+   "breadth": 0.93,
    "competitiveRatio": 29.5,
    "winRate": 42.4
   },
   "inConference": {
    "matches": 1786,
    "bands": {
-    "STRETCH": 203,
-    "UP": 491,
+    "STRETCH": 187,
+    "UP": 507,
     "EVEN": 398,
-    "DOWN": 491,
-    "ANCHOR": 203
+    "DOWN": 507,
+    "ANCHOR": 187
    },
    "bandPct": {
-    "STRETCH": 11.4,
-    "UP": 27.5,
+    "STRETCH": 10.5,
+    "UP": 28.4,
     "EVEN": 22.3,
-    "DOWN": 27.5,
-    "ANCHOR": 11.4
+    "DOWN": 28.4,
+    "ANCHOR": 10.5
    },
-   "stretchRate": 11.4,
-   "anchorRate": 11.4,
-   "breadth": 0.956,
+   "stretchRate": 10.5,
+   "anchorRate": 10.5,
+   "breadth": 0.946,
    "competitiveRatio": 29.7,
    "winRate": 50
   },
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 11.4,
+  "inConference": 10.5,
   "nonConference": 13.1,
-  "delta": 1.7,
+  "delta": 2.6,
   "nonConferenceShare": 60
  },
  "members": [
@@ -281,19 +281,19 @@
     "STRETCH": 25,
     "UP": 111,
     "EVEN": 107,
-    "DOWN": 60,
-    "ANCHOR": 33
+    "DOWN": 76,
+    "ANCHOR": 17
    },
    "bandPct": {
     "STRETCH": 7.4,
     "UP": 33,
     "EVEN": 31.8,
-    "DOWN": 17.9,
-    "ANCHOR": 9.8
+    "DOWN": 22.6,
+    "ANCHOR": 5.1
    },
    "stretchRate": 7.4,
-   "anchorRate": 9.8,
-   "breadth": 0.907,
+   "anchorRate": 5.1,
+   "breadth": 0.877,
    "competitiveRatio": 31.5,
    "winRate": 44.3
   },
@@ -440,22 +440,22 @@
    "lineupWTN": 32.63,
    "matches": 224,
    "bands": {
-    "STRETCH": 121,
-    "UP": 95,
+    "STRETCH": 105,
+    "UP": 111,
     "EVEN": 0,
     "DOWN": 8,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 54,
-    "UP": 42.4,
+    "STRETCH": 46.9,
+    "UP": 49.6,
     "EVEN": 0,
     "DOWN": 3.6,
     "ANCHOR": 0
    },
-   "stretchRate": 54,
+   "stretchRate": 46.9,
    "anchorRate": 0,
-   "breadth": 0.507,
+   "breadth": 0.511,
    "competitiveRatio": 9,
    "winRate": 6.3
   },

--- a/public/data/conferences/horizon-league-conference.json
+++ b/public/data/conferences/horizon-league-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/horizon-league.json
+++ b/public/data/conferences/horizon-league.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 628,
     "UP": 1324,
-    "EVEN": 556,
-    "DOWN": 939,
+    "EVEN": 562,
+    "DOWN": 933,
     "ANCHOR": 276
    },
    "bandPct": {
     "STRETCH": 16.9,
     "UP": 35.6,
-    "EVEN": 14.9,
-    "DOWN": 25.2,
+    "EVEN": 15.1,
+    "DOWN": 25.1,
     "ANCHOR": 7.4
    },
    "stretchRate": 16.9,
    "anchorRate": 7.4,
-   "breadth": 0.927,
+   "breadth": 0.928,
    "competitiveRatio": 47.6,
    "winRate": 45.4
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 499,
     "UP": 1057,
-    "EVEN": 412,
-    "DOWN": 672,
+    "EVEN": 418,
+    "DOWN": 666,
     "ANCHOR": 147
    },
    "bandPct": {
     "STRETCH": 17.9,
     "UP": 37.9,
-    "EVEN": 14.8,
-    "DOWN": 24.1,
+    "EVEN": 15,
+    "DOWN": 23.9,
     "ANCHOR": 5.3
    },
    "stretchRate": 17.9,
    "anchorRate": 5.3,
-   "breadth": 0.905,
+   "breadth": 0.906,
    "competitiveRatio": 46.6,
    "winRate": 43.9
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -171,20 +171,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 145,
-    "EVEN": 85,
-    "DOWN": 138,
+    "EVEN": 91,
+    "DOWN": 132,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 38.8,
-    "EVEN": 22.7,
-    "DOWN": 36.9,
+    "EVEN": 24.3,
+    "DOWN": 35.3,
     "ANCHOR": 0
    },
    "stretchRate": 1.6,
    "anchorRate": 0,
-   "breadth": 0.707,
+   "breadth": 0.712,
    "competitiveRatio": 47.3,
    "winRate": 50.5
   },

--- a/public/data/conferences/illinois-skyway-colleg-conf.json
+++ b/public/data/conferences/illinois-skyway-colleg-conf.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/independent.json
+++ b/public/data/conferences/independent.json
@@ -17,22 +17,22 @@
   "overall": {
    "matches": 3195,
    "bands": {
-    "STRETCH": 592,
-    "UP": 1317,
+    "STRETCH": 586,
+    "UP": 1323,
     "EVEN": 459,
     "DOWN": 616,
     "ANCHOR": 211
    },
    "bandPct": {
-    "STRETCH": 18.5,
-    "UP": 41.2,
+    "STRETCH": 18.3,
+    "UP": 41.4,
     "EVEN": 14.4,
     "DOWN": 19.3,
     "ANCHOR": 6.6
    },
-   "stretchRate": 18.5,
+   "stretchRate": 18.3,
    "anchorRate": 6.6,
-   "breadth": 0.903,
+   "breadth": 0.902,
    "competitiveRatio": 25,
    "winRate": 40.4
   },
@@ -61,22 +61,22 @@
   "nonConference": {
    "matches": 3131,
    "bands": {
-    "STRETCH": 592,
-    "UP": 1285,
+    "STRETCH": 586,
+    "UP": 1291,
     "EVEN": 459,
     "DOWN": 584,
     "ANCHOR": 211
    },
    "bandPct": {
-    "STRETCH": 18.9,
-    "UP": 41,
+    "STRETCH": 18.7,
+    "UP": 41.2,
     "EVEN": 14.7,
     "DOWN": 18.7,
     "ANCHOR": 6.7
    },
-   "stretchRate": 18.9,
+   "stretchRate": 18.7,
    "anchorRate": 6.7,
-   "breadth": 0.905,
+   "breadth": 0.904,
    "competitiveRatio": 25.1,
    "winRate": 40.2
   }
@@ -84,29 +84,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 0,
-  "nonConference": 18.9,
-  "delta": 18.9,
+  "nonConference": 18.7,
+  "delta": 18.7,
   "nonConferenceShare": 98
  },
  "members": [
@@ -253,22 +253,22 @@
    "lineupWTN": 29.34,
    "matches": 235,
    "bands": {
-    "STRETCH": 128,
-    "UP": 66,
+    "STRETCH": 122,
+    "UP": 72,
     "EVEN": 41,
     "DOWN": 0,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 54.5,
-    "UP": 28.1,
+    "STRETCH": 51.9,
+    "UP": 30.6,
     "EVEN": 17.4,
     "DOWN": 0,
     "ANCHOR": 0
    },
-   "stretchRate": 54.5,
+   "stretchRate": 51.9,
    "anchorRate": 0,
-   "breadth": 0.616,
+   "breadth": 0.626,
    "competitiveRatio": 18.7,
    "winRate": 24.7
   },

--- a/public/data/conferences/index.json
+++ b/public/data/conferences/index.json
@@ -1,47 +1,46 @@
 {
  "generatedFor": "courthive-public conference pages",
- "policy": "absolute",
+ "policy": "default",
  "deltaBands": [
   {
    "key": "ANCHOR",
-   "max": -4
+   "maxPct": -10.3
   },
   {
    "key": "DOWN",
-   "max": -0.5
+   "maxPct": -1.3
   },
   {
    "key": "EVEN",
-   "max": 0.5
+   "maxPct": 1.3
   },
   {
    "key": "UP",
-   "max": 4
+   "maxPct": 10.3
   },
   {
    "key": "STRETCH"
   }
  ],
- "threshold": 4,
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -54,9 +53,9 @@
    ],
    "programCount": 31,
    "matches": 12461,
-   "stretchRate": 0.7,
-   "anchorRate": 16.1,
-   "breadth": 0.837,
+   "stretchRate": 0.6,
+   "anchorRate": 15.8,
+   "breadth": 0.831,
    "competitiveRatio": 45.4,
    "nonConferenceShare": 42.4
   },
@@ -70,7 +69,7 @@
    "matches": 12327,
    "stretchRate": 1.9,
    "anchorRate": 15,
-   "breadth": 0.867,
+   "breadth": 0.868,
    "competitiveRatio": 44.1,
    "nonConferenceShare": 47.7
   },
@@ -82,9 +81,9 @@
    ],
    "programCount": 31,
    "matches": 11038,
-   "stretchRate": 1.3,
+   "stretchRate": 1.2,
    "anchorRate": 10.1,
-   "breadth": 0.827,
+   "breadth": 0.826,
    "competitiveRatio": 46.1,
    "nonConferenceShare": 51.4
   },
@@ -99,7 +98,7 @@
    "matches": 9367,
    "stretchRate": 9.3,
    "anchorRate": 9.4,
-   "breadth": 0.903,
+   "breadth": 0.906,
    "competitiveRatio": 40.3,
    "nonConferenceShare": 49.1
   },
@@ -112,8 +111,8 @@
    "programCount": 25,
    "matches": 8663,
    "stretchRate": 2,
-   "anchorRate": 12.8,
-   "breadth": 0.842,
+   "anchorRate": 12.6,
+   "breadth": 0.841,
    "competitiveRatio": 44.8,
    "nonConferenceShare": 56.4
   },
@@ -126,8 +125,8 @@
    "programCount": 24,
    "matches": 8033,
    "stretchRate": 3.5,
-   "anchorRate": 7.2,
-   "breadth": 0.839,
+   "anchorRate": 7.1,
+   "breadth": 0.841,
    "competitiveRatio": 47.5,
    "nonConferenceShare": 71.9
   },
@@ -154,9 +153,9 @@
    ],
    "programCount": 21,
    "matches": 7458,
-   "stretchRate": 8.9,
-   "anchorRate": 15.8,
-   "breadth": 0.922,
+   "stretchRate": 8.6,
+   "anchorRate": 15.6,
+   "breadth": 0.918,
    "competitiveRatio": 34.5,
    "nonConferenceShare": 54
   },
@@ -170,7 +169,7 @@
    "matches": 7321,
    "stretchRate": 9.4,
    "anchorRate": 14.1,
-   "breadth": 0.916,
+   "breadth": 0.918,
    "competitiveRatio": 42.4,
    "nonConferenceShare": 41.4
   },
@@ -183,7 +182,7 @@
    ],
    "programCount": 24,
    "matches": 7247,
-   "stretchRate": 11.2,
+   "stretchRate": 11.1,
    "anchorRate": 11.5,
    "breadth": 0.923,
    "competitiveRatio": 39.3,
@@ -197,9 +196,9 @@
    ],
    "programCount": 23,
    "matches": 7223,
-   "stretchRate": 5.8,
-   "anchorRate": 5.5,
-   "breadth": 0.841,
+   "stretchRate": 5.5,
+   "anchorRate": 5.4,
+   "breadth": 0.837,
    "competitiveRatio": 43.4,
    "nonConferenceShare": 72.4
   },
@@ -213,7 +212,7 @@
    "matches": 6856,
    "stretchRate": 5.3,
    "anchorRate": 5.8,
-   "breadth": 0.847,
+   "breadth": 0.848,
    "competitiveRatio": 44.1,
    "nonConferenceShare": 61.5
   },
@@ -283,8 +282,8 @@
    "programCount": 20,
    "matches": 6540,
    "stretchRate": 1.6,
-   "anchorRate": 4.5,
-   "breadth": 0.776,
+   "anchorRate": 4.4,
+   "breadth": 0.775,
    "competitiveRatio": 46.7,
    "nonConferenceShare": 59.6
   },
@@ -310,9 +309,9 @@
    ],
    "programCount": 19,
    "matches": 6402,
-   "stretchRate": 9.6,
-   "anchorRate": 12.9,
-   "breadth": 0.917,
+   "stretchRate": 9.5,
+   "anchorRate": 12.7,
+   "breadth": 0.915,
    "competitiveRatio": 34.7,
    "nonConferenceShare": 56.7
   },
@@ -324,9 +323,9 @@
    ],
    "programCount": 18,
    "matches": 6349,
-   "stretchRate": 8.3,
-   "anchorRate": 4.7,
-   "breadth": 0.864,
+   "stretchRate": 8.1,
+   "anchorRate": 4.6,
+   "breadth": 0.862,
    "competitiveRatio": 46.6,
    "nonConferenceShare": 66.4
   },
@@ -366,9 +365,9 @@
    ],
    "programCount": 18,
    "matches": 6223,
-   "stretchRate": 7.7,
-   "anchorRate": 6.7,
-   "breadth": 0.852,
+   "stretchRate": 7.5,
+   "anchorRate": 6.5,
+   "breadth": 0.846,
    "competitiveRatio": 42.5,
    "nonConferenceShare": 67.2
   },
@@ -380,9 +379,9 @@
    ],
    "programCount": 21,
    "matches": 6218,
-   "stretchRate": 10.8,
-   "anchorRate": 8.3,
-   "breadth": 0.905,
+   "stretchRate": 10.7,
+   "anchorRate": 8.2,
+   "breadth": 0.903,
    "competitiveRatio": 43,
    "nonConferenceShare": 53.9
   },
@@ -410,7 +409,7 @@
    "matches": 5976,
    "stretchRate": 8.2,
    "anchorRate": 4.4,
-   "breadth": 0.866,
+   "breadth": 0.865,
    "competitiveRatio": 46.8,
    "nonConferenceShare": 61.2
   },
@@ -423,8 +422,8 @@
    "programCount": 20,
    "matches": 5876,
    "stretchRate": 12.8,
-   "anchorRate": 16.1,
-   "breadth": 0.947,
+   "anchorRate": 16,
+   "breadth": 0.946,
    "competitiveRatio": 31.8,
    "nonConferenceShare": 47.2
   },
@@ -452,7 +451,7 @@
    "matches": 5841,
    "stretchRate": 7.7,
    "anchorRate": 12.5,
-   "breadth": 0.908,
+   "breadth": 0.913,
    "competitiveRatio": 42.3,
    "nonConferenceShare": 58.7
   },
@@ -465,8 +464,8 @@
    "programCount": 20,
    "matches": 5829,
    "stretchRate": 6.1,
-   "anchorRate": 7.4,
-   "breadth": 0.841,
+   "anchorRate": 7.3,
+   "breadth": 0.84,
    "competitiveRatio": 27.9,
    "nonConferenceShare": 43.9
   },
@@ -479,8 +478,8 @@
    "programCount": 20,
    "matches": 5821,
    "stretchRate": 15,
-   "anchorRate": 5.7,
-   "breadth": 0.87,
+   "anchorRate": 5.3,
+   "breadth": 0.868,
    "competitiveRatio": 27.9,
    "nonConferenceShare": 70.7
   },
@@ -521,8 +520,8 @@
    "programCount": 16,
    "matches": 5708,
    "stretchRate": 0.5,
-   "anchorRate": 13.6,
-   "breadth": 0.823,
+   "anchorRate": 12.9,
+   "breadth": 0.82,
    "competitiveRatio": 47.5,
    "nonConferenceShare": 61.5
   },
@@ -535,8 +534,8 @@
    "programCount": 16,
    "matches": 5600,
    "stretchRate": 4.1,
-   "anchorRate": 24.8,
-   "breadth": 0.893,
+   "anchorRate": 24.2,
+   "breadth": 0.892,
    "competitiveRatio": 38.7,
    "nonConferenceShare": 78
   },
@@ -550,7 +549,7 @@
    "matches": 5549,
    "stretchRate": 3.6,
    "anchorRate": 9.3,
-   "breadth": 0.868,
+   "breadth": 0.869,
    "competitiveRatio": 43.8,
    "nonConferenceShare": 84.6
   },
@@ -576,9 +575,9 @@
    ],
    "programCount": 17,
    "matches": 5431,
-   "stretchRate": 6.3,
+   "stretchRate": 6.2,
    "anchorRate": 5.9,
-   "breadth": 0.864,
+   "breadth": 0.863,
    "competitiveRatio": 46.5,
    "nonConferenceShare": 67.4
   },
@@ -591,8 +590,8 @@
    "programCount": 17,
    "matches": 5423,
    "stretchRate": 10.1,
-   "anchorRate": 8.8,
-   "breadth": 0.886,
+   "anchorRate": 8.7,
+   "breadth": 0.887,
    "competitiveRatio": 34.5,
    "nonConferenceShare": 56.4
   },
@@ -605,8 +604,8 @@
    "programCount": 17,
    "matches": 5369,
    "stretchRate": 6.8,
-   "anchorRate": 10,
-   "breadth": 0.898,
+   "anchorRate": 9.8,
+   "breadth": 0.896,
    "competitiveRatio": 36,
    "nonConferenceShare": 53.7
   },
@@ -662,7 +661,7 @@
    "matches": 5236,
    "stretchRate": 15.4,
    "anchorRate": 15.5,
-   "breadth": 0.966,
+   "breadth": 0.967,
    "competitiveRatio": 30.8,
    "nonConferenceShare": 53.1
   },
@@ -690,7 +689,7 @@
    "matches": 5105,
    "stretchRate": 16.6,
    "anchorRate": 18.7,
-   "breadth": 0.95,
+   "breadth": 0.955,
    "competitiveRatio": 31.2,
    "nonConferenceShare": 63.8
   },
@@ -718,8 +717,8 @@
    "programCount": 13,
    "matches": 5057,
    "stretchRate": 3.8,
-   "anchorRate": 4,
-   "breadth": 0.81,
+   "anchorRate": 3.8,
+   "breadth": 0.807,
    "competitiveRatio": 51.4,
    "nonConferenceShare": 57.5
   },
@@ -732,8 +731,8 @@
    "programCount": 14,
    "matches": 4974,
    "stretchRate": 11.8,
-   "anchorRate": 12.8,
-   "breadth": 0.925,
+   "anchorRate": 12.6,
+   "breadth": 0.926,
    "competitiveRatio": 28.3,
    "nonConferenceShare": 67.8
   },
@@ -761,8 +760,8 @@
    "programCount": 17,
    "matches": 4827,
    "stretchRate": 8.9,
-   "anchorRate": 7.6,
-   "breadth": 0.876,
+   "anchorRate": 7.5,
+   "breadth": 0.875,
    "competitiveRatio": 23,
    "nonConferenceShare": 46.5
   },
@@ -789,7 +788,7 @@
    ],
    "programCount": 16,
    "matches": 4755,
-   "stretchRate": 15.5,
+   "stretchRate": 15.4,
    "anchorRate": 6.6,
    "breadth": 0.88,
    "competitiveRatio": 27.1,
@@ -873,9 +872,9 @@
    ],
    "programCount": 15,
    "matches": 4464,
-   "stretchRate": 12.4,
-   "anchorRate": 9.6,
-   "breadth": 0.935,
+   "stretchRate": 12,
+   "anchorRate": 9.3,
+   "breadth": 0.93,
    "competitiveRatio": 29.5,
    "nonConferenceShare": 60
   },
@@ -888,8 +887,8 @@
    "programCount": 14,
    "matches": 4418,
    "stretchRate": 16.3,
-   "anchorRate": 9.1,
-   "breadth": 0.93,
+   "anchorRate": 8.6,
+   "breadth": 0.927,
    "competitiveRatio": 26.7,
    "nonConferenceShare": 64.1
   },
@@ -902,7 +901,7 @@
    "programCount": 14,
    "matches": 4364,
    "stretchRate": 15.4,
-   "anchorRate": 12,
+   "anchorRate": 11.9,
    "breadth": 0.927,
    "competitiveRatio": 34.4,
    "nonConferenceShare": 57.4
@@ -915,9 +914,9 @@
    ],
    "programCount": 15,
    "matches": 4331,
-   "stretchRate": 18.8,
-   "anchorRate": 12.8,
-   "breadth": 0.938,
+   "stretchRate": 18.7,
+   "anchorRate": 12.7,
+   "breadth": 0.937,
    "competitiveRatio": 25.7,
    "nonConferenceShare": 58.2
   },
@@ -945,7 +944,7 @@
    "matches": 4213,
    "stretchRate": 18.4,
    "anchorRate": 9.6,
-   "breadth": 0.936,
+   "breadth": 0.937,
    "competitiveRatio": 34.7,
    "nonConferenceShare": 66.9
   },
@@ -957,9 +956,9 @@
    ],
    "programCount": 15,
    "matches": 4177,
-   "stretchRate": 16.7,
+   "stretchRate": 16.3,
    "anchorRate": 15,
-   "breadth": 0.938,
+   "breadth": 0.937,
    "competitiveRatio": 30.6,
    "nonConferenceShare": 56.5
   },
@@ -1043,8 +1042,8 @@
    "programCount": 14,
    "matches": 3932,
    "stretchRate": 6.3,
-   "anchorRate": 11.8,
-   "breadth": 0.88,
+   "anchorRate": 11.5,
+   "breadth": 0.878,
    "competitiveRatio": 39.8,
    "nonConferenceShare": 62.8
   },
@@ -1072,7 +1071,7 @@
    "matches": 3723,
    "stretchRate": 16.9,
    "anchorRate": 7.4,
-   "breadth": 0.927,
+   "breadth": 0.928,
    "competitiveRatio": 47.6,
    "nonConferenceShare": 74.9
   },
@@ -1085,8 +1084,8 @@
    "programCount": 11,
    "matches": 3489,
    "stretchRate": 6.2,
-   "anchorRate": 10.9,
-   "breadth": 0.898,
+   "anchorRate": 10.8,
+   "breadth": 0.897,
    "competitiveRatio": 35.3,
    "nonConferenceShare": 79
   },
@@ -1112,9 +1111,9 @@
    ],
    "programCount": 16,
    "matches": 3470,
-   "stretchRate": 6.2,
+   "stretchRate": 6.1,
    "anchorRate": 3.8,
-   "breadth": 0.796,
+   "breadth": 0.795,
    "competitiveRatio": 25.3,
    "nonConferenceShare": 49
   },
@@ -1128,7 +1127,7 @@
    "matches": 3356,
    "stretchRate": 37,
    "anchorRate": 6.9,
-   "breadth": 0.862,
+   "breadth": 0.863,
    "competitiveRatio": 23.8,
    "nonConferenceShare": 66
   },
@@ -1141,8 +1140,8 @@
    "programCount": 12,
    "matches": 3325,
    "stretchRate": 15.5,
-   "anchorRate": 11,
-   "breadth": 0.896,
+   "anchorRate": 10.8,
+   "breadth": 0.895,
    "competitiveRatio": 28.7,
    "nonConferenceShare": 61.3
   },
@@ -1170,7 +1169,7 @@
    "matches": 3207,
    "stretchRate": 12.5,
    "anchorRate": 6.3,
-   "breadth": 0.892,
+   "breadth": 0.898,
    "competitiveRatio": 33.2,
    "nonConferenceShare": 39.8
   },
@@ -1184,9 +1183,9 @@
    ],
    "programCount": 17,
    "matches": 3195,
-   "stretchRate": 18.5,
+   "stretchRate": 18.3,
    "anchorRate": 6.6,
-   "breadth": 0.903,
+   "breadth": 0.902,
    "competitiveRatio": 25,
    "nonConferenceShare": 98
   },
@@ -1200,7 +1199,7 @@
    "matches": 3177,
    "stretchRate": 9.9,
    "anchorRate": 13.8,
-   "breadth": 0.943,
+   "breadth": 0.946,
    "competitiveRatio": 36,
    "nonConferenceShare": 78.7
   },
@@ -1214,7 +1213,7 @@
    "matches": 3165,
    "stretchRate": 3.4,
    "anchorRate": 6.2,
-   "breadth": 0.813,
+   "breadth": 0.818,
    "competitiveRatio": 46.8,
    "nonConferenceShare": 73.8
   },
@@ -1240,9 +1239,9 @@
    ],
    "programCount": 9,
    "matches": 3134,
-   "stretchRate": 4,
-   "anchorRate": 4.1,
-   "breadth": 0.83,
+   "stretchRate": 3.6,
+   "anchorRate": 3.9,
+   "breadth": 0.821,
    "competitiveRatio": 45.9,
    "nonConferenceShare": 66.1
   },
@@ -1268,9 +1267,9 @@
    ],
    "programCount": 9,
    "matches": 3072,
-   "stretchRate": 5.6,
-   "anchorRate": 9.7,
-   "breadth": 0.859,
+   "stretchRate": 4.6,
+   "anchorRate": 9.3,
+   "breadth": 0.844,
    "competitiveRatio": 40.4,
    "nonConferenceShare": 87.5
   },
@@ -1284,7 +1283,7 @@
    "matches": 3041,
    "stretchRate": 10.2,
    "anchorRate": 8.4,
-   "breadth": 0.917,
+   "breadth": 0.919,
    "competitiveRatio": 24.5,
    "nonConferenceShare": 48.9
   },
@@ -1297,8 +1296,8 @@
    "programCount": 14,
    "matches": 2969,
    "stretchRate": 9.6,
-   "anchorRate": 14.6,
-   "breadth": 0.933,
+   "anchorRate": 14.4,
+   "breadth": 0.932,
    "competitiveRatio": 28.5,
    "nonConferenceShare": 65.2
   },
@@ -1310,9 +1309,9 @@
    ],
    "programCount": 13,
    "matches": 2909,
-   "stretchRate": 21.6,
-   "anchorRate": 10.1,
-   "breadth": 0.942,
+   "stretchRate": 20.8,
+   "anchorRate": 9.5,
+   "breadth": 0.936,
    "competitiveRatio": 27.3,
    "nonConferenceShare": 63
   },
@@ -1352,9 +1351,9 @@
    ],
    "programCount": 10,
    "matches": 2546,
-   "stretchRate": 10.3,
+   "stretchRate": 9.9,
    "anchorRate": 4.1,
-   "breadth": 0.873,
+   "breadth": 0.87,
    "competitiveRatio": 24.7,
    "nonConferenceShare": 64.8
   },
@@ -1381,8 +1380,8 @@
    "programCount": 8,
    "matches": 2376,
    "stretchRate": 11.2,
-   "anchorRate": 16.1,
-   "breadth": 0.912,
+   "anchorRate": 14.7,
+   "breadth": 0.905,
    "competitiveRatio": 35.2,
    "nonConferenceShare": 67.8
   },
@@ -1410,7 +1409,7 @@
    "matches": 2141,
    "stretchRate": 15.8,
    "anchorRate": 13.8,
-   "breadth": 0.936,
+   "breadth": 0.943,
    "competitiveRatio": 15.4,
    "nonConferenceShare": 56.3
   },
@@ -1423,8 +1422,8 @@
    "programCount": 7,
    "matches": 2106,
    "stretchRate": 10.4,
-   "anchorRate": 8.9,
-   "breadth": 0.911,
+   "anchorRate": 8.3,
+   "breadth": 0.906,
    "competitiveRatio": 38.8,
    "nonConferenceShare": 69.9
   },
@@ -1436,9 +1435,9 @@
    ],
    "programCount": 12,
    "matches": 2080,
-   "stretchRate": 21.3,
+   "stretchRate": 20.9,
    "anchorRate": 9.2,
-   "breadth": 0.91,
+   "breadth": 0.909,
    "competitiveRatio": 16.1,
    "nonConferenceShare": 43.6
   },
@@ -1506,9 +1505,9 @@
    ],
    "programCount": 7,
    "matches": 1789,
-   "stretchRate": 10.2,
-   "anchorRate": 6.3,
-   "breadth": 0.888,
+   "stretchRate": 9.2,
+   "anchorRate": 5.3,
+   "breadth": 0.871,
    "competitiveRatio": 29.4,
    "nonConferenceShare": 88
   },
@@ -1521,8 +1520,8 @@
    "programCount": 10,
    "matches": 1721,
    "stretchRate": 18.4,
-   "anchorRate": 9.8,
-   "breadth": 0.894,
+   "anchorRate": 9.5,
+   "breadth": 0.891,
    "competitiveRatio": 30.5,
    "nonConferenceShare": 72.9
   },
@@ -1590,9 +1589,9 @@
    ],
    "programCount": 7,
    "matches": 1325,
-   "stretchRate": 31.5,
-   "anchorRate": 4.4,
-   "breadth": 0.867,
+   "stretchRate": 28.8,
+   "anchorRate": 1.7,
+   "breadth": 0.827,
    "competitiveRatio": 21.1,
    "nonConferenceShare": 74.6
   },
@@ -1648,7 +1647,7 @@
    "matches": 1077,
    "stretchRate": 8.6,
    "anchorRate": 11,
-   "breadth": 0.858,
+   "breadth": 0.861,
    "competitiveRatio": 40.1,
    "nonConferenceShare": 81.4
   },

--- a/public/data/conferences/inland-empire-athletic-conference.json
+++ b/public/data/conferences/inland-empire-athletic-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/ivy-league.json
+++ b/public/data/conferences/ivy-league.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 31,
     "UP": 1374,
-    "EVEN": 1108,
-    "DOWN": 2419,
-    "ANCHOR": 776
+    "EVEN": 1128,
+    "DOWN": 2439,
+    "ANCHOR": 736
    },
    "bandPct": {
     "STRETCH": 0.5,
     "UP": 24.1,
-    "EVEN": 19.4,
-    "DOWN": 42.4,
-    "ANCHOR": 13.6
+    "EVEN": 19.8,
+    "DOWN": 42.7,
+    "ANCHOR": 12.9
    },
    "stretchRate": 0.5,
-   "anchorRate": 13.6,
-   "breadth": 0.823,
+   "anchorRate": 12.9,
+   "breadth": 0.82,
    "competitiveRatio": 47.5,
    "winRate": 59.8
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 12,
     "UP": 635,
-    "EVEN": 428,
-    "DOWN": 1680,
-    "ANCHOR": 757
+    "EVEN": 448,
+    "DOWN": 1700,
+    "ANCHOR": 717
    },
    "bandPct": {
     "STRETCH": 0.3,
     "UP": 18.1,
-    "EVEN": 12.2,
-    "DOWN": 47.8,
-    "ANCHOR": 21.6
+    "EVEN": 12.8,
+    "DOWN": 48.4,
+    "ANCHOR": 20.4
    },
    "stretchRate": 0.3,
-   "anchorRate": 21.6,
-   "breadth": 0.788,
+   "anchorRate": 20.4,
+   "breadth": 0.787,
    "competitiveRatio": 46.3,
    "winRate": 66
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -145,19 +145,19 @@
     "STRETCH": 31,
     "UP": 161,
     "EVEN": 18,
-    "DOWN": 143,
-    "ANCHOR": 82
+    "DOWN": 160,
+    "ANCHOR": 65
    },
    "bandPct": {
     "STRETCH": 7.1,
     "UP": 37,
     "EVEN": 4.1,
-    "DOWN": 32.9,
-    "ANCHOR": 18.9
+    "DOWN": 36.8,
+    "ANCHOR": 14.9
    },
    "stretchRate": 7.1,
-   "anchorRate": 18.9,
-   "breadth": 0.85,
+   "anchorRate": 14.9,
+   "breadth": 0.832,
    "competitiveRatio": 50.3,
    "winRate": 49
   },
@@ -225,20 +225,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 135,
-    "EVEN": 40,
-    "DOWN": 105,
+    "EVEN": 45,
+    "DOWN": 100,
     "ANCHOR": 97
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 35.8,
-    "EVEN": 10.6,
-    "DOWN": 27.9,
+    "EVEN": 11.9,
+    "DOWN": 26.5,
     "ANCHOR": 25.7
    },
    "stretchRate": 0,
    "anchorRate": 25.7,
-   "breadth": 0.815,
+   "breadth": 0.822,
    "competitiveRatio": 47.5,
    "winRate": 55.2
   },
@@ -333,20 +333,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 64,
-    "EVEN": 80,
-    "DOWN": 174,
+    "EVEN": 89,
+    "DOWN": 165,
     "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 18.2,
-    "EVEN": 22.8,
-    "DOWN": 49.6,
+    "EVEN": 25.4,
+    "DOWN": 47,
     "ANCHOR": 9.4
    },
    "stretchRate": 0,
    "anchorRate": 9.4,
-   "breadth": 0.756,
+   "breadth": 0.768,
    "competitiveRatio": 53.3,
    "winRate": 65.2
   },
@@ -361,19 +361,19 @@
     "STRETCH": 0,
     "UP": 117,
     "EVEN": 64,
-    "DOWN": 118,
-    "ANCHOR": 42
+    "DOWN": 123,
+    "ANCHOR": 37
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 34.3,
     "EVEN": 18.8,
-    "DOWN": 34.6,
-    "ANCHOR": 12.3
+    "DOWN": 36.1,
+    "ANCHOR": 10.9
    },
    "stretchRate": 0,
-   "anchorRate": 12.3,
-   "breadth": 0.812,
+   "anchorRate": 10.9,
+   "breadth": 0.801,
    "competitiveRatio": 39.4,
    "winRate": 60.7
   },
@@ -414,20 +414,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 12,
-    "EVEN": 91,
-    "DOWN": 181,
+    "EVEN": 97,
+    "DOWN": 175,
     "ANCHOR": 36
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 3.8,
-    "EVEN": 28.4,
-    "DOWN": 56.6,
+    "EVEN": 30.3,
+    "DOWN": 54.7,
     "ANCHOR": 11.3
    },
    "stretchRate": 0,
    "anchorRate": 11.3,
-   "breadth": 0.652,
+   "breadth": 0.659,
    "competitiveRatio": 38.4,
    "winRate": 61.6
   },
@@ -469,19 +469,19 @@
     "STRETCH": 0,
     "UP": 162,
     "EVEN": 24,
-    "DOWN": 80,
-    "ANCHOR": 48
+    "DOWN": 98,
+    "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 51.6,
     "EVEN": 7.6,
-    "DOWN": 25.5,
-    "ANCHOR": 15.3
+    "DOWN": 31.2,
+    "ANCHOR": 9.6
    },
    "stretchRate": 0,
-   "anchorRate": 15.3,
-   "breadth": 0.729,
+   "anchorRate": 9.6,
+   "breadth": 0.699,
    "competitiveRatio": 44.9,
    "winRate": 52.9
   },

--- a/public/data/conferences/kansas-collegiate-athletic-conference.json
+++ b/public/data/conferences/kansas-collegiate-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/kansas-jayhawk-community-college-conference.json
+++ b/public/data/conferences/kansas-jayhawk-community-college-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/landmark-conference.json
+++ b/public/data/conferences/landmark-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 355,
     "UP": 2188,
     "EVEN": 697,
-    "DOWN": 2157,
-    "ANCHOR": 432
+    "DOWN": 2163,
+    "ANCHOR": 426
    },
    "bandPct": {
     "STRETCH": 6.1,
     "UP": 37.5,
     "EVEN": 12,
-    "DOWN": 37,
-    "ANCHOR": 7.4
+    "DOWN": 37.1,
+    "ANCHOR": 7.3
    },
    "stretchRate": 6.1,
-   "anchorRate": 7.4,
-   "breadth": 0.841,
+   "anchorRate": 7.3,
+   "breadth": 0.84,
    "competitiveRatio": 27.9,
    "winRate": 49
   },
@@ -62,19 +62,19 @@
     "STRETCH": 164,
     "UP": 956,
     "EVEN": 271,
-    "DOWN": 925,
-    "ANCHOR": 241
+    "DOWN": 931,
+    "ANCHOR": 235
    },
    "bandPct": {
     "STRETCH": 6.4,
     "UP": 37.4,
     "EVEN": 10.6,
-    "DOWN": 36.2,
-    "ANCHOR": 9.4
+    "DOWN": 36.4,
+    "ANCHOR": 9.2
    },
    "stretchRate": 6.4,
-   "anchorRate": 9.4,
-   "breadth": 0.853,
+   "anchorRate": 9.2,
+   "breadth": 0.851,
    "competitiveRatio": 29.1,
    "winRate": 47.8
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -470,19 +470,19 @@
     "STRETCH": 0,
     "UP": 81,
     "EVEN": 24,
-    "DOWN": 119,
-    "ANCHOR": 36
+    "DOWN": 125,
+    "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 31.2,
     "EVEN": 9.2,
-    "DOWN": 45.8,
-    "ANCHOR": 13.8
+    "DOWN": 48.1,
+    "ANCHOR": 11.5
    },
    "stretchRate": 0,
-   "anchorRate": 13.8,
-   "breadth": 0.755,
+   "anchorRate": 11.5,
+   "breadth": 0.736,
    "competitiveRatio": 27.3,
    "winRate": 55
   },

--- a/public/data/conferences/liberty-league.json
+++ b/public/data/conferences/liberty-league.json
@@ -18,19 +18,19 @@
     "STRETCH": 367,
     "UP": 1715,
     "EVEN": 900,
-    "DOWN": 1848,
-    "ANCHOR": 539
+    "DOWN": 1861,
+    "ANCHOR": 526
    },
    "bandPct": {
     "STRETCH": 6.8,
     "UP": 31.9,
     "EVEN": 16.8,
-    "DOWN": 34.4,
-    "ANCHOR": 10
+    "DOWN": 34.7,
+    "ANCHOR": 9.8
    },
    "stretchRate": 6.8,
-   "anchorRate": 10,
-   "breadth": 0.898,
+   "anchorRate": 9.8,
+   "breadth": 0.896,
    "competitiveRatio": 36,
    "winRate": 51.3
   },
@@ -62,19 +62,19 @@
     "STRETCH": 151,
     "UP": 948,
     "EVEN": 382,
-    "DOWN": 1081,
-    "ANCHOR": 323
+    "DOWN": 1094,
+    "ANCHOR": 310
    },
    "bandPct": {
     "STRETCH": 5.2,
     "UP": 32.9,
     "EVEN": 13.2,
-    "DOWN": 37.5,
-    "ANCHOR": 11.2
+    "DOWN": 37.9,
+    "ANCHOR": 10.7
    },
    "stretchRate": 5.2,
-   "anchorRate": 11.2,
-   "breadth": 0.87,
+   "anchorRate": 10.7,
+   "breadth": 0.867,
    "competitiveRatio": 37.9,
    "winRate": 52.4
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -308,19 +308,19 @@
     "STRETCH": 0,
     "UP": 100,
     "EVEN": 83,
-    "DOWN": 119,
-    "ANCHOR": 19
+    "DOWN": 121,
+    "ANCHOR": 17
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 31.2,
     "EVEN": 25.9,
-    "DOWN": 37.1,
-    "ANCHOR": 5.9
+    "DOWN": 37.7,
+    "ANCHOR": 5.3
    },
    "stretchRate": 0,
-   "anchorRate": 5.9,
-   "breadth": 0.776,
+   "anchorRate": 5.3,
+   "breadth": 0.768,
    "competitiveRatio": 30.6,
    "winRate": 53
   },
@@ -497,19 +497,19 @@
     "STRETCH": 16,
     "UP": 132,
     "EVEN": 60,
-    "DOWN": 77,
-    "ANCHOR": 11
+    "DOWN": 88,
+    "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 5.4,
     "UP": 44.6,
     "EVEN": 20.3,
-    "DOWN": 26,
-    "ANCHOR": 3.7
+    "DOWN": 29.7,
+    "ANCHOR": 0
    },
    "stretchRate": 5.4,
-   "anchorRate": 3.7,
-   "breadth": 0.816,
+   "anchorRate": 0,
+   "breadth": 0.747,
    "competitiveRatio": 22.7,
    "winRate": 36.5
   },

--- a/public/data/conferences/little-east-conference.json
+++ b/public/data/conferences/little-east-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/lone-star-conference.json
+++ b/public/data/conferences/lone-star-conference.json
@@ -83,22 +83,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/metro-atlantic-athletic-conference.json
+++ b/public/data/conferences/metro-atlantic-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/michigan-intercollegiate-athletic-association.json
+++ b/public/data/conferences/michigan-intercollegiate-athletic-association.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/mid-america-intercollegiate-athletics-association.json
+++ b/public/data/conferences/mid-america-intercollegiate-athletics-association.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/mid-american-conference.json
+++ b/public/data/conferences/mid-american-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 191,
     "UP": 1442,
     "EVEN": 1072,
-    "DOWN": 2149,
-    "ANCHOR": 203
+    "DOWN": 2158,
+    "ANCHOR": 194
    },
    "bandPct": {
     "STRETCH": 3.8,
     "UP": 28.5,
     "EVEN": 21.2,
-    "DOWN": 42.5,
-    "ANCHOR": 4
+    "DOWN": 42.7,
+    "ANCHOR": 3.8
    },
    "stretchRate": 3.8,
-   "anchorRate": 4,
-   "breadth": 0.81,
+   "anchorRate": 3.8,
+   "breadth": 0.807,
    "competitiveRatio": 51.4,
    "winRate": 53.3
   },
@@ -62,19 +62,19 @@
     "STRETCH": 191,
     "UP": 721,
     "EVEN": 364,
-    "DOWN": 1428,
-    "ANCHOR": 203
+    "DOWN": 1437,
+    "ANCHOR": 194
    },
    "bandPct": {
     "STRETCH": 6.6,
     "UP": 24.8,
     "EVEN": 12.5,
-    "DOWN": 49.1,
-    "ANCHOR": 7
+    "DOWN": 49.4,
+    "ANCHOR": 6.7
    },
    "stretchRate": 6.6,
-   "anchorRate": 7,
-   "breadth": 0.82,
+   "anchorRate": 6.7,
+   "breadth": 0.816,
    "competitiveRatio": 46.3,
    "winRate": 55.8
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -227,19 +227,19 @@
     "STRETCH": 18,
     "UP": 51,
     "EVEN": 103,
-    "DOWN": 149,
-    "ANCHOR": 71
+    "DOWN": 158,
+    "ANCHOR": 62
    },
    "bandPct": {
     "STRETCH": 4.6,
     "UP": 13,
     "EVEN": 26.3,
-    "DOWN": 38,
-    "ANCHOR": 18.1
+    "DOWN": 40.3,
+    "ANCHOR": 15.8
    },
    "stretchRate": 4.6,
-   "anchorRate": 18.1,
-   "breadth": 0.892,
+   "anchorRate": 15.8,
+   "breadth": 0.88,
    "competitiveRatio": 49.7,
    "winRate": 53.6
   },

--- a/public/data/conferences/mid-eastern-athletic-conference.json
+++ b/public/data/conferences/mid-eastern-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/mid-south-conference.json
+++ b/public/data/conferences/mid-south-conference.json
@@ -17,19 +17,19 @@
    "bands": {
     "STRETCH": 674,
     "UP": 1460,
-    "EVEN": 412,
-    "DOWN": 1294,
-    "ANCHOR": 524
+    "EVEN": 417,
+    "DOWN": 1295,
+    "ANCHOR": 518
    },
    "bandPct": {
     "STRETCH": 15.4,
     "UP": 33.5,
-    "EVEN": 9.4,
+    "EVEN": 9.6,
     "DOWN": 29.7,
-    "ANCHOR": 12
+    "ANCHOR": 11.9
    },
    "stretchRate": 15.4,
-   "anchorRate": 12,
+   "anchorRate": 11.9,
    "breadth": 0.927,
    "competitiveRatio": 34.4,
    "winRate": 50.8
@@ -61,19 +61,19 @@
    "bands": {
     "STRETCH": 360,
     "UP": 904,
-    "EVEN": 292,
-    "DOWN": 738,
-    "ANCHOR": 210
+    "EVEN": 297,
+    "DOWN": 739,
+    "ANCHOR": 204
    },
    "bandPct": {
     "STRETCH": 14.4,
     "UP": 36.1,
-    "EVEN": 11.7,
+    "EVEN": 11.9,
     "DOWN": 29.5,
-    "ANCHOR": 8.4
+    "ANCHOR": 8.1
    },
    "stretchRate": 14.4,
-   "anchorRate": 8.4,
+   "anchorRate": 8.1,
    "breadth": 0.91,
    "competitiveRatio": 35.4,
    "winRate": 51.5
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -307,20 +307,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 11,
-    "EVEN": 19,
-    "DOWN": 182,
+    "EVEN": 24,
+    "DOWN": 177,
     "ANCHOR": 82
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 3.7,
-    "EVEN": 6.5,
-    "DOWN": 61.9,
+    "EVEN": 8.2,
+    "DOWN": 60.2,
     "ANCHOR": 27.9
    },
    "stretchRate": 0,
    "anchorRate": 27.9,
-   "breadth": 0.592,
+   "breadth": 0.615,
    "competitiveRatio": 26.9,
    "winRate": 81
   },
@@ -335,19 +335,19 @@
     "STRETCH": 0,
     "UP": 155,
     "EVEN": 12,
-    "DOWN": 96,
-    "ANCHOR": 30
+    "DOWN": 102,
+    "ANCHOR": 24
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 52.9,
     "EVEN": 4.1,
-    "DOWN": 32.8,
-    "ANCHOR": 10.2
+    "DOWN": 34.8,
+    "ANCHOR": 8.2
    },
    "stretchRate": 0,
-   "anchorRate": 10.2,
-   "breadth": 0.663,
+   "anchorRate": 8.2,
+   "breadth": 0.646,
    "competitiveRatio": 31.6,
    "winRate": 57.7
   },

--- a/public/data/conferences/middle-atlantic-conference.json
+++ b/public/data/conferences/middle-atlantic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/midwest-conference.json
+++ b/public/data/conferences/midwest-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 585,
     "UP": 1414,
-    "EVEN": 571,
-    "DOWN": 1767,
-    "ANCHOR": 637
+    "EVEN": 589,
+    "DOWN": 1758,
+    "ANCHOR": 628
    },
    "bandPct": {
     "STRETCH": 11.8,
     "UP": 28.4,
-    "EVEN": 11.5,
-    "DOWN": 35.5,
-    "ANCHOR": 12.8
+    "EVEN": 11.8,
+    "DOWN": 35.3,
+    "ANCHOR": 12.6
    },
    "stretchRate": 11.8,
-   "anchorRate": 12.8,
-   "breadth": 0.925,
+   "anchorRate": 12.6,
+   "breadth": 0.926,
    "competitiveRatio": 28.3,
    "winRate": 48.3
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 305,
     "UP": 977,
-    "EVEN": 403,
-    "DOWN": 1330,
-    "ANCHOR": 357
+    "EVEN": 421,
+    "DOWN": 1321,
+    "ANCHOR": 348
    },
    "bandPct": {
     "STRETCH": 9,
     "UP": 29,
-    "EVEN": 12,
-    "DOWN": 39.4,
-    "ANCHOR": 10.6
+    "EVEN": 12.5,
+    "DOWN": 39.2,
+    "ANCHOR": 10.3
    },
    "stretchRate": 9,
-   "anchorRate": 10.6,
-   "breadth": 0.892,
+   "anchorRate": 10.3,
+   "breadth": 0.893,
    "competitiveRatio": 31.9,
    "winRate": 47.5
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -388,20 +388,20 @@
    "bands": {
     "STRETCH": 49,
     "UP": 96,
-    "EVEN": 36,
-    "DOWN": 111,
+    "EVEN": 54,
+    "DOWN": 93,
     "ANCHOR": 33
    },
    "bandPct": {
     "STRETCH": 15.1,
     "UP": 29.5,
-    "EVEN": 11.1,
-    "DOWN": 34.2,
+    "EVEN": 16.6,
+    "DOWN": 28.6,
     "ANCHOR": 10.2
    },
    "stretchRate": 15.1,
    "anchorRate": 10.2,
-   "breadth": 0.925,
+   "breadth": 0.953,
    "competitiveRatio": 27.5,
    "winRate": 43.4
   },
@@ -416,19 +416,19 @@
     "STRETCH": 36,
     "UP": 106,
     "EVEN": 36,
-    "DOWN": 82,
-    "ANCHOR": 15
+    "DOWN": 91,
+    "ANCHOR": 6
    },
    "bandPct": {
     "STRETCH": 13.1,
     "UP": 38.5,
     "EVEN": 13.1,
-    "DOWN": 29.8,
-    "ANCHOR": 5.5
+    "DOWN": 33.1,
+    "ANCHOR": 2.2
    },
    "stretchRate": 13.1,
-   "anchorRate": 5.5,
-   "breadth": 0.882,
+   "anchorRate": 2.2,
+   "breadth": 0.838,
    "competitiveRatio": 22.9,
    "winRate": 33.5
   },

--- a/public/data/conferences/minnesota-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/minnesota-intercollegiate-athletic-conference.json
@@ -16,66 +16,66 @@
   "overall": {
    "matches": 7458,
    "bands": {
-    "STRETCH": 661,
-    "UP": 1954,
+    "STRETCH": 638,
+    "UP": 1977,
     "EVEN": 920,
-    "DOWN": 2742,
-    "ANCHOR": 1181
+    "DOWN": 2760,
+    "ANCHOR": 1163
    },
    "bandPct": {
-    "STRETCH": 8.9,
-    "UP": 26.2,
+    "STRETCH": 8.6,
+    "UP": 26.5,
     "EVEN": 12.3,
-    "DOWN": 36.8,
-    "ANCHOR": 15.8
+    "DOWN": 37,
+    "ANCHOR": 15.6
    },
-   "stretchRate": 8.9,
-   "anchorRate": 15.8,
-   "breadth": 0.922,
+   "stretchRate": 8.6,
+   "anchorRate": 15.6,
+   "breadth": 0.918,
    "competitiveRatio": 34.5,
    "winRate": 56.2
   },
   "inConference": {
    "matches": 3434,
    "bands": {
-    "STRETCH": 507,
-    "UP": 957,
+    "STRETCH": 489,
+    "UP": 975,
     "EVEN": 506,
-    "DOWN": 957,
-    "ANCHOR": 507
+    "DOWN": 975,
+    "ANCHOR": 489
    },
    "bandPct": {
-    "STRETCH": 14.8,
-    "UP": 27.9,
+    "STRETCH": 14.2,
+    "UP": 28.4,
     "EVEN": 14.7,
-    "DOWN": 27.9,
-    "ANCHOR": 14.8
+    "DOWN": 28.4,
+    "ANCHOR": 14.2
    },
-   "stretchRate": 14.8,
-   "anchorRate": 14.8,
-   "breadth": 0.969,
+   "stretchRate": 14.2,
+   "anchorRate": 14.2,
+   "breadth": 0.964,
    "competitiveRatio": 32.8,
    "winRate": 50
   },
   "nonConference": {
    "matches": 4024,
    "bands": {
-    "STRETCH": 154,
-    "UP": 997,
+    "STRETCH": 149,
+    "UP": 1002,
     "EVEN": 414,
     "DOWN": 1785,
     "ANCHOR": 674
    },
    "bandPct": {
-    "STRETCH": 3.8,
-    "UP": 24.8,
+    "STRETCH": 3.7,
+    "UP": 24.9,
     "EVEN": 10.3,
     "DOWN": 44.4,
     "ANCHOR": 16.7
    },
-   "stretchRate": 3.8,
+   "stretchRate": 3.7,
    "anchorRate": 16.7,
-   "breadth": 0.848,
+   "breadth": 0.846,
    "competitiveRatio": 36.1,
    "winRate": 61.4
   }
@@ -83,29 +83,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 14.8,
-  "nonConference": 3.8,
-  "delta": -11,
+  "inConference": 14.2,
+  "nonConference": 3.7,
+  "delta": -10.5,
   "nonConferenceShare": 54
  },
  "members": [
@@ -441,22 +441,22 @@
    "lineupWTN": 28.07,
    "matches": 332,
    "bands": {
-    "STRETCH": 65,
-    "UP": 99,
+    "STRETCH": 60,
+    "UP": 104,
     "EVEN": 78,
     "DOWN": 84,
     "ANCHOR": 6
    },
    "bandPct": {
-    "STRETCH": 19.6,
-    "UP": 29.8,
+    "STRETCH": 18.1,
+    "UP": 31.3,
     "EVEN": 23.5,
     "DOWN": 25.3,
     "ANCHOR": 1.8
    },
-   "stretchRate": 19.6,
+   "stretchRate": 18.1,
    "anchorRate": 1.8,
-   "breadth": 0.895,
+   "breadth": 0.891,
    "competitiveRatio": 30.7,
    "winRate": 41.9
   },
@@ -498,19 +498,19 @@
     "STRETCH": 0,
     "UP": 50,
     "EVEN": 47,
-    "DOWN": 122,
-    "ANCHOR": 108
+    "DOWN": 140,
+    "ANCHOR": 90
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.3,
     "EVEN": 14.4,
-    "DOWN": 37.3,
-    "ANCHOR": 33
+    "DOWN": 42.8,
+    "ANCHOR": 27.5
    },
    "stretchRate": 0,
-   "anchorRate": 33,
-   "breadth": 0.808,
+   "anchorRate": 27.5,
+   "breadth": 0.798,
    "competitiveRatio": 23.5,
    "winRate": 82
   },
@@ -549,22 +549,22 @@
    "lineupWTN": 27.97,
    "matches": 305,
    "bands": {
-    "STRETCH": 39,
-    "UP": 78,
+    "STRETCH": 21,
+    "UP": 96,
     "EVEN": 72,
     "DOWN": 100,
     "ANCHOR": 16
    },
    "bandPct": {
-    "STRETCH": 12.8,
-    "UP": 25.6,
+    "STRETCH": 6.9,
+    "UP": 31.5,
     "EVEN": 23.6,
     "DOWN": 32.8,
     "ANCHOR": 5.2
    },
-   "stretchRate": 12.8,
+   "stretchRate": 6.9,
    "anchorRate": 5.2,
-   "breadth": 0.915,
+   "breadth": 0.876,
    "competitiveRatio": 35.6,
    "winRate": 53.4
   },

--- a/public/data/conferences/mississippi-assn-for-comm-juco.json
+++ b/public/data/conferences/mississippi-assn-for-comm-juco.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/missouri-valley-conference.json
+++ b/public/data/conferences/missouri-valley-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 3134,
    "bands": {
-    "STRETCH": 126,
-    "UP": 1167,
+    "STRETCH": 113,
+    "UP": 1180,
     "EVEN": 813,
-    "DOWN": 901,
-    "ANCHOR": 127
+    "DOWN": 907,
+    "ANCHOR": 121
    },
    "bandPct": {
-    "STRETCH": 4,
-    "UP": 37.2,
+    "STRETCH": 3.6,
+    "UP": 37.7,
     "EVEN": 25.9,
-    "DOWN": 28.7,
-    "ANCHOR": 4.1
+    "DOWN": 28.9,
+    "ANCHOR": 3.9
    },
-   "stretchRate": 4,
-   "anchorRate": 4.1,
-   "breadth": 0.83,
+   "stretchRate": 3.6,
+   "anchorRate": 3.9,
+   "breadth": 0.821,
    "competitiveRatio": 45.9,
    "winRate": 47.5
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 2072,
    "bands": {
-    "STRETCH": 109,
-    "UP": 817,
+    "STRETCH": 96,
+    "UP": 830,
     "EVEN": 485,
-    "DOWN": 551,
-    "ANCHOR": 110
+    "DOWN": 557,
+    "ANCHOR": 104
    },
    "bandPct": {
-    "STRETCH": 5.3,
-    "UP": 39.4,
+    "STRETCH": 4.6,
+    "UP": 40.1,
     "EVEN": 23.4,
-    "DOWN": 26.6,
-    "ANCHOR": 5.3
+    "DOWN": 26.9,
+    "ANCHOR": 5
    },
-   "stretchRate": 5.3,
-   "anchorRate": 5.3,
-   "breadth": 0.851,
+   "stretchRate": 4.6,
+   "anchorRate": 5,
+   "breadth": 0.84,
    "competitiveRatio": 45.1,
    "winRate": 46.2
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 1.6,
-  "nonConference": 5.3,
-  "delta": 3.7,
+  "nonConference": 4.6,
+  "delta": 3,
   "nonConferenceShare": 66.1
  },
  "members": [
@@ -281,19 +281,19 @@
     "STRETCH": 0,
     "UP": 153,
     "EVEN": 75,
-    "DOWN": 77,
-    "ANCHOR": 24
+    "DOWN": 83,
+    "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 46.5,
     "EVEN": 22.8,
-    "DOWN": 23.4,
-    "ANCHOR": 7.3
+    "DOWN": 25.2,
+    "ANCHOR": 5.5
    },
    "stretchRate": 0,
-   "anchorRate": 7.3,
-   "breadth": 0.76,
+   "anchorRate": 5.5,
+   "breadth": 0.745,
    "competitiveRatio": 38.8,
    "winRate": 49.8
   },
@@ -332,22 +332,22 @@
    "lineupWTN": 24.14,
    "matches": 322,
    "bands": {
-    "STRETCH": 42,
-    "UP": 274,
+    "STRETCH": 29,
+    "UP": 287,
     "EVEN": 0,
     "DOWN": 6,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 13,
-    "UP": 85.1,
+    "STRETCH": 9,
+    "UP": 89.1,
     "EVEN": 0,
     "DOWN": 1.9,
     "ANCHOR": 0
    },
-   "stretchRate": 13,
+   "stretchRate": 9,
    "anchorRate": 0,
-   "breadth": 0.297,
+   "breadth": 0.245,
    "competitiveRatio": 38.6,
    "winRate": 24.5
   }

--- a/public/data/conferences/mountain-east-conference.json
+++ b/public/data/conferences/mountain-east-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 248,
     "UP": 1294,
     "EVEN": 479,
-    "DOWN": 1448,
-    "ANCHOR": 463
+    "DOWN": 1457,
+    "ANCHOR": 454
    },
    "bandPct": {
     "STRETCH": 6.3,
     "UP": 32.9,
     "EVEN": 12.2,
-    "DOWN": 36.8,
-    "ANCHOR": 11.8
+    "DOWN": 37.1,
+    "ANCHOR": 11.5
    },
    "stretchRate": 6.3,
-   "anchorRate": 11.8,
-   "breadth": 0.88,
+   "anchorRate": 11.5,
+   "breadth": 0.878,
    "competitiveRatio": 39.8,
    "winRate": 50.7
   },
@@ -62,19 +62,19 @@
     "STRETCH": 90,
     "UP": 782,
     "EVEN": 355,
-    "DOWN": 936,
-    "ANCHOR": 305
+    "DOWN": 945,
+    "ANCHOR": 296
    },
    "bandPct": {
     "STRETCH": 3.6,
     "UP": 31.7,
     "EVEN": 14.4,
-    "DOWN": 37.9,
-    "ANCHOR": 12.4
+    "DOWN": 38.3,
+    "ANCHOR": 12
    },
    "stretchRate": 3.6,
-   "anchorRate": 12.4,
-   "breadth": 0.864,
+   "anchorRate": 12,
+   "breadth": 0.861,
    "competitiveRatio": 41.6,
    "winRate": 51.1
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -200,19 +200,19 @@
     "STRETCH": 6,
     "UP": 97,
     "EVEN": 50,
-    "DOWN": 141,
-    "ANCHOR": 57
+    "DOWN": 150,
+    "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 1.7,
     "UP": 27.6,
     "EVEN": 14.2,
-    "DOWN": 40.2,
-    "ANCHOR": 16.2
+    "DOWN": 42.7,
+    "ANCHOR": 13.7
    },
    "stretchRate": 1.7,
-   "anchorRate": 16.2,
-   "breadth": 0.848,
+   "anchorRate": 13.7,
+   "breadth": 0.831,
    "competitiveRatio": 47.9,
    "winRate": 60.7
   },

--- a/public/data/conferences/mountain-west-conference.json
+++ b/public/data/conferences/mountain-west-conference.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 103,
     "UP": 2191,
-    "EVEN": 1214,
-    "DOWN": 2737,
-    "ANCHOR": 295
+    "EVEN": 1219,
+    "DOWN": 2738,
+    "ANCHOR": 289
    },
    "bandPct": {
     "STRETCH": 1.6,
     "UP": 33.5,
     "EVEN": 18.6,
     "DOWN": 41.9,
-    "ANCHOR": 4.5
+    "ANCHOR": 4.4
    },
    "stretchRate": 1.6,
-   "anchorRate": 4.5,
-   "breadth": 0.776,
+   "anchorRate": 4.4,
+   "breadth": 0.775,
    "competitiveRatio": 46.7,
    "winRate": 53.8
   },
@@ -38,15 +38,15 @@
    "bands": {
     "STRETCH": 0,
     "UP": 1009,
-    "EVEN": 617,
-    "DOWN": 1014,
+    "EVEN": 622,
+    "DOWN": 1009,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 38.2,
-    "EVEN": 23.4,
-    "DOWN": 38.4,
+    "EVEN": 23.6,
+    "DOWN": 38.2,
     "ANCHOR": 0
    },
    "stretchRate": 0,
@@ -61,19 +61,19 @@
     "STRETCH": 103,
     "UP": 1182,
     "EVEN": 597,
-    "DOWN": 1723,
-    "ANCHOR": 295
+    "DOWN": 1729,
+    "ANCHOR": 289
    },
    "bandPct": {
     "STRETCH": 2.6,
     "UP": 30.3,
     "EVEN": 15.3,
-    "DOWN": 44.2,
-    "ANCHOR": 7.6
+    "DOWN": 44.3,
+    "ANCHOR": 7.4
    },
    "stretchRate": 2.6,
-   "anchorRate": 7.6,
-   "breadth": 0.809,
+   "anchorRate": 7.4,
+   "breadth": 0.807,
    "competitiveRatio": 46.9,
    "winRate": 56.3
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -279,20 +279,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 59,
-    "EVEN": 27,
-    "DOWN": 248,
+    "EVEN": 32,
+    "DOWN": 243,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 1.8,
     "UP": 17.4,
-    "EVEN": 7.9,
-    "DOWN": 72.9,
+    "EVEN": 9.4,
+    "DOWN": 71.5,
     "ANCHOR": 0
    },
    "stretchRate": 1.8,
    "anchorRate": 0,
-   "breadth": 0.501,
+   "breadth": 0.52,
    "competitiveRatio": 35.9,
    "winRate": 65
   },
@@ -550,19 +550,19 @@
     "STRETCH": 0,
     "UP": 70,
     "EVEN": 70,
-    "DOWN": 132,
-    "ANCHOR": 26
+    "DOWN": 138,
+    "ANCHOR": 20
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 23.5,
     "EVEN": 23.5,
-    "DOWN": 44.3,
-    "ANCHOR": 8.7
+    "DOWN": 46.3,
+    "ANCHOR": 6.7
    },
    "stretchRate": 0,
-   "anchorRate": 8.7,
-   "breadth": 0.779,
+   "anchorRate": 6.7,
+   "breadth": 0.757,
    "competitiveRatio": 50.3,
    "winRate": 47
   },

--- a/public/data/conferences/new-england-small-college-athletic-conference.json
+++ b/public/data/conferences/new-england-small-college-athletic-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 688,
     "UP": 2049,
-    "EVEN": 855,
-    "DOWN": 2696,
+    "EVEN": 878,
+    "DOWN": 2673,
     "ANCHOR": 1033
    },
    "bandPct": {
     "STRETCH": 9.4,
     "UP": 28,
-    "EVEN": 11.7,
-    "DOWN": 36.8,
+    "EVEN": 12,
+    "DOWN": 36.5,
     "ANCHOR": 14.1
    },
    "stretchRate": 9.4,
    "anchorRate": 14.1,
-   "breadth": 0.916,
+   "breadth": 0.918,
    "competitiveRatio": 42.4,
    "winRate": 55.6
   },
@@ -39,20 +39,20 @@
    "bands": {
     "STRETCH": 609,
     "UP": 1303,
-    "EVEN": 456,
-    "DOWN": 1315,
+    "EVEN": 468,
+    "DOWN": 1303,
     "ANCHOR": 609
    },
    "bandPct": {
     "STRETCH": 14.2,
     "UP": 30.4,
-    "EVEN": 10.6,
-    "DOWN": 30.6,
+    "EVEN": 10.9,
+    "DOWN": 30.4,
     "ANCHOR": 14.2
    },
    "stretchRate": 14.2,
    "anchorRate": 14.2,
-   "breadth": 0.942,
+   "breadth": 0.944,
    "competitiveRatio": 42.2,
    "winRate": 50
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 79,
     "UP": 746,
-    "EVEN": 399,
-    "DOWN": 1381,
+    "EVEN": 410,
+    "DOWN": 1370,
     "ANCHOR": 424
    },
    "bandPct": {
     "STRETCH": 2.6,
     "UP": 24.6,
-    "EVEN": 13.2,
-    "DOWN": 45.6,
+    "EVEN": 13.5,
+    "DOWN": 45.2,
     "ANCHOR": 14
    },
    "stretchRate": 2.6,
    "anchorRate": 14,
-   "breadth": 0.833,
+   "breadth": 0.836,
    "competitiveRatio": 42.7,
    "winRate": 63.5
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -172,20 +172,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 0,
-    "EVEN": 11,
-    "DOWN": 227,
+    "EVEN": 22,
+    "DOWN": 216,
     "ANCHOR": 139
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 0,
-    "EVEN": 2.9,
-    "DOWN": 60.2,
+    "EVEN": 5.8,
+    "DOWN": 57.3,
     "ANCHOR": 36.9
    },
    "stretchRate": 0,
    "anchorRate": 36.9,
-   "breadth": 0.482,
+   "breadth": 0.53,
    "competitiveRatio": 36.9,
    "winRate": 80.6
   },
@@ -388,20 +388,20 @@
    "bands": {
     "STRETCH": 18,
     "UP": 93,
-    "EVEN": 24,
-    "DOWN": 162,
+    "EVEN": 36,
+    "DOWN": 150,
     "ANCHOR": 30
    },
    "bandPct": {
     "STRETCH": 5.5,
     "UP": 28.4,
-    "EVEN": 7.3,
-    "DOWN": 49.5,
+    "EVEN": 11,
+    "DOWN": 45.9,
     "ANCHOR": 9.2
    },
    "stretchRate": 5.5,
    "anchorRate": 9.2,
-   "breadth": 0.793,
+   "breadth": 0.831,
    "competitiveRatio": 45.9,
    "winRate": 52.3
   },

--- a/public/data/conferences/new-england-women-and-men-athletics-conference.json
+++ b/public/data/conferences/new-england-women-and-men-athletics-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 805,
     "UP": 1375,
-    "EVEN": 683,
-    "DOWN": 1562,
+    "EVEN": 699,
+    "DOWN": 1546,
     "ANCHOR": 811
    },
    "bandPct": {
     "STRETCH": 15.4,
     "UP": 26.3,
-    "EVEN": 13,
-    "DOWN": 29.8,
+    "EVEN": 13.3,
+    "DOWN": 29.5,
     "ANCHOR": 15.5
    },
    "stretchRate": 15.4,
    "anchorRate": 15.5,
-   "breadth": 0.966,
+   "breadth": 0.967,
    "competitiveRatio": 30.8,
    "winRate": 50.2
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 189,
     "UP": 867,
-    "EVEN": 477,
-    "DOWN": 1054,
+    "EVEN": 493,
+    "DOWN": 1038,
     "ANCHOR": 195
    },
    "bandPct": {
     "STRETCH": 6.8,
     "UP": 31.2,
-    "EVEN": 17.1,
-    "DOWN": 37.9,
+    "EVEN": 17.7,
+    "DOWN": 37.3,
     "ANCHOR": 7
    },
    "stretchRate": 6.8,
    "anchorRate": 7,
-   "breadth": 0.871,
+   "breadth": 0.874,
    "competitiveRatio": 38.7,
    "winRate": 50.4
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -199,20 +199,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 33,
-    "EVEN": 66,
-    "DOWN": 142,
+    "EVEN": 76,
+    "DOWN": 132,
     "ANCHOR": 102
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 9.6,
-    "EVEN": 19.2,
-    "DOWN": 41.4,
+    "EVEN": 22.2,
+    "DOWN": 38.5,
     "ANCHOR": 29.7
    },
    "stretchRate": 0,
    "anchorRate": 29.7,
-   "breadth": 0.788,
+   "breadth": 0.8,
    "competitiveRatio": 27.7,
    "winRate": 77.8
   },
@@ -496,20 +496,20 @@
    "bands": {
     "STRETCH": 90,
     "UP": 130,
-    "EVEN": 36,
-    "DOWN": 12,
+    "EVEN": 42,
+    "DOWN": 6,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 33.6,
     "UP": 48.5,
-    "EVEN": 13.4,
-    "DOWN": 4.5,
+    "EVEN": 15.7,
+    "DOWN": 2.2,
     "ANCHOR": 0
    },
    "stretchRate": 33.6,
    "anchorRate": 0,
-   "breadth": 0.7,
+   "breadth": 0.679,
    "competitiveRatio": 16,
    "winRate": 21.3
   },

--- a/public/data/conferences/new-jersey-athletic-conference.json
+++ b/public/data/conferences/new-jersey-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/north-atlantic-conference.json
+++ b/public/data/conferences/north-atlantic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/north-coast-atlantic-conference.json
+++ b/public/data/conferences/north-coast-atlantic-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 848,
     "UP": 1248,
-    "EVEN": 428,
-    "DOWN": 1626,
+    "EVEN": 464,
+    "DOWN": 1590,
     "ANCHOR": 955
    },
    "bandPct": {
     "STRETCH": 16.6,
     "UP": 24.4,
-    "EVEN": 8.4,
-    "DOWN": 31.9,
+    "EVEN": 9.1,
+    "DOWN": 31.1,
     "ANCHOR": 18.7
    },
    "stretchRate": 16.6,
    "anchorRate": 18.7,
-   "breadth": 0.95,
+   "breadth": 0.955,
    "competitiveRatio": 31.2,
    "winRate": 53.4
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 335,
     "UP": 873,
-    "EVEN": 356,
-    "DOWN": 1251,
+    "EVEN": 392,
+    "DOWN": 1215,
     "ANCHOR": 442
    },
    "bandPct": {
     "STRETCH": 10.3,
     "UP": 26.8,
-    "EVEN": 10.9,
-    "DOWN": 38.4,
+    "EVEN": 12,
+    "DOWN": 37.3,
     "ANCHOR": 13.6
    },
    "stretchRate": 10.3,
    "anchorRate": 13.6,
-   "breadth": 0.912,
+   "breadth": 0.92,
    "competitiveRatio": 35.7,
    "winRate": 55.4
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -145,20 +145,20 @@
    "bands": {
     "STRETCH": 59,
     "UP": 107,
-    "EVEN": 34,
-    "DOWN": 153,
+    "EVEN": 40,
+    "DOWN": 147,
     "ANCHOR": 69
    },
    "bandPct": {
     "STRETCH": 14,
     "UP": 25.4,
-    "EVEN": 8.1,
-    "DOWN": 36.3,
+    "EVEN": 9.5,
+    "DOWN": 34.8,
     "ANCHOR": 16.4
    },
    "stretchRate": 14,
    "anchorRate": 16.4,
-   "breadth": 0.926,
+   "breadth": 0.938,
    "competitiveRatio": 40.8,
    "winRate": 55.2
   },
@@ -172,20 +172,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 100,
-    "EVEN": 6,
-    "DOWN": 206,
+    "EVEN": 12,
+    "DOWN": 200,
     "ANCHOR": 96
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 24.5,
-    "EVEN": 1.5,
-    "DOWN": 50.5,
+    "EVEN": 2.9,
+    "DOWN": 49,
     "ANCHOR": 23.5
    },
    "stretchRate": 0,
    "anchorRate": 23.5,
-   "breadth": 0.679,
+   "breadth": 0.707,
    "competitiveRatio": 28.4,
    "winRate": 65.7
   },
@@ -280,20 +280,20 @@
    "bands": {
     "STRETCH": 68,
     "UP": 127,
-    "EVEN": 17,
-    "DOWN": 142,
+    "EVEN": 23,
+    "DOWN": 136,
     "ANCHOR": 16
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 34.3,
-    "EVEN": 4.6,
-    "DOWN": 38.4,
+    "EVEN": 6.2,
+    "DOWN": 36.8,
     "ANCHOR": 4.3
    },
    "stretchRate": 18.4,
    "anchorRate": 4.3,
-   "breadth": 0.822,
+   "breadth": 0.842,
    "competitiveRatio": 26.5,
    "winRate": 47.3
   },
@@ -307,20 +307,20 @@
    "bands": {
     "STRETCH": 30,
     "UP": 112,
-    "EVEN": 36,
-    "DOWN": 138,
+    "EVEN": 42,
+    "DOWN": 132,
     "ANCHOR": 45
    },
    "bandPct": {
     "STRETCH": 8.3,
     "UP": 31,
-    "EVEN": 10,
-    "DOWN": 38.2,
+    "EVEN": 11.6,
+    "DOWN": 36.6,
     "ANCHOR": 12.5
    },
    "stretchRate": 8.3,
    "anchorRate": 12.5,
-   "breadth": 0.887,
+   "breadth": 0.899,
    "competitiveRatio": 38.6,
    "winRate": 47.4
   },
@@ -334,20 +334,20 @@
    "bands": {
     "STRETCH": 51,
     "UP": 136,
-    "EVEN": 42,
-    "DOWN": 53,
+    "EVEN": 54,
+    "DOWN": 41,
     "ANCHOR": 27
    },
    "bandPct": {
     "STRETCH": 16.5,
     "UP": 44,
-    "EVEN": 13.6,
-    "DOWN": 17.2,
+    "EVEN": 17.5,
+    "DOWN": 13.3,
     "ANCHOR": 8.7
    },
    "stretchRate": 16.5,
    "anchorRate": 8.7,
-   "breadth": 0.898,
+   "breadth": 0.897,
    "competitiveRatio": 26.9,
    "winRate": 34
   },

--- a/public/data/conferences/northeast-10-conference.json
+++ b/public/data/conferences/northeast-10-conference.json
@@ -83,22 +83,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/northeast-conference.json
+++ b/public/data/conferences/northeast-conference.json
@@ -83,22 +83,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/northern-athletic-collegiate-conference.json
+++ b/public/data/conferences/northern-athletic-collegiate-conference.json
@@ -15,20 +15,20 @@
   "overall": {
    "matches": 4755,
    "bands": {
-    "STRETCH": 739,
-    "UP": 2019,
-    "EVEN": 503,
-    "DOWN": 1178,
+    "STRETCH": 730,
+    "UP": 2028,
+    "EVEN": 515,
+    "DOWN": 1166,
     "ANCHOR": 316
    },
    "bandPct": {
-    "STRETCH": 15.5,
-    "UP": 42.5,
-    "EVEN": 10.6,
-    "DOWN": 24.8,
+    "STRETCH": 15.4,
+    "UP": 42.6,
+    "EVEN": 10.8,
+    "DOWN": 24.5,
     "ANCHOR": 6.6
    },
-   "stretchRate": 15.5,
+   "stretchRate": 15.4,
    "anchorRate": 6.6,
    "breadth": 0.88,
    "competitiveRatio": 27.1,
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 2541,
    "bands": {
-    "STRETCH": 467,
-    "UP": 1287,
-    "EVEN": 297,
-    "DOWN": 446,
+    "STRETCH": 458,
+    "UP": 1296,
+    "EVEN": 309,
+    "DOWN": 434,
     "ANCHOR": 44
    },
    "bandPct": {
-    "STRETCH": 18.4,
-    "UP": 50.6,
-    "EVEN": 11.7,
-    "DOWN": 17.6,
+    "STRETCH": 18,
+    "UP": 51,
+    "EVEN": 12.2,
+    "DOWN": 17.1,
     "ANCHOR": 1.7
    },
-   "stretchRate": 18.4,
+   "stretchRate": 18,
    "anchorRate": 1.7,
-   "breadth": 0.797,
+   "breadth": 0.796,
    "competitiveRatio": 31.6,
    "winRate": 32.3
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 12.3,
-  "nonConference": 18.4,
-  "delta": 6.1,
+  "nonConference": 18,
+  "delta": 5.7,
   "nonConferenceShare": 53.4
  },
  "members": [
@@ -118,20 +118,20 @@
    "bands": {
     "STRETCH": 24,
     "UP": 108,
-    "EVEN": 103,
-    "DOWN": 147,
+    "EVEN": 115,
+    "DOWN": 135,
     "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 5.6,
     "UP": 25.1,
-    "EVEN": 24,
-    "DOWN": 34.2,
+    "EVEN": 26.7,
+    "DOWN": 31.4,
     "ANCHOR": 11.2
    },
    "stretchRate": 5.6,
    "anchorRate": 11.2,
-   "breadth": 0.908,
+   "breadth": 0.913,
    "competitiveRatio": 27.5,
    "winRate": 64.4
   },
@@ -521,22 +521,22 @@
    "lineupWTN": 32.8,
    "matches": 141,
    "bands": {
-    "STRETCH": 47,
-    "UP": 78,
+    "STRETCH": 38,
+    "UP": 87,
     "EVEN": 16,
     "DOWN": 0,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 33.3,
-    "UP": 55.3,
+    "STRETCH": 27,
+    "UP": 61.7,
     "EVEN": 11.3,
     "DOWN": 0,
     "ANCHOR": 0
    },
-   "stretchRate": 33.3,
+   "stretchRate": 27,
    "anchorRate": 0,
-   "breadth": 0.584,
+   "breadth": 0.558,
    "competitiveRatio": 23.4,
    "winRate": 28.4
   }

--- a/public/data/conferences/northern-sun-intercollegiate-conference.json
+++ b/public/data/conferences/northern-sun-intercollegiate-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 400,
     "UP": 1167,
-    "EVEN": 432,
-    "DOWN": 1006,
+    "EVEN": 471,
+    "DOWN": 967,
     "ANCHOR": 202
    },
    "bandPct": {
     "STRETCH": 12.5,
     "UP": 36.4,
-    "EVEN": 13.5,
-    "DOWN": 31.4,
+    "EVEN": 14.7,
+    "DOWN": 30.2,
     "ANCHOR": 6.3
    },
    "stretchRate": 12.5,
    "anchorRate": 6.3,
-   "breadth": 0.892,
+   "breadth": 0.898,
    "competitiveRatio": 33.2,
    "winRate": 47.1
   },
@@ -39,20 +39,20 @@
    "bands": {
     "STRETCH": 141,
     "UP": 680,
-    "EVEN": 251,
-    "DOWN": 719,
+    "EVEN": 290,
+    "DOWN": 680,
     "ANCHOR": 141
    },
    "bandPct": {
     "STRETCH": 7.3,
     "UP": 35.2,
-    "EVEN": 13,
-    "DOWN": 37.2,
+    "EVEN": 15,
+    "DOWN": 35.2,
     "ANCHOR": 7.3
    },
    "stretchRate": 7.3,
    "anchorRate": 7.3,
-   "breadth": 0.859,
+   "breadth": 0.871,
    "competitiveRatio": 32.6,
    "winRate": 50
   },
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -172,20 +172,20 @@
    "bands": {
     "STRETCH": 87,
     "UP": 118,
-    "EVEN": 42,
-    "DOWN": 74,
+    "EVEN": 81,
+    "DOWN": 35,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 27.1,
     "UP": 36.8,
-    "EVEN": 13.1,
-    "DOWN": 23.1,
+    "EVEN": 25.2,
+    "DOWN": 10.9,
     "ANCHOR": 0
    },
    "stretchRate": 27.1,
    "anchorRate": 0,
-   "breadth": 0.824,
+   "breadth": 0.814,
    "competitiveRatio": 31.2,
    "winRate": 45.2
   },

--- a/public/data/conferences/northwest-conference.json
+++ b/public/data/conferences/northwest-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/ohio-athletic-conference.json
+++ b/public/data/conferences/ohio-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/ohio-valley-conference.json
+++ b/public/data/conferences/ohio-valley-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 218,
     "UP": 734,
     "EVEN": 320,
-    "DOWN": 647,
-    "ANCHOR": 187
+    "DOWN": 660,
+    "ANCHOR": 174
    },
    "bandPct": {
     "STRETCH": 10.4,
     "UP": 34.9,
     "EVEN": 15.2,
-    "DOWN": 30.7,
-    "ANCHOR": 8.9
+    "DOWN": 31.3,
+    "ANCHOR": 8.3
    },
    "stretchRate": 10.4,
-   "anchorRate": 8.9,
-   "breadth": 0.911,
+   "anchorRate": 8.3,
+   "breadth": 0.906,
    "competitiveRatio": 38.8,
    "winRate": 43.7
   },
@@ -62,19 +62,19 @@
     "STRETCH": 197,
     "UP": 495,
     "EVEN": 206,
-    "DOWN": 408,
-    "ANCHOR": 166
+    "DOWN": 421,
+    "ANCHOR": 153
    },
    "bandPct": {
     "STRETCH": 13.4,
     "UP": 33.6,
     "EVEN": 14,
-    "DOWN": 27.7,
-    "ANCHOR": 11.3
+    "DOWN": 28.6,
+    "ANCHOR": 10.4
    },
    "stretchRate": 13.4,
-   "anchorRate": 11.3,
-   "breadth": 0.94,
+   "anchorRate": 10.4,
+   "breadth": 0.935,
    "competitiveRatio": 37.6,
    "winRate": 41
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -227,19 +227,19 @@
     "STRETCH": 3,
     "UP": 6,
     "EVEN": 16,
-    "DOWN": 187,
-    "ANCHOR": 85
+    "DOWN": 200,
+    "ANCHOR": 72
    },
    "bandPct": {
     "STRETCH": 1,
     "UP": 2,
     "EVEN": 5.4,
-    "DOWN": 63,
-    "ANCHOR": 28.6
+    "DOWN": 67.3,
+    "ANCHOR": 24.2
    },
    "stretchRate": 1,
-   "anchorRate": 28.6,
-   "breadth": 0.579,
+   "anchorRate": 24.2,
+   "breadth": 0.554,
    "competitiveRatio": 37,
    "winRate": 73.7
   },

--- a/public/data/conferences/old-dominion-athletic-conference.json
+++ b/public/data/conferences/old-dominion-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/orange-empire-conference.json
+++ b/public/data/conferences/orange-empire-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/pacific-coast-athletic-conference.json
+++ b/public/data/conferences/pacific-coast-athletic-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/pacific-west-conference.json
+++ b/public/data/conferences/pacific-west-conference.json
@@ -16,20 +16,20 @@
   "overall": {
    "matches": 7247,
    "bands": {
-    "STRETCH": 813,
-    "UP": 2381,
+    "STRETCH": 807,
+    "UP": 2387,
     "EVEN": 923,
     "DOWN": 2298,
     "ANCHOR": 832
    },
    "bandPct": {
-    "STRETCH": 11.2,
+    "STRETCH": 11.1,
     "UP": 32.9,
     "EVEN": 12.7,
     "DOWN": 31.7,
     "ANCHOR": 11.5
    },
-   "stretchRate": 11.2,
+   "stretchRate": 11.1,
    "anchorRate": 11.5,
    "breadth": 0.923,
    "competitiveRatio": 39.3,
@@ -60,22 +60,22 @@
   "nonConference": {
    "matches": 2417,
    "bands": {
-    "STRETCH": 393,
-    "UP": 716,
+    "STRETCH": 387,
+    "UP": 722,
     "EVEN": 263,
     "DOWN": 633,
     "ANCHOR": 412
    },
    "bandPct": {
-    "STRETCH": 16.3,
-    "UP": 29.6,
+    "STRETCH": 16,
+    "UP": 29.9,
     "EVEN": 10.9,
     "DOWN": 26.2,
     "ANCHOR": 17
    },
-   "stretchRate": 16.3,
+   "stretchRate": 16,
    "anchorRate": 17,
-   "breadth": 0.963,
+   "breadth": 0.962,
    "competitiveRatio": 35.7,
    "winRate": 52.3
   }
@@ -83,29 +83,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 8.7,
-  "nonConference": 16.3,
-  "delta": 7.6,
+  "nonConference": 16,
+  "delta": 7.3,
   "nonConferenceShare": 33.4
  },
  "members": [
@@ -522,22 +522,22 @@
    "lineupWTN": 16.23,
    "matches": 286,
    "bands": {
-    "STRETCH": 6,
-    "UP": 106,
+    "STRETCH": 0,
+    "UP": 112,
     "EVEN": 41,
     "DOWN": 133,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 2.1,
-    "UP": 37.1,
+    "STRETCH": 0,
+    "UP": 39.2,
     "EVEN": 14.3,
     "DOWN": 46.5,
     "ANCHOR": 0
    },
-   "stretchRate": 2.1,
+   "stretchRate": 0,
    "anchorRate": 0,
-   "breadth": 0.673,
+   "breadth": 0.622,
    "competitiveRatio": 55.6,
    "winRate": 52.1
   },

--- a/public/data/conferences/patriot-league.json
+++ b/public/data/conferences/patriot-league.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 6223,
    "bands": {
-    "STRETCH": 481,
-    "UP": 2328,
+    "STRETCH": 464,
+    "UP": 2345,
     "EVEN": 756,
-    "DOWN": 2238,
-    "ANCHOR": 420
+    "DOWN": 2256,
+    "ANCHOR": 402
    },
    "bandPct": {
-    "STRETCH": 7.7,
-    "UP": 37.4,
+    "STRETCH": 7.5,
+    "UP": 37.7,
     "EVEN": 12.1,
-    "DOWN": 36,
-    "ANCHOR": 6.7
+    "DOWN": 36.3,
+    "ANCHOR": 6.5
    },
-   "stretchRate": 7.7,
-   "anchorRate": 6.7,
-   "breadth": 0.852,
+   "stretchRate": 7.5,
+   "anchorRate": 6.5,
+   "breadth": 0.846,
    "competitiveRatio": 42.5,
    "winRate": 49.8
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 4183,
    "bands": {
-    "STRETCH": 324,
-    "UP": 1529,
+    "STRETCH": 307,
+    "UP": 1546,
     "EVEN": 628,
-    "DOWN": 1439,
-    "ANCHOR": 263
+    "DOWN": 1457,
+    "ANCHOR": 245
    },
    "bandPct": {
-    "STRETCH": 7.7,
-    "UP": 36.6,
+    "STRETCH": 7.3,
+    "UP": 37,
     "EVEN": 15,
-    "DOWN": 34.4,
-    "ANCHOR": 6.3
+    "DOWN": 34.8,
+    "ANCHOR": 5.9
    },
-   "stretchRate": 7.7,
-   "anchorRate": 6.3,
-   "breadth": 0.865,
+   "stretchRate": 7.3,
+   "anchorRate": 5.9,
+   "breadth": 0.856,
    "competitiveRatio": 44.6,
    "winRate": 49.8
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 7.7,
-  "nonConference": 7.7,
-  "delta": 0,
+  "nonConference": 7.3,
+  "delta": -0.4,
   "nonConferenceShare": 67.2
  },
  "members": [
@@ -146,19 +146,19 @@
     "STRETCH": 3,
     "UP": 46,
     "EVEN": 57,
-    "DOWN": 351,
-    "ANCHOR": 40
+    "DOWN": 369,
+    "ANCHOR": 22
    },
    "bandPct": {
     "STRETCH": 0.6,
     "UP": 9.3,
     "EVEN": 11.5,
-    "DOWN": 70.6,
-    "ANCHOR": 8
+    "DOWN": 74.2,
+    "ANCHOR": 4.4
    },
    "stretchRate": 0.6,
-   "anchorRate": 8,
-   "breadth": 0.589,
+   "anchorRate": 4.4,
+   "breadth": 0.533,
    "competitiveRatio": 40.8,
    "winRate": 66.2
   },
@@ -440,22 +440,22 @@
    "lineupWTN": 16.72,
    "matches": 302,
    "bands": {
-    "STRETCH": 66,
-    "UP": 96,
+    "STRETCH": 49,
+    "UP": 113,
     "EVEN": 12,
     "DOWN": 128,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 21.9,
-    "UP": 31.8,
+    "STRETCH": 16.2,
+    "UP": 37.4,
     "EVEN": 4,
     "DOWN": 42.4,
     "ANCHOR": 0
    },
-   "stretchRate": 21.9,
+   "stretchRate": 16.2,
    "anchorRate": 0,
-   "breadth": 0.739,
+   "breadth": 0.718,
    "competitiveRatio": 38.5,
    "winRate": 48
   },

--- a/public/data/conferences/peach-belt-conference.json
+++ b/public/data/conferences/peach-belt-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/pennsylvania-state-athletic-conference.json
+++ b/public/data/conferences/pennsylvania-state-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/presidents-athletic-conference.json
+++ b/public/data/conferences/presidents-athletic-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 431,
     "UP": 1547,
     "EVEN": 631,
-    "DOWN": 1852,
-    "ANCHOR": 366
+    "DOWN": 1858,
+    "ANCHOR": 360
    },
    "bandPct": {
     "STRETCH": 8.9,
     "UP": 32,
     "EVEN": 13.1,
-    "DOWN": 38.4,
-    "ANCHOR": 7.6
+    "DOWN": 38.5,
+    "ANCHOR": 7.5
    },
    "stretchRate": 8.9,
-   "anchorRate": 7.6,
-   "breadth": 0.876,
+   "anchorRate": 7.5,
+   "breadth": 0.875,
    "competitiveRatio": 23,
    "winRate": 49.5
   },
@@ -62,19 +62,19 @@
     "STRETCH": 166,
     "UP": 659,
     "EVEN": 355,
-    "DOWN": 964,
-    "ANCHOR": 101
+    "DOWN": 970,
+    "ANCHOR": 95
    },
    "bandPct": {
     "STRETCH": 7.4,
     "UP": 29.4,
     "EVEN": 15.8,
-    "DOWN": 42.9,
-    "ANCHOR": 4.5
+    "DOWN": 43.2,
+    "ANCHOR": 4.2
    },
    "stretchRate": 7.4,
-   "anchorRate": 4.5,
-   "breadth": 0.837,
+   "anchorRate": 4.2,
+   "breadth": 0.833,
    "competitiveRatio": 25,
    "winRate": 48.8
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -146,19 +146,19 @@
     "STRETCH": 24,
     "UP": 48,
     "EVEN": 24,
-    "DOWN": 210,
-    "ANCHOR": 93
+    "DOWN": 216,
+    "ANCHOR": 87
    },
    "bandPct": {
     "STRETCH": 6,
     "UP": 12,
     "EVEN": 6,
-    "DOWN": 52.6,
-    "ANCHOR": 23.3
+    "DOWN": 54.1,
+    "ANCHOR": 21.8
    },
    "stretchRate": 6,
-   "anchorRate": 23.3,
-   "breadth": 0.789,
+   "anchorRate": 21.8,
+   "breadth": 0.781,
    "competitiveRatio": 23.6,
    "winRate": 62.4
   },

--- a/public/data/conferences/red-river-athletic-conference.json
+++ b/public/data/conferences/red-river-athletic-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 218,
     "UP": 950,
     "EVEN": 623,
-    "DOWN": 1316,
-    "ANCHOR": 382
+    "DOWN": 1322,
+    "ANCHOR": 376
    },
    "bandPct": {
     "STRETCH": 6.2,
     "UP": 27.2,
     "EVEN": 17.9,
-    "DOWN": 37.7,
-    "ANCHOR": 10.9
+    "DOWN": 37.9,
+    "ANCHOR": 10.8
    },
    "stretchRate": 6.2,
-   "anchorRate": 10.9,
-   "breadth": 0.898,
+   "anchorRate": 10.8,
+   "breadth": 0.897,
    "competitiveRatio": 35.3,
    "winRate": 56.2
   },
@@ -62,19 +62,19 @@
     "STRETCH": 195,
     "UP": 681,
     "EVEN": 475,
-    "DOWN": 1047,
-    "ANCHOR": 359
+    "DOWN": 1053,
+    "ANCHOR": 353
    },
    "bandPct": {
     "STRETCH": 7.1,
     "UP": 24.7,
     "EVEN": 17.2,
-    "DOWN": 38,
-    "ANCHOR": 13
+    "DOWN": 38.2,
+    "ANCHOR": 12.8
    },
    "stretchRate": 7.1,
-   "anchorRate": 13,
-   "breadth": 0.913,
+   "anchorRate": 12.8,
+   "breadth": 0.911,
    "competitiveRatio": 35.9,
    "winRate": 57.8
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -362,19 +362,19 @@
     "STRETCH": 0,
     "UP": 51,
     "EVEN": 49,
-    "DOWN": 149,
-    "ANCHOR": 24
+    "DOWN": 155,
+    "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 18.7,
     "EVEN": 17.9,
-    "DOWN": 54.6,
-    "ANCHOR": 8.8
+    "DOWN": 56.8,
+    "ANCHOR": 6.6
    },
    "stretchRate": 0,
-   "anchorRate": 8.8,
-   "breadth": 0.724,
+   "anchorRate": 6.6,
+   "breadth": 0.697,
    "competitiveRatio": 33.5,
    "winRate": 64.1
   },

--- a/public/data/conferences/region-1.json
+++ b/public/data/conferences/region-1.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-10.json
+++ b/public/data/conferences/region-10.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-14.json
+++ b/public/data/conferences/region-14.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-17.json
+++ b/public/data/conferences/region-17.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-19.json
+++ b/public/data/conferences/region-19.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-22.json
+++ b/public/data/conferences/region-22.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-23.json
+++ b/public/data/conferences/region-23.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-4.json
+++ b/public/data/conferences/region-4.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-5.json
+++ b/public/data/conferences/region-5.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/region-6.json
+++ b/public/data/conferences/region-6.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 93,
     "UP": 450,
-    "EVEN": 84,
-    "DOWN": 332,
+    "EVEN": 88,
+    "DOWN": 328,
     "ANCHOR": 118
    },
    "bandPct": {
     "STRETCH": 8.6,
     "UP": 41.8,
-    "EVEN": 7.8,
-    "DOWN": 30.8,
+    "EVEN": 8.2,
+    "DOWN": 30.5,
     "ANCHOR": 11
    },
    "stretchRate": 8.6,
    "anchorRate": 11,
-   "breadth": 0.858,
+   "breadth": 0.861,
    "competitiveRatio": 40.1,
    "winRate": 55.1
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 77,
     "UP": 366,
-    "EVEN": 84,
-    "DOWN": 248,
+    "EVEN": 88,
+    "DOWN": 244,
     "ANCHOR": 102
    },
    "bandPct": {
     "STRETCH": 8.8,
     "UP": 41.7,
-    "EVEN": 9.6,
-    "DOWN": 28.3,
+    "EVEN": 10,
+    "DOWN": 27.8,
     "ANCHOR": 11.6
    },
    "stretchRate": 8.8,
    "anchorRate": 11.6,
-   "breadth": 0.876,
+   "breadth": 0.879,
    "competitiveRatio": 39,
    "winRate": 56.2
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -226,20 +226,20 @@
    "bands": {
     "STRETCH": 65,
     "UP": 55,
-    "EVEN": 14,
-    "DOWN": 19,
+    "EVEN": 18,
+    "DOWN": 15,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 42.5,
     "UP": 35.9,
-    "EVEN": 9.2,
-    "DOWN": 12.4,
+    "EVEN": 11.8,
+    "DOWN": 9.8,
     "ANCHOR": 0
    },
    "stretchRate": 42.5,
    "anchorRate": 0,
-   "breadth": 0.751,
+   "breadth": 0.752,
    "competitiveRatio": 31.8,
    "winRate": 46.4
   },

--- a/public/data/conferences/river-states-conference.json
+++ b/public/data/conferences/river-states-conference.json
@@ -15,66 +15,66 @@
   "overall": {
    "matches": 2909,
    "bands": {
-    "STRETCH": 628,
-    "UP": 913,
+    "STRETCH": 605,
+    "UP": 936,
     "EVEN": 307,
-    "DOWN": 766,
-    "ANCHOR": 295
+    "DOWN": 785,
+    "ANCHOR": 276
    },
    "bandPct": {
-    "STRETCH": 21.6,
-    "UP": 31.4,
+    "STRETCH": 20.8,
+    "UP": 32.2,
     "EVEN": 10.6,
-    "DOWN": 26.3,
-    "ANCHOR": 10.1
+    "DOWN": 27,
+    "ANCHOR": 9.5
    },
-   "stretchRate": 21.6,
-   "anchorRate": 10.1,
-   "breadth": 0.942,
+   "stretchRate": 20.8,
+   "anchorRate": 9.5,
+   "breadth": 0.936,
    "competitiveRatio": 27.3,
    "winRate": 41
   },
   "inConference": {
    "matches": 1076,
    "bands": {
-    "STRETCH": 215,
-    "UP": 280,
+    "STRETCH": 198,
+    "UP": 297,
     "EVEN": 86,
-    "DOWN": 280,
-    "ANCHOR": 215
+    "DOWN": 297,
+    "ANCHOR": 198
    },
    "bandPct": {
-    "STRETCH": 20,
-    "UP": 26,
+    "STRETCH": 18.4,
+    "UP": 27.6,
     "EVEN": 8,
-    "DOWN": 26,
-    "ANCHOR": 20
+    "DOWN": 27.6,
+    "ANCHOR": 18.4
    },
-   "stretchRate": 20,
-   "anchorRate": 20,
-   "breadth": 0.961,
+   "stretchRate": 18.4,
+   "anchorRate": 18.4,
+   "breadth": 0.954,
    "competitiveRatio": 23,
    "winRate": 50
   },
   "nonConference": {
    "matches": 1833,
    "bands": {
-    "STRETCH": 413,
-    "UP": 633,
+    "STRETCH": 407,
+    "UP": 639,
     "EVEN": 221,
-    "DOWN": 486,
-    "ANCHOR": 80
+    "DOWN": 488,
+    "ANCHOR": 78
    },
    "bandPct": {
-    "STRETCH": 22.5,
-    "UP": 34.5,
+    "STRETCH": 22.2,
+    "UP": 34.9,
     "EVEN": 12.1,
-    "DOWN": 26.5,
-    "ANCHOR": 4.4
+    "DOWN": 26.6,
+    "ANCHOR": 4.3
    },
-   "stretchRate": 22.5,
-   "anchorRate": 4.4,
-   "breadth": 0.899,
+   "stretchRate": 22.2,
+   "anchorRate": 4.3,
+   "breadth": 0.897,
    "competitiveRatio": 29.9,
    "winRate": 35.8
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 20,
-  "nonConference": 22.5,
-  "delta": 2.5,
+  "inConference": 18.4,
+  "nonConference": 22.2,
+  "delta": 3.8,
   "nonConferenceShare": 63
  },
  "members": [
@@ -146,19 +146,19 @@
     "STRETCH": 0,
     "UP": 71,
     "EVEN": 35,
-    "DOWN": 104,
-    "ANCHOR": 101
+    "DOWN": 123,
+    "ANCHOR": 82
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 22.8,
     "EVEN": 11.3,
-    "DOWN": 33.4,
-    "ANCHOR": 32.5
+    "DOWN": 39.5,
+    "ANCHOR": 26.4
    },
    "stretchRate": 0,
-   "anchorRate": 32.5,
-   "breadth": 0.817,
+   "anchorRate": 26.4,
+   "breadth": 0.809,
    "competitiveRatio": 24,
    "winRate": 62.1
   },
@@ -251,22 +251,22 @@
    "lineupWTN": 27.14,
    "matches": 236,
    "bands": {
-    "STRETCH": 98,
-    "UP": 96,
+    "STRETCH": 92,
+    "UP": 102,
     "EVEN": 5,
     "DOWN": 33,
     "ANCHOR": 4
    },
    "bandPct": {
-    "STRETCH": 41.5,
-    "UP": 40.7,
+    "STRETCH": 39,
+    "UP": 43.2,
     "EVEN": 2.1,
     "DOWN": 14,
     "ANCHOR": 1.7
    },
-   "stretchRate": 41.5,
+   "stretchRate": 39,
    "anchorRate": 1.7,
-   "breadth": 0.719,
+   "breadth": 0.718,
    "competitiveRatio": 22.6,
    "winRate": 28.8
   },
@@ -278,22 +278,22 @@
    "lineupWTN": 28.52,
    "matches": 219,
    "bands": {
-    "STRETCH": 36,
-    "UP": 31,
+    "STRETCH": 19,
+    "UP": 48,
     "EVEN": 75,
     "DOWN": 71,
     "ANCHOR": 6
    },
    "bandPct": {
-    "STRETCH": 16.4,
-    "UP": 14.2,
+    "STRETCH": 8.7,
+    "UP": 21.9,
     "EVEN": 34.2,
     "DOWN": 32.4,
     "ANCHOR": 2.7
    },
-   "stretchRate": 16.4,
+   "stretchRate": 8.7,
    "anchorRate": 2.7,
-   "breadth": 0.873,
+   "breadth": 0.855,
    "competitiveRatio": 25.7,
    "winRate": 43.4
   },

--- a/public/data/conferences/rocky-mountain-athletic-conference.json
+++ b/public/data/conferences/rocky-mountain-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/skyline-conference.json
+++ b/public/data/conferences/skyline-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 310,
     "UP": 839,
-    "EVEN": 564,
-    "DOWN": 1073,
+    "EVEN": 576,
+    "DOWN": 1061,
     "ANCHOR": 255
    },
    "bandPct": {
     "STRETCH": 10.2,
     "UP": 27.6,
-    "EVEN": 18.5,
-    "DOWN": 35.3,
+    "EVEN": 18.9,
+    "DOWN": 34.9,
     "ANCHOR": 8.4
    },
    "stretchRate": 10.2,
    "anchorRate": 8.4,
-   "breadth": 0.917,
+   "breadth": 0.919,
    "competitiveRatio": 24.5,
    "winRate": 50.6
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 163,
     "UP": 400,
-    "EVEN": 182,
-    "DOWN": 634,
+    "EVEN": 194,
+    "DOWN": 622,
     "ANCHOR": 108
    },
    "bandPct": {
     "STRETCH": 11,
     "UP": 26.9,
-    "EVEN": 12.2,
-    "DOWN": 42.6,
+    "EVEN": 13,
+    "DOWN": 41.8,
     "ANCHOR": 7.3
    },
    "stretchRate": 11,
    "anchorRate": 7.3,
-   "breadth": 0.874,
+   "breadth": 0.88,
    "competitiveRatio": 22.8,
    "winRate": 51.2
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -442,20 +442,20 @@
    "bands": {
     "STRETCH": 35,
     "UP": 74,
-    "EVEN": 24,
-    "DOWN": 39,
+    "EVEN": 36,
+    "DOWN": 27,
     "ANCHOR": 0
    },
    "bandPct": {
     "STRETCH": 20.3,
     "UP": 43,
-    "EVEN": 14,
-    "DOWN": 22.7,
+    "EVEN": 20.9,
+    "DOWN": 15.7,
     "ANCHOR": 0
    },
    "stretchRate": 20.3,
    "anchorRate": 0,
-   "breadth": 0.807,
+   "breadth": 0.811,
    "competitiveRatio": 28.5,
    "winRate": 36.6
   },

--- a/public/data/conferences/sooner-athletic-conference.json
+++ b/public/data/conferences/sooner-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/south-atlantic-conference.json
+++ b/public/data/conferences/south-atlantic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/south-coast-conference.json
+++ b/public/data/conferences/south-coast-conference.json
@@ -80,22 +80,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/southeastern-conference.json
+++ b/public/data/conferences/southeastern-conference.json
@@ -14,44 +14,44 @@
   "overall": {
    "matches": 12461,
    "bands": {
-    "STRETCH": 91,
-    "UP": 3373,
+    "STRETCH": 71,
+    "UP": 3393,
     "EVEN": 2038,
-    "DOWN": 4955,
-    "ANCHOR": 2004
+    "DOWN": 4994,
+    "ANCHOR": 1965
    },
    "bandPct": {
-    "STRETCH": 0.7,
-    "UP": 27.1,
+    "STRETCH": 0.6,
+    "UP": 27.2,
     "EVEN": 16.4,
-    "DOWN": 39.8,
-    "ANCHOR": 16.1
+    "DOWN": 40.1,
+    "ANCHOR": 15.8
    },
-   "stretchRate": 0.7,
-   "anchorRate": 16.1,
-   "breadth": 0.837,
+   "stretchRate": 0.6,
+   "anchorRate": 15.8,
+   "breadth": 0.831,
    "competitiveRatio": 45.4,
    "winRate": 60.3
   },
   "inConference": {
    "matches": 7178,
    "bands": {
-    "STRETCH": 91,
-    "UP": 2832,
+    "STRETCH": 71,
+    "UP": 2852,
     "EVEN": 1332,
-    "DOWN": 2832,
-    "ANCHOR": 91
+    "DOWN": 2852,
+    "ANCHOR": 71
    },
    "bandPct": {
-    "STRETCH": 1.3,
-    "UP": 39.5,
+    "STRETCH": 1,
+    "UP": 39.7,
     "EVEN": 18.6,
-    "DOWN": 39.5,
-    "ANCHOR": 1.3
+    "DOWN": 39.7,
+    "ANCHOR": 1
    },
-   "stretchRate": 1.3,
-   "anchorRate": 1.3,
-   "breadth": 0.719,
+   "stretchRate": 1,
+   "anchorRate": 1,
+   "breadth": 0.707,
    "competitiveRatio": 50.3,
    "winRate": 50
   },
@@ -61,18 +61,18 @@
     "STRETCH": 0,
     "UP": 541,
     "EVEN": 706,
-    "DOWN": 2123,
-    "ANCHOR": 1913
+    "DOWN": 2142,
+    "ANCHOR": 1894
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 10.2,
     "EVEN": 13.4,
-    "DOWN": 40.2,
-    "ANCHOR": 36.2
+    "DOWN": 40.5,
+    "ANCHOR": 35.9
    },
    "stretchRate": 0,
-   "anchorRate": 36.2,
+   "anchorRate": 35.9,
    "breadth": 0.768,
    "competitiveRatio": 38.7,
    "winRate": 74.3
@@ -81,29 +81,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
-  "inConference": 1.3,
+  "inConference": 1,
   "nonConference": 0,
-  "delta": -1.3,
+  "delta": -1,
   "nonConferenceShare": 42.4
  },
  "members": [
@@ -523,19 +523,19 @@
     "STRETCH": 0,
     "UP": 131,
     "EVEN": 34,
-    "DOWN": 147,
-    "ANCHOR": 92
+    "DOWN": 153,
+    "ANCHOR": 86
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.4,
     "EVEN": 8.4,
-    "DOWN": 36.4,
-    "ANCHOR": 22.8
+    "DOWN": 37.9,
+    "ANCHOR": 21.3
    },
    "stretchRate": 0,
-   "anchorRate": 22.8,
-   "breadth": 0.794,
+   "anchorRate": 21.3,
+   "breadth": 0.789,
    "competitiveRatio": 50.7,
    "winRate": 56.9
   },
@@ -550,19 +550,19 @@
     "STRETCH": 0,
     "UP": 44,
     "EVEN": 105,
-    "DOWN": 206,
-    "ANCHOR": 42
+    "DOWN": 209,
+    "ANCHOR": 39
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 11.1,
     "EVEN": 26.4,
-    "DOWN": 51.9,
-    "ANCHOR": 10.6
+    "DOWN": 52.6,
+    "ANCHOR": 9.8
    },
    "stretchRate": 0,
-   "anchorRate": 10.6,
-   "breadth": 0.729,
+   "anchorRate": 9.8,
+   "breadth": 0.722,
    "competitiveRatio": 41.3,
    "winRate": 66.5
   },
@@ -685,19 +685,19 @@
     "STRETCH": 0,
     "UP": 112,
     "EVEN": 109,
-    "DOWN": 122,
-    "ANCHOR": 28
+    "DOWN": 132,
+    "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 30.2,
     "EVEN": 29.4,
-    "DOWN": 32.9,
-    "ANCHOR": 7.5
+    "DOWN": 35.6,
+    "ANCHOR": 4.9
    },
    "stretchRate": 0,
-   "anchorRate": 7.5,
-   "breadth": 0.797,
+   "anchorRate": 4.9,
+   "breadth": 0.768,
    "competitiveRatio": 44.6,
    "winRate": 60.6
   },
@@ -712,19 +712,19 @@
     "STRETCH": 0,
     "UP": 0,
     "EVEN": 0,
-    "DOWN": 313,
-    "ANCHOR": 49
+    "DOWN": 323,
+    "ANCHOR": 39
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 0,
     "EVEN": 0,
-    "DOWN": 86.5,
-    "ANCHOR": 13.5
+    "DOWN": 89.2,
+    "ANCHOR": 10.8
    },
    "stretchRate": 0,
-   "anchorRate": 13.5,
-   "breadth": 0.246,
+   "anchorRate": 10.8,
+   "breadth": 0.212,
    "competitiveRatio": 39.2,
    "winRate": 74
   },
@@ -790,22 +790,22 @@
    "lineupWTN": 16.48,
    "matches": 347,
    "bands": {
-    "STRETCH": 10,
-    "UP": 142,
+    "STRETCH": 0,
+    "UP": 152,
     "EVEN": 93,
     "DOWN": 64,
     "ANCHOR": 38
    },
    "bandPct": {
-    "STRETCH": 2.9,
-    "UP": 40.9,
+    "STRETCH": 0,
+    "UP": 43.8,
     "EVEN": 26.8,
     "DOWN": 18.4,
     "ANCHOR": 11
    },
-   "stretchRate": 2.9,
+   "stretchRate": 0,
    "anchorRate": 11,
-   "breadth": 0.854,
+   "breadth": 0.788,
    "competitiveRatio": 42.2,
    "winRate": 49
   },
@@ -820,19 +820,19 @@
     "STRETCH": 0,
     "UP": 103,
     "EVEN": 56,
-    "DOWN": 147,
-    "ANCHOR": 33
+    "DOWN": 157,
+    "ANCHOR": 23
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 30.4,
     "EVEN": 16.5,
-    "DOWN": 43.4,
-    "ANCHOR": 9.7
+    "DOWN": 46.3,
+    "ANCHOR": 6.8
    },
    "stretchRate": 0,
-   "anchorRate": 9.7,
-   "breadth": 0.776,
+   "anchorRate": 6.8,
+   "breadth": 0.745,
    "competitiveRatio": 44,
    "winRate": 56.6
   },
@@ -871,22 +871,22 @@
    "lineupWTN": 18.66,
    "matches": 335,
    "bands": {
-    "STRETCH": 72,
-    "UP": 137,
+    "STRETCH": 62,
+    "UP": 147,
     "EVEN": 9,
     "DOWN": 104,
     "ANCHOR": 13
    },
    "bandPct": {
-    "STRETCH": 21.5,
-    "UP": 40.9,
+    "STRETCH": 18.5,
+    "UP": 43.9,
     "EVEN": 2.7,
     "DOWN": 31,
     "ANCHOR": 3.9
    },
-   "stretchRate": 21.5,
+   "stretchRate": 18.5,
    "anchorRate": 3.9,
-   "breadth": 0.797,
+   "breadth": 0.783,
    "competitiveRatio": 27.5,
    "winRate": 38.5
   },

--- a/public/data/conferences/southern-athletic-association.json
+++ b/public/data/conferences/southern-athletic-association.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 774,
     "UP": 1314,
-    "EVEN": 476,
-    "DOWN": 1244,
+    "EVEN": 482,
+    "DOWN": 1238,
     "ANCHOR": 405
    },
    "bandPct": {
     "STRETCH": 18.4,
     "UP": 31.2,
-    "EVEN": 11.3,
-    "DOWN": 29.5,
+    "EVEN": 11.4,
+    "DOWN": 29.4,
     "ANCHOR": 9.6
    },
    "stretchRate": 18.4,
    "anchorRate": 9.6,
-   "breadth": 0.936,
+   "breadth": 0.937,
    "competitiveRatio": 34.7,
    "winRate": 48.4
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 557,
     "UP": 921,
-    "EVEN": 300,
-    "DOWN": 851,
+    "EVEN": 306,
+    "DOWN": 845,
     "ANCHOR": 188
    },
    "bandPct": {
     "STRETCH": 19.8,
     "UP": 32.7,
-    "EVEN": 10.6,
-    "DOWN": 30.2,
+    "EVEN": 10.9,
+    "DOWN": 30,
     "ANCHOR": 6.7
    },
    "stretchRate": 19.8,
    "anchorRate": 6.7,
-   "breadth": 0.911,
+   "breadth": 0.913,
    "competitiveRatio": 34.8,
    "winRate": 47.6
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -333,20 +333,20 @@
    "bands": {
     "STRETCH": 30,
     "UP": 43,
-    "EVEN": 26,
-    "DOWN": 128,
+    "EVEN": 32,
+    "DOWN": 122,
     "ANCHOR": 56
    },
    "bandPct": {
     "STRETCH": 10.6,
     "UP": 15.2,
-    "EVEN": 9.2,
-    "DOWN": 45.2,
+    "EVEN": 11.3,
+    "DOWN": 43.1,
     "ANCHOR": 19.8
    },
    "stretchRate": 10.6,
    "anchorRate": 19.8,
-   "breadth": 0.884,
+   "breadth": 0.903,
    "competitiveRatio": 38.9,
    "winRate": 53
   },

--- a/public/data/conferences/southern-california-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/southern-california-intercollegiate-athletic-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/southern-collegiate-athletic-conference.json
+++ b/public/data/conferences/southern-collegiate-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/southern-conference.json
+++ b/public/data/conferences/southern-conference.json
@@ -14,22 +14,22 @@
   "overall": {
    "matches": 5976,
    "bands": {
-    "STRETCH": 493,
-    "UP": 2108,
+    "STRETCH": 488,
+    "UP": 2113,
     "EVEN": 1149,
     "DOWN": 1963,
     "ANCHOR": 263
    },
    "bandPct": {
     "STRETCH": 8.2,
-    "UP": 35.3,
+    "UP": 35.4,
     "EVEN": 19.2,
     "DOWN": 32.8,
     "ANCHOR": 4.4
    },
    "stretchRate": 8.2,
    "anchorRate": 4.4,
-   "breadth": 0.866,
+   "breadth": 0.865,
    "competitiveRatio": 46.8,
    "winRate": 47.3
   },
@@ -58,22 +58,22 @@
   "nonConference": {
    "matches": 3660,
    "bands": {
-    "STRETCH": 493,
-    "UP": 1201,
+    "STRETCH": 488,
+    "UP": 1206,
     "EVEN": 647,
     "DOWN": 1056,
     "ANCHOR": 263
    },
    "bandPct": {
-    "STRETCH": 13.5,
-    "UP": 32.8,
+    "STRETCH": 13.3,
+    "UP": 33,
     "EVEN": 17.7,
     "DOWN": 28.9,
     "ANCHOR": 7.2
    },
-   "stretchRate": 13.5,
+   "stretchRate": 13.3,
    "anchorRate": 7.2,
-   "breadth": 0.926,
+   "breadth": 0.925,
    "competitiveRatio": 45.1,
    "winRate": 45.6
   }
@@ -81,29 +81,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 0,
-  "nonConference": 13.5,
-  "delta": 13.5,
+  "nonConference": 13.3,
+  "delta": 13.3,
   "nonConferenceShare": 61.2
  },
  "members": [
@@ -493,22 +493,22 @@
    "lineupWTN": 21.52,
    "matches": 335,
    "bands": {
-    "STRETCH": 47,
-    "UP": 170,
+    "STRETCH": 42,
+    "UP": 175,
     "EVEN": 73,
     "DOWN": 33,
     "ANCHOR": 12
    },
    "bandPct": {
-    "STRETCH": 14,
-    "UP": 50.7,
+    "STRETCH": 12.5,
+    "UP": 52.2,
     "EVEN": 21.8,
     "DOWN": 9.9,
     "ANCHOR": 3.6
    },
-   "stretchRate": 14,
+   "stretchRate": 12.5,
    "anchorRate": 3.6,
-   "breadth": 0.807,
+   "breadth": 0.795,
    "competitiveRatio": 38.3,
    "winRate": 43.6
   },

--- a/public/data/conferences/southern-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/southern-intercollegiate-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/southern-states-athletic-conference.json
+++ b/public/data/conferences/southern-states-athletic-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/southland-conference.json
+++ b/public/data/conferences/southland-conference.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 450,
     "UP": 1929,
-    "EVEN": 801,
-    "DOWN": 1929,
+    "EVEN": 848,
+    "DOWN": 1882,
     "ANCHOR": 732
    },
    "bandPct": {
     "STRETCH": 7.7,
     "UP": 33,
-    "EVEN": 13.7,
-    "DOWN": 33,
+    "EVEN": 14.5,
+    "DOWN": 32.2,
     "ANCHOR": 12.5
    },
    "stretchRate": 7.7,
    "anchorRate": 12.5,
-   "breadth": 0.908,
+   "breadth": 0.913,
    "competitiveRatio": 42.3,
    "winRate": 53.6
   },
@@ -38,20 +38,20 @@
    "bands": {
     "STRETCH": 42,
     "UP": 943,
-    "EVEN": 417,
-    "DOWN": 966,
+    "EVEN": 440,
+    "DOWN": 943,
     "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 1.7,
     "UP": 39.1,
-    "EVEN": 17.3,
-    "DOWN": 40.1,
+    "EVEN": 18.3,
+    "DOWN": 39.1,
     "ANCHOR": 1.7
    },
    "stretchRate": 1.7,
    "anchorRate": 1.7,
-   "breadth": 0.732,
+   "breadth": 0.737,
    "competitiveRatio": 48.9,
    "winRate": 50
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 408,
     "UP": 986,
-    "EVEN": 384,
-    "DOWN": 963,
+    "EVEN": 408,
+    "DOWN": 939,
     "ANCHOR": 690
    },
    "bandPct": {
     "STRETCH": 11.9,
     "UP": 28.7,
-    "EVEN": 11.2,
-    "DOWN": 28.1,
+    "EVEN": 11.9,
+    "DOWN": 27.4,
     "ANCHOR": 20.1
    },
    "stretchRate": 11.9,
    "anchorRate": 20.1,
-   "breadth": 0.954,
+   "breadth": 0.958,
    "competitiveRatio": 37.7,
    "winRate": 56.1
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -198,20 +198,20 @@
    "bands": {
     "STRETCH": 6,
     "UP": 129,
-    "EVEN": 38,
-    "DOWN": 136,
+    "EVEN": 50,
+    "DOWN": 124,
     "ANCHOR": 42
    },
    "bandPct": {
     "STRETCH": 1.7,
     "UP": 36.8,
-    "EVEN": 10.8,
-    "DOWN": 38.7,
+    "EVEN": 14.2,
+    "DOWN": 35.3,
     "ANCHOR": 12
    },
    "stretchRate": 1.7,
    "anchorRate": 12,
-   "breadth": 0.807,
+   "breadth": 0.831,
    "competitiveRatio": 44.3,
    "winRate": 53.6
   },
@@ -279,20 +279,20 @@
    "bands": {
     "STRETCH": 3,
     "UP": 7,
-    "EVEN": 21,
-    "DOWN": 219,
+    "EVEN": 44,
+    "DOWN": 196,
     "ANCHOR": 89
    },
    "bandPct": {
     "STRETCH": 0.9,
     "UP": 2.1,
-    "EVEN": 6.2,
-    "DOWN": 64.6,
+    "EVEN": 13,
+    "DOWN": 57.8,
     "ANCHOR": 26.3
    },
    "stretchRate": 0.9,
    "anchorRate": 26.3,
-   "breadth": 0.576,
+   "breadth": 0.655,
    "competitiveRatio": 30.4,
    "winRate": 81.7
   },
@@ -306,20 +306,20 @@
    "bands": {
     "STRETCH": 9,
     "UP": 107,
-    "EVEN": 91,
-    "DOWN": 120,
+    "EVEN": 103,
+    "DOWN": 108,
     "ANCHOR": 4
    },
    "bandPct": {
     "STRETCH": 2.7,
     "UP": 32.3,
-    "EVEN": 27.5,
-    "DOWN": 36.3,
+    "EVEN": 31.1,
+    "DOWN": 32.6,
     "ANCHOR": 1.2
    },
    "stretchRate": 2.7,
    "anchorRate": 1.2,
-   "breadth": 0.77,
+   "breadth": 0.774,
    "competitiveRatio": 46.5,
    "winRate": 62.5
   },

--- a/public/data/conferences/southwestern-athletic-conference.json
+++ b/public/data/conferences/southwestern-athletic-conference.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 1242,
     "UP": 1063,
-    "EVEN": 174,
-    "DOWN": 646,
+    "EVEN": 180,
+    "DOWN": 640,
     "ANCHOR": 231
    },
    "bandPct": {
     "STRETCH": 37,
     "UP": 31.7,
-    "EVEN": 5.2,
-    "DOWN": 19.2,
+    "EVEN": 5.4,
+    "DOWN": 19.1,
     "ANCHOR": 6.9
    },
    "stretchRate": 37,
    "anchorRate": 6.9,
-   "breadth": 0.862,
+   "breadth": 0.863,
    "competitiveRatio": 23.8,
    "winRate": 32.5
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 1094,
     "UP": 669,
-    "EVEN": 118,
-    "DOWN": 252,
+    "EVEN": 124,
+    "DOWN": 246,
     "ANCHOR": 83
    },
    "bandPct": {
     "STRETCH": 49.4,
     "UP": 30.2,
-    "EVEN": 5.3,
-    "DOWN": 11.4,
+    "EVEN": 5.6,
+    "DOWN": 11.1,
     "ANCHOR": 3.7
    },
    "stretchRate": 49.4,
    "anchorRate": 3.7,
-   "breadth": 0.768,
+   "breadth": 0.769,
    "competitiveRatio": 25.7,
    "winRate": 23.6
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -144,20 +144,20 @@
    "bands": {
     "STRETCH": 24,
     "UP": 61,
-    "EVEN": 19,
-    "DOWN": 148,
+    "EVEN": 25,
+    "DOWN": 142,
     "ANCHOR": 49
    },
    "bandPct": {
     "STRETCH": 8,
     "UP": 20.3,
-    "EVEN": 6.3,
-    "DOWN": 49.2,
+    "EVEN": 8.3,
+    "DOWN": 47.2,
     "ANCHOR": 16.3
    },
    "stretchRate": 8,
    "anchorRate": 16.3,
-   "breadth": 0.835,
+   "breadth": 0.859,
    "competitiveRatio": 36.3,
    "winRate": 55.5
   },

--- a/public/data/conferences/state-university-of-new-york-athletic-conference.json
+++ b/public/data/conferences/state-university-of-new-york-athletic-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 2546,
    "bands": {
-    "STRETCH": 263,
-    "UP": 917,
+    "STRETCH": 252,
+    "UP": 928,
     "EVEN": 454,
     "DOWN": 807,
     "ANCHOR": 105
    },
    "bandPct": {
-    "STRETCH": 10.3,
-    "UP": 36,
+    "STRETCH": 9.9,
+    "UP": 36.4,
     "EVEN": 17.8,
     "DOWN": 31.7,
     "ANCHOR": 4.1
    },
-   "stretchRate": 10.3,
+   "stretchRate": 9.9,
    "anchorRate": 4.1,
-   "breadth": 0.873,
+   "breadth": 0.87,
    "competitiveRatio": 24.7,
    "winRate": 47.6
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 1650,
    "bands": {
-    "STRETCH": 222,
-    "UP": 577,
+    "STRETCH": 211,
+    "UP": 588,
     "EVEN": 320,
     "DOWN": 467,
     "ANCHOR": 64
    },
    "bandPct": {
-    "STRETCH": 13.5,
-    "UP": 35,
+    "STRETCH": 12.8,
+    "UP": 35.6,
     "EVEN": 19.4,
     "DOWN": 28.3,
     "ANCHOR": 3.9
    },
-   "stretchRate": 13.5,
+   "stretchRate": 12.8,
    "anchorRate": 3.9,
-   "breadth": 0.894,
+   "breadth": 0.89,
    "competitiveRatio": 24.7,
    "winRate": 46.3
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 4.6,
-  "nonConference": 13.5,
-  "delta": 8.9,
+  "nonConference": 12.8,
+  "delta": 8.2,
   "nonConferenceShare": 64.8
  },
  "members": [
@@ -143,22 +143,22 @@
    "lineupWTN": 30.35,
    "matches": 340,
    "bands": {
-    "STRETCH": 64,
-    "UP": 192,
+    "STRETCH": 53,
+    "UP": 203,
     "EVEN": 60,
     "DOWN": 24,
     "ANCHOR": 0
    },
    "bandPct": {
-    "STRETCH": 18.8,
-    "UP": 56.5,
+    "STRETCH": 15.6,
+    "UP": 59.7,
     "EVEN": 17.6,
     "DOWN": 7.1,
     "ANCHOR": 0
    },
-   "stretchRate": 18.8,
+   "stretchRate": 15.6,
    "anchorRate": 0,
-   "breadth": 0.702,
+   "breadth": 0.678,
    "competitiveRatio": 26.5,
    "winRate": 36.2
   },

--- a/public/data/conferences/summit-league.json
+++ b/public/data/conferences/summit-league.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/sun-belt-conference.json
+++ b/public/data/conferences/sun-belt-conference.json
@@ -16,20 +16,20 @@
    "bands": {
     "STRETCH": 360,
     "UP": 2265,
-    "EVEN": 1233,
-    "DOWN": 2598,
+    "EVEN": 1260,
+    "DOWN": 2571,
     "ANCHOR": 400
    },
    "bandPct": {
     "STRETCH": 5.3,
     "UP": 33,
-    "EVEN": 18,
-    "DOWN": 37.9,
+    "EVEN": 18.4,
+    "DOWN": 37.5,
     "ANCHOR": 5.8
    },
    "stretchRate": 5.3,
    "anchorRate": 5.8,
-   "breadth": 0.847,
+   "breadth": 0.848,
    "competitiveRatio": 44.1,
    "winRate": 53.1
   },
@@ -38,20 +38,20 @@
    "bands": {
     "STRETCH": 10,
     "UP": 1034,
-    "EVEN": 537,
-    "DOWN": 1049,
+    "EVEN": 552,
+    "DOWN": 1034,
     "ANCHOR": 10
    },
    "bandPct": {
     "STRETCH": 0.4,
     "UP": 39.2,
-    "EVEN": 20.3,
-    "DOWN": 39.7,
+    "EVEN": 20.9,
+    "DOWN": 39.2,
     "ANCHOR": 0.4
    },
    "stretchRate": 0.4,
    "anchorRate": 0.4,
-   "breadth": 0.683,
+   "breadth": 0.686,
    "competitiveRatio": 42.3,
    "winRate": 50
   },
@@ -60,20 +60,20 @@
    "bands": {
     "STRETCH": 350,
     "UP": 1231,
-    "EVEN": 696,
-    "DOWN": 1549,
+    "EVEN": 708,
+    "DOWN": 1537,
     "ANCHOR": 390
    },
    "bandPct": {
     "STRETCH": 8.3,
     "UP": 29.2,
-    "EVEN": 16.5,
-    "DOWN": 36.7,
+    "EVEN": 16.8,
+    "DOWN": 36.5,
     "ANCHOR": 9.3
    },
    "stretchRate": 8.3,
    "anchorRate": 9.3,
-   "breadth": 0.902,
+   "breadth": 0.903,
    "competitiveRatio": 45.3,
    "winRate": 55
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -225,20 +225,20 @@
    "bands": {
     "STRETCH": 0,
     "UP": 51,
-    "EVEN": 75,
-    "DOWN": 189,
+    "EVEN": 90,
+    "DOWN": 174,
     "ANCHOR": 18
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 15.3,
-    "EVEN": 22.5,
-    "DOWN": 56.8,
+    "EVEN": 27,
+    "DOWN": 52.3,
     "ANCHOR": 5.4
    },
    "stretchRate": 0,
    "anchorRate": 5.4,
-   "breadth": 0.685,
+   "breadth": 0.707,
    "competitiveRatio": 44.1,
    "winRate": 53.5
   },
@@ -549,20 +549,20 @@
    "bands": {
     "STRETCH": 9,
     "UP": 137,
-    "EVEN": 33,
-    "DOWN": 108,
+    "EVEN": 45,
+    "DOWN": 96,
     "ANCHOR": 5
    },
    "bandPct": {
     "STRETCH": 3.1,
     "UP": 46.9,
-    "EVEN": 11.3,
-    "DOWN": 37,
+    "EVEN": 15.4,
+    "DOWN": 32.9,
     "ANCHOR": 1.7
    },
    "stretchRate": 3.1,
    "anchorRate": 1.7,
-   "breadth": 0.712,
+   "breadth": 0.737,
    "competitiveRatio": 42.8,
    "winRate": 59.2
   },

--- a/public/data/conferences/sunshine-state-conference.json
+++ b/public/data/conferences/sunshine-state-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/the-sun-conference.json
+++ b/public/data/conferences/the-sun-conference.json
@@ -17,19 +17,19 @@
     "STRETCH": 285,
     "UP": 936,
     "EVEN": 395,
-    "DOWN": 920,
-    "ANCHOR": 433
+    "DOWN": 925,
+    "ANCHOR": 428
    },
    "bandPct": {
     "STRETCH": 9.6,
     "UP": 31.5,
     "EVEN": 13.3,
-    "DOWN": 31,
-    "ANCHOR": 14.6
+    "DOWN": 31.2,
+    "ANCHOR": 14.4
    },
    "stretchRate": 9.6,
-   "anchorRate": 14.6,
-   "breadth": 0.933,
+   "anchorRate": 14.4,
+   "breadth": 0.932,
    "competitiveRatio": 28.5,
    "winRate": 50
   },
@@ -61,19 +61,19 @@
     "STRETCH": 171,
     "UP": 587,
     "EVEN": 287,
-    "DOWN": 571,
-    "ANCHOR": 319
+    "DOWN": 576,
+    "ANCHOR": 314
    },
    "bandPct": {
     "STRETCH": 8.8,
     "UP": 30.3,
     "EVEN": 14.8,
-    "DOWN": 29.5,
-    "ANCHOR": 16.5
+    "DOWN": 29.8,
+    "ANCHOR": 16.2
    },
    "stretchRate": 8.8,
-   "anchorRate": 16.5,
-   "breadth": 0.942,
+   "anchorRate": 16.2,
+   "breadth": 0.941,
    "competitiveRatio": 33.9,
    "winRate": 50.1
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -361,19 +361,19 @@
     "STRETCH": 12,
     "UP": 77,
     "EVEN": 14,
-    "DOWN": 42,
-    "ANCHOR": 39
+    "DOWN": 47,
+    "ANCHOR": 34
    },
    "bandPct": {
     "STRETCH": 6.5,
     "UP": 41.8,
     "EVEN": 7.6,
-    "DOWN": 22.8,
-    "ANCHOR": 21.2
+    "DOWN": 25.5,
+    "ANCHOR": 18.5
    },
    "stretchRate": 6.5,
-   "anchorRate": 21.2,
-   "breadth": 0.873,
+   "anchorRate": 18.5,
+   "breadth": 0.869,
    "competitiveRatio": 17.9,
    "winRate": 48.9
   },

--- a/public/data/conferences/united-east-conference.json
+++ b/public/data/conferences/united-east-conference.json
@@ -15,22 +15,22 @@
   "overall": {
    "matches": 3470,
    "bands": {
-    "STRETCH": 215,
-    "UP": 1453,
+    "STRETCH": 212,
+    "UP": 1456,
     "EVEN": 405,
     "DOWN": 1264,
     "ANCHOR": 133
    },
    "bandPct": {
-    "STRETCH": 6.2,
-    "UP": 41.9,
+    "STRETCH": 6.1,
+    "UP": 42,
     "EVEN": 11.7,
     "DOWN": 36.4,
     "ANCHOR": 3.8
    },
-   "stretchRate": 6.2,
+   "stretchRate": 6.1,
    "anchorRate": 3.8,
-   "breadth": 0.796,
+   "breadth": 0.795,
    "competitiveRatio": 25.3,
    "winRate": 44.4
   },
@@ -59,22 +59,22 @@
   "nonConference": {
    "matches": 1700,
    "bands": {
-    "STRETCH": 145,
-    "UP": 748,
+    "STRETCH": 142,
+    "UP": 751,
     "EVEN": 185,
     "DOWN": 559,
     "ANCHOR": 63
    },
    "bandPct": {
-    "STRETCH": 8.5,
-    "UP": 44,
+    "STRETCH": 8.4,
+    "UP": 44.2,
     "EVEN": 10.9,
     "DOWN": 32.9,
     "ANCHOR": 3.7
    },
-   "stretchRate": 8.5,
+   "stretchRate": 8.4,
    "anchorRate": 3.7,
-   "breadth": 0.808,
+   "breadth": 0.806,
    "competitiveRatio": 28.3,
    "winRate": 38.6
   }
@@ -82,29 +82,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 4,
-  "nonConference": 8.5,
-  "delta": 4.5,
+  "nonConference": 8.4,
+  "delta": 4.4,
   "nonConferenceShare": 49
  },
  "members": [
@@ -116,22 +116,22 @@
    "lineupWTN": 24.83,
    "matches": 334,
    "bands": {
-    "STRETCH": 5,
-    "UP": 87,
+    "STRETCH": 2,
+    "UP": 90,
     "EVEN": 30,
     "DOWN": 174,
     "ANCHOR": 38
    },
    "bandPct": {
-    "STRETCH": 1.5,
-    "UP": 26,
+    "STRETCH": 0.6,
+    "UP": 26.9,
     "EVEN": 9,
     "DOWN": 52.1,
     "ANCHOR": 11.4
    },
-   "stretchRate": 1.5,
+   "stretchRate": 0.6,
    "anchorRate": 11.4,
-   "breadth": 0.756,
+   "breadth": 0.738,
    "competitiveRatio": 27.2,
    "winRate": 61.7
   },

--- a/public/data/conferences/university-athletic-association.json
+++ b/public/data/conferences/university-athletic-association.json
@@ -17,19 +17,19 @@
     "STRETCH": 229,
     "UP": 1143,
     "EVEN": 750,
-    "DOWN": 2092,
-    "ANCHOR": 1386
+    "DOWN": 2121,
+    "ANCHOR": 1357
    },
    "bandPct": {
     "STRETCH": 4.1,
     "UP": 20.4,
     "EVEN": 13.4,
-    "DOWN": 37.4,
-    "ANCHOR": 24.8
+    "DOWN": 37.9,
+    "ANCHOR": 24.2
    },
    "stretchRate": 4.1,
-   "anchorRate": 24.8,
-   "breadth": 0.893,
+   "anchorRate": 24.2,
+   "breadth": 0.892,
    "competitiveRatio": 38.7,
    "winRate": 65.2
   },
@@ -61,19 +61,19 @@
     "STRETCH": 107,
     "UP": 785,
     "EVEN": 478,
-    "DOWN": 1734,
-    "ANCHOR": 1264
+    "DOWN": 1763,
+    "ANCHOR": 1235
    },
    "bandPct": {
     "STRETCH": 2.4,
     "UP": 18,
     "EVEN": 10.9,
-    "DOWN": 39.7,
-    "ANCHOR": 28.9
+    "DOWN": 40.4,
+    "ANCHOR": 28.3
    },
    "stretchRate": 2.4,
-   "anchorRate": 28.9,
-   "breadth": 0.849,
+   "anchorRate": 28.3,
+   "breadth": 0.848,
    "competitiveRatio": 38.5,
    "winRate": 69.4
   }
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -199,19 +199,19 @@
     "STRETCH": 0,
     "UP": 10,
     "EVEN": 97,
-    "DOWN": 127,
-    "ANCHOR": 155
+    "DOWN": 133,
+    "ANCHOR": 149
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 2.6,
     "EVEN": 24.9,
-    "DOWN": 32.6,
-    "ANCHOR": 39.8
+    "DOWN": 34.2,
+    "ANCHOR": 38.3
    },
    "stretchRate": 0,
-   "anchorRate": 39.8,
-   "breadth": 0.729,
+   "anchorRate": 38.3,
+   "breadth": 0.73,
    "competitiveRatio": 34.4,
    "winRate": 75.3
   },
@@ -334,19 +334,19 @@
     "STRETCH": 0,
     "UP": 97,
     "EVEN": 61,
-    "DOWN": 148,
-    "ANCHOR": 44
+    "DOWN": 160,
+    "ANCHOR": 32
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 27.7,
     "EVEN": 17.4,
-    "DOWN": 42.3,
-    "ANCHOR": 12.6
+    "DOWN": 45.7,
+    "ANCHOR": 9.1
    },
    "stretchRate": 0,
-   "anchorRate": 12.6,
-   "breadth": 0.798,
+   "anchorRate": 9.1,
+   "breadth": 0.768,
    "competitiveRatio": 47.6,
    "winRate": 55.4
   },
@@ -415,19 +415,19 @@
     "STRETCH": 0,
     "UP": 102,
     "EVEN": 40,
-    "DOWN": 106,
-    "ANCHOR": 69
+    "DOWN": 117,
+    "ANCHOR": 58
    },
    "bandPct": {
     "STRETCH": 0,
     "UP": 32.2,
     "EVEN": 12.6,
-    "DOWN": 33.4,
-    "ANCHOR": 21.8
+    "DOWN": 36.9,
+    "ANCHOR": 18.3
    },
    "stretchRate": 0,
-   "anchorRate": 21.8,
-   "breadth": 0.823,
+   "anchorRate": 18.3,
+   "breadth": 0.811,
    "competitiveRatio": 34.6,
    "winRate": 55.8
   },

--- a/public/data/conferences/upper-midwest-athletic-conference.json
+++ b/public/data/conferences/upper-midwest-athletic-conference.json
@@ -17,20 +17,20 @@
    "bands": {
     "STRETCH": 874,
     "UP": 2489,
-    "EVEN": 627,
-    "DOWN": 1502,
-    "ANCHOR": 329
+    "EVEN": 639,
+    "DOWN": 1510,
+    "ANCHOR": 309
    },
    "bandPct": {
     "STRETCH": 15,
     "UP": 42.8,
-    "EVEN": 10.8,
-    "DOWN": 25.8,
-    "ANCHOR": 5.7
+    "EVEN": 11,
+    "DOWN": 25.9,
+    "ANCHOR": 5.3
    },
    "stretchRate": 15,
-   "anchorRate": 5.7,
-   "breadth": 0.87,
+   "anchorRate": 5.3,
+   "breadth": 0.868,
    "competitiveRatio": 27.9,
    "winRate": 42.6
   },
@@ -61,20 +61,20 @@
    "bands": {
     "STRETCH": 692,
     "UP": 1910,
-    "EVEN": 443,
-    "DOWN": 923,
-    "ANCHOR": 147
+    "EVEN": 455,
+    "DOWN": 931,
+    "ANCHOR": 127
    },
    "bandPct": {
     "STRETCH": 16.8,
     "UP": 46.4,
-    "EVEN": 10.8,
-    "DOWN": 22.4,
-    "ANCHOR": 3.6
+    "EVEN": 11.1,
+    "DOWN": 22.6,
+    "ANCHOR": 3.1
    },
    "stretchRate": 16.8,
-   "anchorRate": 3.6,
-   "breadth": 0.839,
+   "anchorRate": 3.1,
+   "breadth": 0.835,
    "competitiveRatio": 30.3,
    "winRate": 39.6
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -199,20 +199,20 @@
    "bands": {
     "STRETCH": 42,
     "UP": 177,
-    "EVEN": 44,
-    "DOWN": 118,
+    "EVEN": 56,
+    "DOWN": 106,
     "ANCHOR": 48
    },
    "bandPct": {
     "STRETCH": 9.8,
     "UP": 41.3,
-    "EVEN": 10.3,
-    "DOWN": 27.5,
+    "EVEN": 13.1,
+    "DOWN": 24.7,
     "ANCHOR": 11.2
    },
    "stretchRate": 9.8,
    "anchorRate": 11.2,
-   "breadth": 0.886,
+   "breadth": 0.9,
    "competitiveRatio": 47.3,
    "winRate": 49.7
   },
@@ -524,19 +524,19 @@
     "STRETCH": 16,
     "UP": 43,
     "EVEN": 15,
-    "DOWN": 82,
-    "ANCHOR": 72
+    "DOWN": 102,
+    "ANCHOR": 52
    },
    "bandPct": {
     "STRETCH": 7,
     "UP": 18.9,
     "EVEN": 6.6,
-    "DOWN": 36,
-    "ANCHOR": 31.6
+    "DOWN": 44.7,
+    "ANCHOR": 22.8
    },
    "stretchRate": 7,
-   "anchorRate": 31.6,
-   "breadth": 0.877,
+   "anchorRate": 22.8,
+   "breadth": 0.856,
    "competitiveRatio": 26.3,
    "winRate": 42.1
   },

--- a/public/data/conferences/usa-south-athletic-conference.json
+++ b/public/data/conferences/usa-south-athletic-conference.json
@@ -18,19 +18,19 @@
     "STRETCH": 515,
     "UP": 1128,
     "EVEN": 218,
-    "DOWN": 1099,
-    "ANCHOR": 365
+    "DOWN": 1105,
+    "ANCHOR": 359
    },
    "bandPct": {
     "STRETCH": 15.5,
     "UP": 33.9,
     "EVEN": 6.6,
-    "DOWN": 33.1,
-    "ANCHOR": 11
+    "DOWN": 33.2,
+    "ANCHOR": 10.8
    },
    "stretchRate": 15.5,
-   "anchorRate": 11,
-   "breadth": 0.896,
+   "anchorRate": 10.8,
+   "breadth": 0.895,
    "competitiveRatio": 28.7,
    "winRate": 48.5
   },
@@ -62,19 +62,19 @@
     "STRETCH": 294,
     "UP": 716,
     "EVEN": 196,
-    "DOWN": 687,
-    "ANCHOR": 144
+    "DOWN": 693,
+    "ANCHOR": 138
    },
    "bandPct": {
     "STRETCH": 14.4,
     "UP": 35.1,
     "EVEN": 9.6,
-    "DOWN": 33.7,
-    "ANCHOR": 7.1
+    "DOWN": 34,
+    "ANCHOR": 6.8
    },
    "stretchRate": 14.4,
-   "anchorRate": 7.1,
-   "breadth": 0.886,
+   "anchorRate": 6.8,
+   "breadth": 0.883,
    "competitiveRatio": 32.2,
    "winRate": 47.6
   }
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
@@ -146,19 +146,19 @@
     "STRETCH": 59,
     "UP": 91,
     "EVEN": 0,
-    "DOWN": 173,
-    "ANCHOR": 37
+    "DOWN": 179,
+    "ANCHOR": 31
    },
    "bandPct": {
     "STRETCH": 16.4,
     "UP": 25.3,
     "EVEN": 0,
-    "DOWN": 48.1,
-    "ANCHOR": 10.3
+    "DOWN": 49.7,
+    "ANCHOR": 8.6
    },
    "stretchRate": 16.4,
-   "anchorRate": 10.3,
-   "breadth": 0.764,
+   "anchorRate": 8.6,
+   "breadth": 0.747,
    "competitiveRatio": 32.5,
    "winRate": 61.1
   },

--- a/public/data/conferences/west-coast-conference.json
+++ b/public/data/conferences/west-coast-conference.json
@@ -14,22 +14,22 @@
   "overall": {
    "matches": 5431,
    "bands": {
-    "STRETCH": 340,
-    "UP": 1756,
+    "STRETCH": 336,
+    "UP": 1760,
     "EVEN": 1044,
     "DOWN": 1971,
     "ANCHOR": 320
    },
    "bandPct": {
-    "STRETCH": 6.3,
-    "UP": 32.3,
+    "STRETCH": 6.2,
+    "UP": 32.4,
     "EVEN": 19.2,
     "DOWN": 36.3,
     "ANCHOR": 5.9
    },
-   "stretchRate": 6.3,
+   "stretchRate": 6.2,
    "anchorRate": 5.9,
-   "breadth": 0.864,
+   "breadth": 0.863,
    "competitiveRatio": 46.5,
    "winRate": 51.6
   },
@@ -58,22 +58,22 @@
   "nonConference": {
    "matches": 3659,
    "bands": {
-    "STRETCH": 156,
-    "UP": 1233,
+    "STRETCH": 152,
+    "UP": 1237,
     "EVEN": 686,
     "DOWN": 1448,
     "ANCHOR": 136
    },
    "bandPct": {
-    "STRETCH": 4.3,
-    "UP": 33.7,
+    "STRETCH": 4.2,
+    "UP": 33.8,
     "EVEN": 18.7,
     "DOWN": 39.6,
     "ANCHOR": 3.7
    },
-   "stretchRate": 4.3,
+   "stretchRate": 4.2,
    "anchorRate": 3.7,
-   "breadth": 0.81,
+   "breadth": 0.809,
    "competitiveRatio": 48.4,
    "winRate": 52.3
   }
@@ -81,29 +81,29 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },
  "stretchGap": {
   "inConference": 10.4,
-  "nonConference": 4.3,
-  "delta": -6.1,
+  "nonConference": 4.2,
+  "delta": -6.2,
   "nonConferenceShare": 67.4
  },
  "members": [
@@ -277,22 +277,22 @@
    "lineupWTN": 19.51,
    "matches": 322,
    "bands": {
-    "STRETCH": 40,
-    "UP": 119,
+    "STRETCH": 36,
+    "UP": 123,
     "EVEN": 69,
     "DOWN": 88,
     "ANCHOR": 6
    },
    "bandPct": {
-    "STRETCH": 12.4,
-    "UP": 37,
+    "STRETCH": 11.2,
+    "UP": 38.2,
     "EVEN": 21.4,
     "DOWN": 27.3,
     "ANCHOR": 1.9
    },
-   "stretchRate": 12.4,
+   "stretchRate": 11.2,
    "anchorRate": 1.9,
-   "breadth": 0.861,
+   "breadth": 0.852,
    "competitiveRatio": 44.1,
    "winRate": 49.7
   },

--- a/public/data/conferences/western-athletic-conference.json
+++ b/public/data/conferences/western-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/western-state-conference.json
+++ b/public/data/conferences/western-state-conference.json
@@ -81,22 +81,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/wisconsin-intercollegiate-athletic-conference.json
+++ b/public/data/conferences/wisconsin-intercollegiate-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },

--- a/public/data/conferences/wolverine-hoosier-athletic-conference.json
+++ b/public/data/conferences/wolverine-hoosier-athletic-conference.json
@@ -82,22 +82,22 @@
  "baseline": {
   "matches": 531414,
   "bands": {
-   "STRETCH": 51471,
-   "UP": 174555,
-   "EVEN": 75766,
-   "DOWN": 176643,
-   "ANCHOR": 52979
+   "STRETCH": 51143,
+   "UP": 174868,
+   "EVEN": 76379,
+   "DOWN": 176550,
+   "ANCHOR": 52474
   },
   "bandPct": {
-   "STRETCH": 9.7,
-   "UP": 32.8,
-   "EVEN": 14.3,
+   "STRETCH": 9.6,
+   "UP": 32.9,
+   "EVEN": 14.4,
    "DOWN": 33.2,
-   "ANCHOR": 10
+   "ANCHOR": 9.9
   },
-  "stretchRate": 9.7,
-  "anchorRate": 10,
-  "breadth": 0.911,
+  "stretchRate": 9.6,
+  "anchorRate": 9.9,
+  "breadth": 0.91,
   "competitiveRatio": 36.9,
   "winRate": 50.2
  },


### PR DESCRIPTION
Follow-on to courthive-ingest [#70](https://github.com/CourtHive/courthive-ingest/pull/70), which flipped the ITA scripts to the factory's shipped `maxPct` policy: **±4.017 / ±0.507** (10.3% and 1.3% of WTN's 39-point range) instead of absolute ±4 / ±0.5.

**The point is not the 0.017.** These pages and TMX's in-card fingerprint bar now read the *same* policy. Before this they agreed only because the ingest default happened to mirror the old cuts — so a future change to the factory default would have silently pulled them apart.

## Measured against what the site serves today

| | |
|---|---|
| exposure band reassignments | **2,704**, on **both** sides |
| by band | STRETCH 328 · UP 343 · EVEN 613 · DOWN 915 · ANCHOR 505 |
| `competitiveRatio` | **unchanged everywhere** |
| documents whose own bands moved | 67 of 131 |

CR holding still while 2,704 exposure rows move is confirmation *on the deployed artifact* that the two axes are independent in practice, not just by design.

## Why all 131 documents differ when only 67 have band changes

Expected, not suspicious — and worth stating because a 131-file diff for a 67-document change looks wrong at a glance. Every document embeds the all-college `baseline` for its "vs baseline" rendering, and that shifted:

| baseline | before | after |
|---|---|---|
| stretchRate | 9.7 | 9.6 |
| anchorRate | 10 | 9.9 |
| breadth | 0.911 | 0.910 |
| competitiveRatio | 36.9 | 36.9 |

A further 24 documents move `stretchGap`, derived from the in/non-conference split.

## Verification

- Diffed against **git HEAD**, not the working tree. My first attempt compared the regenerated files against themselves after copying them in and reported a reassuring "131 identical" — a detector measuring nothing. The numbers above come from extracting HEAD's documents and comparing properly.
- File set unchanged: 131 conference documents + `index.json`.
- Nothing staged outside `public/data/conferences/`.
- Generation formatting preserved — this data has never been prettier-managed, so reformatting would bury a numbers change in noise.
- `e2e/journeys/18-conference-pages.spec.ts` asserts structure, not figures.

Reproducibility: `--policy absolute` in the ingest scripts still regenerates the pre-flip figures byte-for-byte, so anything published before today remains reproducible.
